### PR TITLE
feat(evm): drop SPP all-or-nothing fallback for dynamic-jump contracts

### DIFF
--- a/docs/changes/2026-04-05-gas-check-placement/README.md
+++ b/docs/changes/2026-04-05-gas-check-placement/README.md
@@ -87,22 +87,42 @@ separate array instead of overwriting the interpreter's table).
 
 ### Metrics
 
-Measured via `evmone-bench` against `upstream/main@a14a9de` on the
-`external/total/(main|micro)/*` benchmark set (3 repetitions, median).
+Numbers are from the CI Performance Regression Check (baseline
+`perf-baseline-*-a14a9de...`, 5 repetitions, 25% threshold) — the
+gate-of-record for this PR. The full 194-bench multipass table lives in
+the github-actions perf-check comment on the PR; this section
+summarizes the design-relevant subset.
 
-- **Geometric mean: −10.13%** across 27 benchmarks.
-- Large wins on memory-growth and signextend chunks:
-  - `micro/memory_grow_mload/*`: −19% to −24%
-  - `micro/memory_grow_mstore/*`: −19% to −20%
-  - `micro/signextend/{one,zero}`: −19% to −20%
-- Headline contract: `main/snailtracer/benchmark`: −7.53%
-- A handful of small regressions remain (≤ +6%) on
-  `sha1_shifts/5311`, `structarray_alloc/nfts_rank`, `weierstrudel/1`,
-  `blake2b_shifts/8415nulls` — these are jump-heavy Solidity patterns where
-  the added CFG edges perturb chunk layout slightly.
+**Wins (jump-light / cost-shift opportunities):**
+
+- `micro/signextend/{one,zero}`: 0.13 → 0.07 μs (≈ −42.7%)
+- `micro/memory_grow_mstore/nogrow`: −6.8%
+- `main/structarray_alloc/nfts_rank`: −6.2%
+- `main/blake2b_huff/8415nulls`: −5.3%
+
+**Regressions (jump-heavy contracts — predicted cost of mixed-CFG
+over-approximation):**
+
+- `micro/jump_around/empty`: 0.04 → 0.05 μs (+22.8%)
+- `main/weierstrudel/1`: 0.20 → 0.24 μs (+19.5%)
+- `main/weierstrudel/15`: 2.22 → 2.60 μs (+17.5%)
+- `main/snailtracer/benchmark`: 28.49 → 31.58 μs (+10.9%)
+
+The +17–23% regressions on jump-heavy contracts are the design tradeoff
+of over-approximating dynamic-jump edges to all `JUMPDEST` blocks in
+order to keep the SPP shift sound (narrowing those edges with partial
+call-site resolution would under-approximate the CFG and break per-path
+total invariants — see Phase 5 / `buildCFGEdges` in
+`src/evm/evm_cache.cpp:389-429`). All 194 benches stay within the 25%
+gate, but `jump_around` has tight headroom.
+
+Earlier drafts of this section cited a 27-bench local `evmone-bench`
+run (3 reps) that drifted from the CI baseline; the CI bot table is the
+authoritative source.
 
 Correctness: 223/223 multipass evmone-unittests, 215/215 interpreter
-evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
+evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun` for both
+multipass and interpreter modes.
 
 ## Implementation Plan
 

--- a/docs/changes/2026-04-05-gas-check-placement/README.md
+++ b/docs/changes/2026-04-05-gas-check-placement/README.md
@@ -6,65 +6,84 @@
 
 ## Overview
 
-Remove all-or-nothing dynamic jump fallback — previously any unresolved dynamic
-jump caused the entire contract to fall back to per-block gas metering (zero SPP
-benefit). Now always builds a CFG with over-approximated edges for all unresolved
-dynamic jumps and precise edges for static jumps (PUSH → JUMP). The CFG is
-intentionally kept over-approximate — using resolved targets to narrow edges
-would under-approximate the CFG when resolution is incomplete, causing
-`lemma614Update` to shift gas along non-existent edges and produce unsafe
-metering.
+Remove the all-or-nothing dynamic-jump fallback in the EVM bytecode cache's
+SPP gas-metering pipeline. Previously, any unresolved dynamic jump caused the
+entire contract to fall back to per-block gas metering (zero SPP benefit).
+The cache now always builds a CFG with mixed-precision edges and runs the
+SPP shifting pass, while keeping the unshifted per-block cost available for
+the interpreter.
 
-Add call-site enumeration for function returns: resolves `SWAPn→JUMP` patterns
-(Solidity internal function returns) by identifying call sites
-(`PUSH ret → PUSH func → JUMP`) and collecting return addresses via reverse
-reachability. Resolved targets are exported through `ResolvedJumpTargets` for
-downstream consumers (e.g. MIR direct-branch optimization with runtime guard),
-not used for CFG refinement.
+The final design has three pieces:
 
-`GasChunkCost` continues to write the original `Blocks[Id].Cost` (not the
-SPP-shifted `Metering[Id]`) — the interpreter's gas chunk fast path requires
-unshifted per-block costs, as established by PR #371. A second parallel array
-`GasChunkCostSPP` is added to `EVMBytecodeCache` specifically for the multipass
-JIT: the SPP metering pass writes shifted values into it, and the JIT prefers
-it over the unshifted table when emitting gas checks. The interpreter never
-reads the new array, preserving #371 semantics.
+- **Mixed-precision CFG**: static jumps (`PUSH → JUMP`) get a single precise
+  edge to the resolved `JUMPDEST`; every other dynamic jump gets
+  over-approximated edges to all `JUMPDEST` blocks. The over-approximation
+  is intentional — narrowing dynamic-jump edges with partially-resolved
+  call-site information would under-approximate the CFG and let the SPP
+  pass shift gas along edges that don't exist at runtime, producing unsafe
+  metering. See `buildCFGEdges` in `src/evm/evm_cache.cpp` (lines 386–429,
+  in particular the dynamic-jump branch at line 419).
+- **SPP-shifted gas cost on a separate array**: the interpreter's gas-chunk
+  fast path requires unshifted per-block costs (PR #371). To preserve those
+  semantics while enabling SPP for the JIT, the cache exposes two parallel
+  arrays. `EVMBytecodeCache::GasChunkCost` keeps the unshifted base cost
+  (written from `Blocks[Id].Cost` at `evm_cache.cpp:1161`), and a new
+  `EVMBytecodeCache::GasChunkCostSPP` carries the SPP-shifted value
+  (written from the metering function `Metering[Id]` at
+  `evm_cache.cpp:1165`). The interpreter (`src/evm/interpreter.cpp:382`)
+  reads only `GasChunkCost`; the multipass JIT prefers `GasChunkCostSPP`
+  when non-null and falls back to `GasChunkCost` otherwise
+  (`src/compiler/evm_frontend/evm_mir_compiler.cpp:534, 578`).
+- **Interpreter-mode gating**: the SPP pipeline (CFG construction + metering
+  pass) is expensive and only useful for the JIT consumer. `buildBytecodeCache`
+  takes an `EnableSPP` parameter; when false, it emits unshifted per-block
+  costs and skips the CFG/metering work entirely. `EVMModule::CacheNeedsSPP`
+  is set to `true` immediately before `performEVMJITCompile` runs, so
+  interpreter-only modules never pay the SPP pipeline cost. When the JIT
+  somehow runs without SPP being built, `evm_compiler.cpp` passes `nullptr`
+  for `GasChunkCostSPP` so the JIT falls back to the unshifted array.
 
 ## Motivation
 
-The existing all-or-nothing fallback meant that any contract with unresolvable
-dynamic jumps got zero benefit from SPP. Real-world contracts mix static and
-dynamic jumps, so a mixed-edge CFG approach is needed to let the pass do useful
-work on the resolved portion of the CFG.
+The existing all-or-nothing fallback meant any contract with unresolvable
+dynamic jumps got zero benefit from SPP. Real-world Solidity contracts mix
+static and dynamic jumps, so a mixed-edge CFG is needed to let the SPP pass
+do useful work on the resolved portion of the CFG while staying sound on
+the unresolved portion.
 
 ## Scope
 
-This PR is scoped to the cache-side CFG improvements only:
+This PR is scoped to the cache-side CFG and JIT-cost wiring:
 
 - Remove the `HasDynamicJump` early-exit bailout in `buildGasChunksSPP`.
 - Factor out `buildCFGEdges()` with over-approximation for all unresolved
   dynamic jumps (sound for SPP metering).
-- Add `resolveCallSiteTargets()` — identifies `SWAPn→JUMP` return patterns and
-  walks predecessors to find the enclosing function entry, then collects valid
-  return addresses from matching call sites.
-- Introduce `decodePushAsJumpDest()` as a shared helper, and add `Prev2Pc` /
-  `Prev2Opcode` tracking on `GasBlock` to support the 3-instruction call-site
-  window lookup.
-- Tighten the SPP shifting guards to bail out of the shift when a successor is
-  a `isGasChunkTerminator` — prevents masking gas cost across chunk boundaries.
+- Add `EVMBytecodeCache::GasChunkCostSPP` and write SPP-shifted costs into
+  it, leaving `GasChunkCost` unshifted for the interpreter.
+- Plumb the SPP pointer through `EVMFrontendContext::setGasChunkInfo` and
+  `EVMMirBuilder`; swap the JIT's chunk-cost reads (`meterOpcode`,
+  `meterOpcodeRange`, JUMPDEST-run suffix-sum precompute) to prefer
+  `GasChunkCostSPP` when non-null.
+- Add an `EnableSPP` parameter to `buildBytecodeCache` and gate the
+  pipeline on JIT-consumer modules only.
+- Tighten the SPP shifting guards to bail out of the shift when a successor
+  is a `isGasChunkTerminator` — prevents masking gas cost across chunk
+  boundaries.
 
-No frontend/MIR changes are included in this PR.
+No frontend/MIR changes beyond the cost-source swap are included.
 
 ## Impact
 
 ### Affected Modules
 
-- `docs/modules/evm/` — EVM bytecode cache, CFG construction, jump resolution
+- `docs/modules/evm/` — EVM bytecode cache, CFG construction, SPP metering
 
 ### Compatibility
 
 No breaking changes. Interpreter semantics are preserved (`GasChunkCost`
-unchanged). JIT semantics are preserved (no frontend changes).
+remains the unshifted per-block cost, matching PR #371). JIT semantics are
+preserved when SPP is enabled (the JIT now reads SPP-shifted costs from a
+separate array instead of overwriting the interpreter's table).
 
 ### Metrics
 
@@ -80,64 +99,65 @@ Measured via `evmone-bench` against `upstream/main@a14a9de` on the
 - A handful of small regressions remain (≤ +6%) on
   `sha1_shifts/5311`, `structarray_alloc/nfts_rank`, `weierstrudel/1`,
   `blake2b_shifts/8415nulls` — these are jump-heavy Solidity patterns where
-  the added CFG edges apparently perturb chunk layout slightly.
+  the added CFG edges perturb chunk layout slightly.
 
 Correctness: 223/223 multipass evmone-unittests, 215/215 interpreter
 evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
 
 ## Implementation Plan
 
-### Phase 1: Remove all-or-nothing fallback
+### Mixed CFG construction
 
-- [x] Remove the fallback that disabled SPP when any dynamic jump was unresolved
-- [x] Build mixed CFG with over-approximated edges for unresolved jumps
+- [x] Remove the all-or-nothing fallback that disabled SPP on any unresolved
+      dynamic jump
+- [x] Factor `buildCFGEdges()` so static jumps get precise single-target
+      edges and unresolved dynamic jumps get over-approximated edges to
+      every `JUMPDEST`
 
-### Phase 2: Call-site enumeration
+### JIT cost wiring
 
-- [x] Add `resolveCallSiteTargets()` for `SWAPn→JUMP` patterns
-- [x] Identify call sites and collect return addresses via reverse reachability
-
-### Phase 3: JIT integration
-
-- [x] Add `EVMBytecodeCache::GasChunkCostSPP` parallel array populated from
-      `Metering[]` in `buildGasChunksSPP`
-- [x] Plumb through `EVMFrontendContext::setGasChunkInfo` and `EVMMirBuilder`
-- [x] Swap reads in `meterOpcode`, `meterOpcodeRange`, and the JUMPDEST-run
-      suffix-sum precompute to prefer `GasChunkCostSPP` when non-null
+- [x] Add `EVMBytecodeCache::GasChunkCostSPP` parallel array, populated from
+      the SPP metering function in `buildGasChunksSPP`
+- [x] Plumb the SPP pointer through `EVMFrontendContext::setGasChunkInfo`
+      and `EVMMirBuilder`
+- [x] In `meterOpcode`, `meterOpcodeRange`, and the JUMPDEST-run suffix-sum
+      precompute, prefer `GasChunkCostSPP` when non-null
 - [x] Interpreter continues reading the unshifted `GasChunkCost` — no change
 
-### Phase 4: SPP pipeline gating
+### SPP pipeline gating
 
 - [x] Add `buildBytecodeCache(..., bool EnableSPP)` parameter
-- [x] When `EnableSPP == false`, skip the expensive CFG / call-site /
-      metering pipeline entirely and emit unshifted per-block costs
-- [x] `EVMModule::CacheNeedsSPP` is flipped to `true` only immediately
-      before `performEVMJITCompile` runs, so interpreter-only modules never
-      pay the SPP pipeline cost
+- [x] When `EnableSPP == false`, skip the CFG / metering pipeline and emit
+      unshifted per-block costs only
+- [x] `EVMModule::CacheNeedsSPP` is flipped to `true` immediately before
+      `performEVMJITCompile` runs, so interpreter-only modules never pay
+      the SPP pipeline cost
 - [x] `evm_compiler.cpp` passes `nullptr` for `GasChunkCostSPP` when the
-      cache array is empty, so the JIT falls back to the unshifted array if
-      a module somehow ends up JIT-compiled without SPP being built
+      array is empty, so the JIT falls back to the unshifted array if a
+      module is JIT-compiled without SPP being built
 
-## Changed Files
+### Soundness guards
 
-- `src/evm/evm_cache.h` — add `GasChunkCostSPP` array
-- `src/evm/evm_cache.cpp` — mixed-CFG, SPP export, soundness fix (always
-  over-approximate CFG for dynamic jumps)
-- `src/compiler/evm_frontend/evm_mir_compiler.h` — plumb SPP pointer through
-  context and builder
-- `src/compiler/evm_frontend/evm_mir_compiler.cpp` — prefer SPP-shifted cost
-  at the three chunk-cost read sites
-- `src/compiler/evm_compiler.cpp` — pass the new pointer via `setGasChunkInfo`
-
-### Phase 5: Soundness fix
-
-- [x] Remove two-pass CFG rebuild — `buildCFGEdges` always over-approximates
-      dynamic jumps (edges to all JUMPDESTs)
-- [x] Remove dead call-site enumeration code (no downstream consumer yet)
 - [x] Tighten `lemma614Update` to set `MinSucc = 0` when encountering
       excluded successors or gas-chunk terminators
 
+## Changed Files
+
+- `src/evm/evm_cache.h` — add `GasChunkCostSPP` array, document
+  interpreter vs JIT consumer split
+- `src/evm/evm_cache.cpp` — mixed-CFG `buildCFGEdges`, SPP-shifted cost
+  export, `EnableSPP` gating
+- `src/compiler/evm_frontend/evm_mir_compiler.h` — plumb SPP pointer
+  through context and builder
+- `src/compiler/evm_frontend/evm_mir_compiler.cpp` — prefer SPP-shifted
+  cost at the three chunk-cost read sites
+- `src/compiler/evm_compiler.cpp` — pass the new pointer via
+  `setGasChunkInfo`, with `nullptr` fallback when the SPP array is empty
+- `src/runtime/evm_module.h` — `CacheNeedsSPP` flag
+
 ## Risks
 
-- Over-approximated edges for unresolved jumps may pessimize gas placement for
-  pathological contracts with many unresolved targets.
+- Over-approximated edges for unresolved jumps may pessimize gas placement
+  for pathological contracts with many unresolved targets. Acceptable
+  because the alternative (narrowed edges from partial resolution) is
+  unsound for SPP.

--- a/docs/changes/2026-04-05-gas-check-placement/README.md
+++ b/docs/changes/2026-04-05-gas-check-placement/README.md
@@ -18,11 +18,11 @@ reachability. Achieves high jump resolution rate on typical Solidity contracts.
 
 `GasChunkCost` continues to write the original `Blocks[Id].Cost` (not the
 SPP-shifted `Metering[Id]`) — the interpreter's gas chunk fast path requires
-unshifted per-block costs, as established by PR #371. The SPP pipeline still
-runs so that mixed-CFG gains benefit the downstream `isGasChunkTerminator`
-shifting guards, but shifted values are not exported back to the chunk tables.
-Wiring shifted values into the JIT via a separate JIT-only output path is left
-as a follow-up.
+unshifted per-block costs, as established by PR #371. A second parallel array
+`GasChunkCostSPP` is added to `EVMBytecodeCache` specifically for the multipass
+JIT: the SPP metering pass writes shifted values into it, and the JIT prefers
+it over the unshifted table when emitting gas checks. The interpreter never
+reads the new array, preserving #371 semantics.
 
 ## Motivation
 
@@ -91,14 +91,24 @@ evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
 - [x] Add `resolveCallSiteTargets()` for `SWAPn→JUMP` patterns
 - [x] Identify call sites and collect return addresses via reverse reachability
 
-### Phase 3: JIT integration (deferred)
+### Phase 3: JIT integration
 
-- [ ] Plumb SPP-shifted metering into a JIT-only output path without perturbing
-      the interpreter chunk tables
+- [x] Add `EVMBytecodeCache::GasChunkCostSPP` parallel array populated from
+      `Metering[]` in `buildGasChunksSPP`
+- [x] Plumb through `EVMFrontendContext::setGasChunkInfo` and `EVMMirBuilder`
+- [x] Swap reads in `meterOpcode`, `meterOpcodeRange`, and the JUMPDEST-run
+      suffix-sum precompute to prefer `GasChunkCostSPP` when non-null
+- [x] Interpreter continues reading the unshifted `GasChunkCost` — no change
 
 ## Changed Files
 
-- `src/evm/evm_cache.cpp`
+- `src/evm/evm_cache.h` — add `GasChunkCostSPP` field
+- `src/evm/evm_cache.cpp` — mixed-CFG, call-site enumeration, SPP export
+- `src/compiler/evm_frontend/evm_mir_compiler.h` — plumb SPP pointer through
+  context and builder
+- `src/compiler/evm_frontend/evm_mir_compiler.cpp` — prefer SPP-shifted cost
+  at the three chunk-cost read sites
+- `src/compiler/evm_compiler.cpp` — pass the new pointer via `setGasChunkInfo`
 
 ## Risks
 

--- a/docs/changes/2026-04-05-gas-check-placement/README.md
+++ b/docs/changes/2026-04-05-gas-check-placement/README.md
@@ -1,0 +1,97 @@
+# Change: Gas check placement optimization with mixed CFG support
+
+- **Status**: Implemented
+- **Date**: 2026-04-05
+- **Tier**: Full
+
+## Overview
+
+Remove all-or-nothing dynamic jump fallback — previously any unresolved dynamic
+jump caused the entire contract to fall back to per-block gas metering (zero SPP
+benefit). Now always builds a CFG with mixed edges: precise for resolved jumps,
+over-approximated for unresolved ones.
+
+Add call-site enumeration for function returns: resolves `SWAPn→JUMP` patterns
+(Solidity internal function returns) by identifying call sites
+(`PUSH ret → PUSH func → JUMP`) and collecting return addresses via reverse
+reachability. Achieves high jump resolution rate on typical Solidity contracts.
+
+`GasChunkCost` continues to write the original `Blocks[Id].Cost` (not the
+SPP-shifted `Metering[Id]`) — the interpreter's gas chunk fast path requires
+unshifted per-block costs, as established by PR #371. The SPP pipeline still
+runs so that mixed-CFG gains benefit the downstream `isGasChunkTerminator`
+shifting guards, but shifted values are not exported back to the chunk tables.
+Wiring shifted values into the JIT via a separate JIT-only output path is left
+as a follow-up.
+
+## Motivation
+
+The existing all-or-nothing fallback meant that any contract with unresolvable
+dynamic jumps got zero benefit from SPP. Real-world contracts mix static and
+dynamic jumps, so a mixed-edge CFG approach is needed to let the pass do useful
+work on the resolved portion of the CFG.
+
+## Scope
+
+This PR is scoped to the cache-side CFG improvements only:
+
+- Remove the `HasDynamicJump` early-exit bailout in `buildGasChunksSPP`.
+- Factor out `buildCFGEdges()` so the CFG can be built twice: once with
+  over-approximation, once with call-site-resolved targets mixed in.
+- Add `resolveCallSiteTargets()` — identifies `SWAPn→JUMP` return patterns and
+  walks predecessors to find the enclosing function entry, then collects valid
+  return addresses from matching call sites.
+- Introduce `decodePushAsJumpDest()` as a shared helper, and add `Prev2Pc` /
+  `Prev2Opcode` tracking on `GasBlock` to support the 3-instruction call-site
+  window lookup.
+- Tighten the SPP shifting guards to bail out of the shift when a successor is
+  a `isGasChunkTerminator` — prevents masking gas cost across chunk boundaries.
+
+No frontend/MIR changes are included in this PR.
+
+## Impact
+
+### Affected Modules
+
+- `docs/modules/evm/` — EVM bytecode cache, CFG construction, jump resolution
+
+### Compatibility
+
+No breaking changes. Interpreter semantics are preserved (`GasChunkCost`
+unchanged). JIT semantics are preserved (no frontend changes).
+
+### Metrics
+
+Metrics need to be re-measured on top of current `upstream/main` (which
+includes true-SSA stack lifting from PR #395). Previous numbers reported on a
+stale base are no longer comparable and have been dropped from this document.
+
+## Implementation Plan
+
+### Phase 1: Remove all-or-nothing fallback
+
+- [x] Remove the fallback that disabled SPP when any dynamic jump was unresolved
+- [x] Build mixed CFG with over-approximated edges for unresolved jumps
+
+### Phase 2: Call-site enumeration
+
+- [x] Add `resolveCallSiteTargets()` for `SWAPn→JUMP` patterns
+- [x] Identify call sites and collect return addresses via reverse reachability
+
+### Phase 3: JIT integration (deferred)
+
+- [ ] Plumb SPP-shifted metering into a JIT-only output path without perturbing
+      the interpreter chunk tables
+
+## Changed Files
+
+- `src/evm/evm_cache.cpp`
+
+## Risks
+
+- Over-approximated edges for unresolved jumps may pessimize gas placement for
+  pathological contracts with many unresolved targets.
+- Call-site enumeration assumes the Solidity-style
+  `PUSH ret → PUSH func → JUMP` pattern; non-standard compilers may not match.
+- Reverse-reachability walk is bounded by `MAX_REVERSE_REACHABILITY_DEPTH` to
+  cap worst-case compile-time cost.

--- a/docs/changes/2026-04-05-gas-check-placement/README.md
+++ b/docs/changes/2026-04-05-gas-check-placement/README.md
@@ -62,9 +62,22 @@ unchanged). JIT semantics are preserved (no frontend changes).
 
 ### Metrics
 
-Metrics need to be re-measured on top of current `upstream/main` (which
-includes true-SSA stack lifting from PR #395). Previous numbers reported on a
-stale base are no longer comparable and have been dropped from this document.
+Measured via `evmone-bench` against `upstream/main@a14a9de` on the
+`external/total/(main|micro)/*` benchmark set (3 repetitions, median).
+
+- **Geometric mean: −10.13%** across 27 benchmarks.
+- Large wins on memory-growth and signextend chunks:
+  - `micro/memory_grow_mload/*`: −19% to −24%
+  - `micro/memory_grow_mstore/*`: −19% to −20%
+  - `micro/signextend/{one,zero}`: −19% to −20%
+- Headline contract: `main/snailtracer/benchmark`: −7.53%
+- A handful of small regressions remain (≤ +6%) on
+  `sha1_shifts/5311`, `structarray_alloc/nfts_rank`, `weierstrudel/1`,
+  `blake2b_shifts/8415nulls` — these are jump-heavy Solidity patterns where
+  the added CFG edges apparently perturb chunk layout slightly.
+
+Correctness: 223/223 multipass evmone-unittests, 215/215 interpreter
+evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
 
 ## Implementation Plan
 

--- a/docs/changes/2026-04-05-gas-check-placement/README.md
+++ b/docs/changes/2026-04-05-gas-check-placement/README.md
@@ -53,8 +53,7 @@ This PR is scoped to the cache-side CFG improvements only:
 - Tighten the SPP shifting guards to bail out of the shift when a successor is
   a `isGasChunkTerminator` — prevents masking gas cost across chunk boundaries.
 
-No frontend/MIR changes are included in this PR. Resolved jump targets are
-exported via `EVMBytecodeCache::ResolvedJumpTargets` for future use.
+No frontend/MIR changes are included in this PR.
 
 ## Impact
 
@@ -121,9 +120,9 @@ evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
 
 ## Changed Files
 
-- `src/evm/evm_cache.h` — add `GasChunkCostSPP` array and `ResolvedJumpTargets` map
-- `src/evm/evm_cache.cpp` — mixed-CFG, call-site enumeration, SPP export,
-  soundness fix (always over-approximate CFG for dynamic jumps)
+- `src/evm/evm_cache.h` — add `GasChunkCostSPP` array
+- `src/evm/evm_cache.cpp` — mixed-CFG, SPP export, soundness fix (always
+  over-approximate CFG for dynamic jumps)
 - `src/compiler/evm_frontend/evm_mir_compiler.h` — plumb SPP pointer through
   context and builder
 - `src/compiler/evm_frontend/evm_mir_compiler.cpp` — prefer SPP-shifted cost
@@ -134,8 +133,7 @@ evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
 
 - [x] Remove two-pass CFG rebuild — `buildCFGEdges` always over-approximates
       dynamic jumps (edges to all JUMPDESTs)
-- [x] Export `ResolvedJumpTargets` through `EVMBytecodeCache` for downstream
-      MIR direct-branch optimization (with runtime guard)
+- [x] Remove dead call-site enumeration code (no downstream consumer yet)
 - [x] Tighten `lemma614Update` to set `MinSucc = 0` when encountering
       excluded successors or gas-chunk terminators
 
@@ -143,10 +141,3 @@ evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
 
 - Over-approximated edges for unresolved jumps may pessimize gas placement for
   pathological contracts with many unresolved targets.
-- Call-site enumeration assumes the Solidity-style
-  `PUSH ret → PUSH func → JUMP` pattern; non-standard compilers may not match.
-- Reverse-reachability walk is bounded by `MAX_REVERSE_REACHABILITY_DEPTH` to
-  cap worst-case compile-time cost.
-- Reverse-reachability BFS uses over-approximate predecessor edges, so it may
-  cross function boundaries and find a wrong entry. This is benign because
-  resolved targets are only used with runtime guards downstream.

--- a/docs/changes/2026-04-05-gas-check-placement/README.md
+++ b/docs/changes/2026-04-05-gas-check-placement/README.md
@@ -8,13 +8,19 @@
 
 Remove all-or-nothing dynamic jump fallback — previously any unresolved dynamic
 jump caused the entire contract to fall back to per-block gas metering (zero SPP
-benefit). Now always builds a CFG with mixed edges: precise for resolved jumps,
-over-approximated for unresolved ones.
+benefit). Now always builds a CFG with over-approximated edges for all unresolved
+dynamic jumps and precise edges for static jumps (PUSH → JUMP). The CFG is
+intentionally kept over-approximate — using resolved targets to narrow edges
+would under-approximate the CFG when resolution is incomplete, causing
+`lemma614Update` to shift gas along non-existent edges and produce unsafe
+metering.
 
 Add call-site enumeration for function returns: resolves `SWAPn→JUMP` patterns
 (Solidity internal function returns) by identifying call sites
 (`PUSH ret → PUSH func → JUMP`) and collecting return addresses via reverse
-reachability. Achieves high jump resolution rate on typical Solidity contracts.
+reachability. Resolved targets are exported through `ResolvedJumpTargets` for
+downstream consumers (e.g. MIR direct-branch optimization with runtime guard),
+not used for CFG refinement.
 
 `GasChunkCost` continues to write the original `Blocks[Id].Cost` (not the
 SPP-shifted `Metering[Id]`) — the interpreter's gas chunk fast path requires
@@ -47,7 +53,8 @@ This PR is scoped to the cache-side CFG improvements only:
 - Tighten the SPP shifting guards to bail out of the shift when a successor is
   a `isGasChunkTerminator` — prevents masking gas cost across chunk boundaries.
 
-No frontend/MIR changes are included in this PR.
+No frontend/MIR changes are included in this PR. Resolved jump targets are
+exported via `EVMBytecodeCache::ResolvedJumpTargets` for future use.
 
 ## Impact
 
@@ -114,13 +121,23 @@ evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
 
 ## Changed Files
 
-- `src/evm/evm_cache.h` — add `GasChunkCostSPP` field
-- `src/evm/evm_cache.cpp` — mixed-CFG, call-site enumeration, SPP export
+- `src/evm/evm_cache.h` — add `GasChunkCostSPP` array and `ResolvedJumpTargets` map
+- `src/evm/evm_cache.cpp` — mixed-CFG, call-site enumeration, SPP export,
+  soundness fix (always over-approximate CFG for dynamic jumps)
 - `src/compiler/evm_frontend/evm_mir_compiler.h` — plumb SPP pointer through
   context and builder
 - `src/compiler/evm_frontend/evm_mir_compiler.cpp` — prefer SPP-shifted cost
   at the three chunk-cost read sites
 - `src/compiler/evm_compiler.cpp` — pass the new pointer via `setGasChunkInfo`
+
+### Phase 5: Soundness fix
+
+- [x] Remove two-pass CFG rebuild — `buildCFGEdges` always over-approximates
+      dynamic jumps (edges to all JUMPDESTs)
+- [x] Export `ResolvedJumpTargets` through `EVMBytecodeCache` for downstream
+      MIR direct-branch optimization (with runtime guard)
+- [x] Tighten `lemma614Update` to set `MinSucc = 0` when encountering
+      excluded successors or gas-chunk terminators
 
 ## Risks
 
@@ -130,3 +147,6 @@ evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
   `PUSH ret → PUSH func → JUMP` pattern; non-standard compilers may not match.
 - Reverse-reachability walk is bounded by `MAX_REVERSE_REACHABILITY_DEPTH` to
   cap worst-case compile-time cost.
+- Reverse-reachability BFS uses over-approximate predecessor edges, so it may
+  cross function boundaries and find a wrong entry. This is benign because
+  resolved targets are only used with runtime guards downstream.

--- a/docs/changes/2026-04-05-gas-check-placement/README.md
+++ b/docs/changes/2026-04-05-gas-check-placement/README.md
@@ -36,8 +36,8 @@ work on the resolved portion of the CFG.
 This PR is scoped to the cache-side CFG improvements only:
 
 - Remove the `HasDynamicJump` early-exit bailout in `buildGasChunksSPP`.
-- Factor out `buildCFGEdges()` so the CFG can be built twice: once with
-  over-approximation, once with call-site-resolved targets mixed in.
+- Factor out `buildCFGEdges()` with over-approximation for all unresolved
+  dynamic jumps (sound for SPP metering).
 - Add `resolveCallSiteTargets()` — identifies `SWAPn→JUMP` return patterns and
   walks predecessors to find the enclosing function entry, then collects valid
   return addresses from matching call sites.

--- a/docs/changes/2026-04-05-gas-check-placement/README.md
+++ b/docs/changes/2026-04-05-gas-check-placement/README.md
@@ -100,6 +100,18 @@ evmone-unittests, 2723/2723 evmone-statetests on `fork_Cancun`.
       suffix-sum precompute to prefer `GasChunkCostSPP` when non-null
 - [x] Interpreter continues reading the unshifted `GasChunkCost` — no change
 
+### Phase 4: SPP pipeline gating
+
+- [x] Add `buildBytecodeCache(..., bool EnableSPP)` parameter
+- [x] When `EnableSPP == false`, skip the expensive CFG / call-site /
+      metering pipeline entirely and emit unshifted per-block costs
+- [x] `EVMModule::CacheNeedsSPP` is flipped to `true` only immediately
+      before `performEVMJITCompile` runs, so interpreter-only modules never
+      pay the SPP pipeline cost
+- [x] `evm_compiler.cpp` passes `nullptr` for `GasChunkCostSPP` when the
+      cache array is empty, so the JIT falls back to the unshifted array if
+      a module somehow ends up JIT-compiled without SPP being built
+
 ## Changed Files
 
 - `src/evm/evm_cache.h` — add `GasChunkCostSPP` field

--- a/docs/changes/2026-04-05-gas-check-placement/review-fixes.md
+++ b/docs/changes/2026-04-05-gas-check-placement/review-fixes.md
@@ -1,9 +1,27 @@
 # PR #446 Review Response Plan
 
-- **Status**: Planned
+- **Status**: Implemented (F1, F4, F5); F2/F3 applied to PR body; F6 dropped
 - **Date**: 2026-05-07
 - **Parent change**: `README.md` (gas check placement w/ mixed CFG, SPP JIT output, interpreter-mode gating)
 - **Branch**: `feat/gas-check-placement`
+
+## Status update (2026-05-07)
+
+- **F1 implemented** in commit `81efba3` — `Prev2Pc/Prev2Opcode` removed,
+  whole-repo grep clean, `GasBlock` shrinks ~9 bytes.
+- **F4 implemented** in commit `81efba3` (squashed with F1) — added the
+  soundness-pairing comment to `buildCFGEdges`.
+- **F5 implemented** in commit `691069a` — `CacheNeedsSPP` lifecycle
+  invariant comment added.
+- **F2 / F3 applied** to the PR body via `gh pr edit` — Copilot threads
+  noted as already-resolved + content-stale (live GraphQL confirmed
+  `isResolved: true` for all three before the edit), perf table
+  rewritten with honest +17 to +22.8% jump-heavy regressions from the
+  latest CI bot output.
+- **F6 dropped** — opening an upstream issue for an `addEdge` O(deg²)
+  concern that was theoretical, unmeasured, and not touched by any
+  commit on this branch would have been noise. The concern remains
+  documented below for future reference but no issue is filed.
 
 This plan addresses the findings of the 2026-05-07 self-review of PR #446.
 Items are grouped by whether they block merge.
@@ -142,24 +160,25 @@ Append to the field's existing comment:
 
 Documentation only.
 
-### F6 — `addEdge` O(deg²) compile-time guardrail
+### F6 — `addEdge` O(deg²) compile-time guardrail [DROPPED 2026-05-07]
 
-`addEdge` (`src/evm/evm_cache.cpp:204` area) uses `std::find` for dedup,
-giving O(current_deg) per insertion. Combined with over-approximated
+**Status**: dropped. Opening an upstream issue about a code path none
+of the F1/F4/F5 commits touch, with no measured evidence of compile-
+time pain on the existing CI matrix, would have been noise.
+
+**Original concern (kept for future reference)**: `addEdge`
+(`src/evm/evm_cache.cpp:204` area) uses `std::find` for dedup, giving
+O(current_deg) per insertion. Combined with over-approximated
 dynamic-jump edges (`|JUMPDEST| × |dynamic jumps|`), pathological
-contracts may inflate compile time. Phase 4 gating limits exposure to
-JIT-consumer modules, but no guardrail exists.
+contracts could inflate compile time. Phase 4 gating limits exposure
+to JIT-consumer modules.
 
-**Action**: file a follow-up issue, do **not** include in this PR. Two
-options for the follow-up:
-
-1. Switch `Succs` / `Preds` to a hybrid representation: `vector<uint32_t>`
-   plus a side `unordered_set<uint32_t>` for dedup-only on hot insertions.
-2. Add a `LOG_INFO` warning when `JumpDestBlocks.size() *
-   dynamic_jump_count > THRESHOLD` so we have telemetry before tuning.
-
-**Verification of follow-up issue**: open before merge, link from the PR
-body.
+**If a future contract trips this**: capture the offending bytecode
++ JIT compile-time profile first, then either (a) switch `Succs` /
+`Preds` to a `vector<uint32_t>` + `unordered_set<uint32_t>` hybrid for
+O(1) dedup, or (b) add a `LOG_INFO` warning when
+`JumpDestBlocks.size() * dynamic_jump_count` exceeds a threshold so
+the next tuning cycle has telemetry. Don't act preemptively.
 
 ## Sequencing
 
@@ -168,10 +187,10 @@ body.
 | 1 | F1: remove `Prev2Pc/Prev2Opcode` (1 commit) | `src/evm/evm_cache.cpp` |
 | 2 | F4 + F5: documentation tweaks (1 commit, squashable) | `src/evm/evm_cache.cpp`, `src/runtime/evm_module.h` |
 | 3 | Build + format + local test gate (see below) | `tools/format.sh` + `evmone-unittests` + `evmone-statetest` + `ctest` |
-| 4 | F6: open follow-up GitHub issue for `addEdge` O(deg²) — capture title/number now so step 6 can link to it | GitHub issue tracker |
-| 5 | Push to `feat/gas-check-placement`; await CI green (~35 min for the multipass perf job) | — |
-| 6 | F2: edit PR body to point at `c26bf7c` and the F6 issue (no thread mutation — Round-2 live query confirmed all 4 threads already resolved) | GitHub web/CLI |
-| 7 | F3: rewrite Risks/Evaluation section in PR body using numbers regenerated from the latest CI bot table (per "PR perf table integrity" rule, never paste from memory) | GitHub web/CLI |
+| 4 | Push to `feat/gas-check-placement`; await CI green (~35 min for the multipass perf job) | — |
+| 5 | F2: edit PR body to point at `c26bf7c` (no thread mutation — Round-2 live query confirmed all 4 threads already resolved) | GitHub web/CLI |
+| 6 | F3: rewrite Evaluation section in PR body using numbers from the latest CI bot table (per "PR perf table integrity" rule, never paste from memory) | GitHub web/CLI |
+| 7 | (F6 dropped) | — |
 
 ## Out-of-scope
 

--- a/docs/changes/2026-04-05-gas-check-placement/review-fixes.md
+++ b/docs/changes/2026-04-05-gas-check-placement/review-fixes.md
@@ -1,0 +1,218 @@
+# PR #446 Review Response Plan
+
+- **Status**: Planned
+- **Date**: 2026-05-07
+- **Parent change**: `README.md` (gas check placement w/ mixed CFG, SPP JIT output, interpreter-mode gating)
+- **Branch**: `feat/gas-check-placement`
+
+This plan addresses the findings of the 2026-05-07 self-review of PR #446.
+Items are grouped by whether they block merge.
+
+## Blocking before merge
+
+### F1 — Remove dead `Prev2Pc` / `Prev2Opcode` tracking
+
+**Symptom**: `src/evm/evm_cache.cpp:195, 198` add two `GasBlock` fields and
+`src/evm/evm_cache.cpp:323-324` write them in `buildGasBlocks`, but no
+reader exists in `src/` or `tests/`. The PR description justifies them as
+"future 3-instruction call-site window lookup", but Phase 5 (commit
+`c26bf7c`) removed call-site enumeration entirely, so the rationale no
+longer applies on this branch.
+
+**Why this blocks**: a fresh reviewer will re-question every PR cycle until
+the dead fields are gone or have a concrete forward link. Leaving them in
+also adds a small per-block bookkeeping cost on every cache build.
+
+**Fix**: remove `GasBlock::Prev2Pc`, `GasBlock::Prev2Opcode`, and the two
+writes inside `buildGasBlocks`. Verify no header or test exposes them.
+
+**Verification**:
+- `grep -rn 'Prev2Pc\|Prev2Opcode'` (whole repo) returns nothing.
+- `tools/format.sh check` clean.
+- Local `evmone-unittests` multipass + interpreter both pass — confirm no
+  hidden dependency surfaces.
+
+**Side effect to note in commit body**: `GasBlock` shrinks by ~9 bytes
+(one `uint32_t` + one `uint8_t` + alignment). Cache memory footprint
+drops marginally; not expected to perturb perf but worth flagging.
+
+**Out of scope**: re-introducing the tracking when a real consumer lands.
+That belongs in the consumer's own PR.
+
+### F2 — Annotate PR body re: stale Copilot AI threads
+
+**Symptom**: the three Copilot AI inline comments on PR #446 target an
+earlier iteration that included `ResolvedJumpTargets` and call-site
+enumeration. Phase 5 (`c26bf7c`) deleted that code, making the threads
+content-stale.
+
+**Round-2 update**: a live GraphQL query
+(`gh api graphql ... reviewThreads`) on 2026-05-07 confirmed that all
+three Copilot threads are **already** `isResolved: true` (Copilot author
+login: `copilot-pull-request-reviewer`). zoowii's design-doc thread is
+also resolved. So the previously-planned `resolveReviewThread` mutation
+is unnecessary.
+
+**Why this still matters (downgraded from blocking)**: even though the
+threads are visually collapsed, the resolution didn't cite the commit
+that made them obsolete. A future reviewer expanding the threads can
+still be confused. A short pointer in the PR body removes that
+confusion.
+
+**Fix**:
+1. Edit the PR description to add a short "Resolved review threads" line
+   noting that Phase 5 commit `c26bf7c` (call-site enumeration removal)
+   makes the three Copilot AI inline threads content-stale; threads are
+   already resolved on the GitHub side.
+2. Do **not** edit, reply to, re-resolve, or unresolve any thread — they
+   are already in the correct state, and zoowii's thread must be left
+   alone per the "no-auto-reply-to-zoowii" rule.
+
+**Verification**:
+- `gh api graphql -f query='query{repository(owner:"DTVMStack",name:"DTVM"){pullRequest(number:446){reviewThreads(first:50){nodes{id isResolved comments(first:1){nodes{author{login}}}}}}}}'`
+  still reports `isResolved: true` for all 4 threads (3 Copilot + 1
+  zoowii) after the PR body edit.
+- `gh pr view 446` shows the PR body now mentions `c26bf7c` as the
+  commit that obsoleted the call-site / `ResolvedJumpTargets`
+  discussion.
+
+### F3 — Make `weierstrudel` / `jump_around` regression visible in PR body
+
+**Symptom**: the multipass perf table shows `weierstrudel/15 +17.5%`,
+`weierstrudel/1 +19.5%`, `micro/jump_around/empty +22.8%` — within the
+25% gate but clustered near the ceiling. The current PR description
+groups them with "small regressions remain (≤ +6%)" which is wrong, and
+buries them in the per-bench list.
+
+**Why this blocks**: hides a known design-tradeoff cost from upstream
+reviewers; if a future contract trips +25%, reviewers will treat it as a
+new regression rather than the predicted cost of mixed-CFG over-approx.
+
+**Fix**: rewrite the "Risks" / "Evaluation" section of the PR body to:
+1. Correct the "≤ +6%" claim; explicitly list the ~+17 to +23% jump-heavy
+   regressions with the actual numbers.
+2. State that these are the predicted cost of CFG over-approximation on
+   jump-heavy contracts (consistent with the design-doc rationale) — not
+   noise.
+3. Note the 25% threshold buffer is intentional but tight; if a future
+   contract trips, the right move is to investigate that contract, not
+   to widen the threshold.
+
+**Verification**:
+- Read the rewritten PR body once before pushing, confirm each cited
+  number matches the CI bot's latest table (per the
+  "PR perf table integrity" rule, regenerate from the bot, do not paste
+  from memory).
+
+## Non-blocking follow-ups (file as TODO comments + GitHub issue)
+
+### F4 — Document `buildCFGEdges` over-approx invariant
+
+`buildCFGEdges` is at `src/evm/evm_cache.cpp:389-429`. Its function-level
+comment (lines 386-388) and inline branch comment (lines 419-422) already
+explain *why* over-approximation is intentional, but neither links forward
+to the soundness mechanism that absorbs the cost (`lemma614Update` at line
+920, which uses the `effectivePredCount > 1` guard at line 911 to refuse
+shifting along over-approx edges).
+
+Append one sentence to the function-level comment block at lines 386-388:
+
+> "After this pass, JUMPDEST blocks may have many predecessors; this is
+> the intentional partner to `lemma614Update`'s `effectivePredCount > 1`
+> guard, which refuses to shift gas across edges with multiple
+> predecessors and so absorbs the over-approximation soundly."
+
+Documentation only — no behavior change. ~3-line edit at the function
+header.
+
+### F5 — `CacheNeedsSPP` lifecycle invariant comment
+
+The `CacheNeedsSPP` field is at `src/runtime/evm_module.h:82` (already
+has a short comment about JIT consumption). The lifecycle constraint is
+visible at `src/runtime/evm_module.cpp:117` (set before
+`performEVMJITCompile`), `:125` (`getBytecodeCache` triggers build), and
+`:135` (`initBytecodeCache` reads `CacheNeedsSPP`).
+
+Append to the field's existing comment:
+
+> "Must be set before any `getBytecodeCache()` call — once the cache is
+> built, the `EnableSPP` decision is fixed for the lifetime of the
+> module. Future lazy / on-demand JIT paths must flip this flag before
+> triggering the lazy cache build."
+
+Documentation only.
+
+### F6 — `addEdge` O(deg²) compile-time guardrail
+
+`addEdge` (`src/evm/evm_cache.cpp:204` area) uses `std::find` for dedup,
+giving O(current_deg) per insertion. Combined with over-approximated
+dynamic-jump edges (`|JUMPDEST| × |dynamic jumps|`), pathological
+contracts may inflate compile time. Phase 4 gating limits exposure to
+JIT-consumer modules, but no guardrail exists.
+
+**Action**: file a follow-up issue, do **not** include in this PR. Two
+options for the follow-up:
+
+1. Switch `Succs` / `Preds` to a hybrid representation: `vector<uint32_t>`
+   plus a side `unordered_set<uint32_t>` for dedup-only on hot insertions.
+2. Add a `LOG_INFO` warning when `JumpDestBlocks.size() *
+   dynamic_jump_count > THRESHOLD` so we have telemetry before tuning.
+
+**Verification of follow-up issue**: open before merge, link from the PR
+body.
+
+## Sequencing
+
+| Step | Action | Where |
+|------|--------|-------|
+| 1 | F1: remove `Prev2Pc/Prev2Opcode` (1 commit) | `src/evm/evm_cache.cpp` |
+| 2 | F4 + F5: documentation tweaks (1 commit, squashable) | `src/evm/evm_cache.cpp`, `src/runtime/evm_module.h` |
+| 3 | Build + format + local test gate (see below) | `tools/format.sh` + `evmone-unittests` + `evmone-statetest` + `ctest` |
+| 4 | F6: open follow-up GitHub issue for `addEdge` O(deg²) — capture title/number now so step 6 can link to it | GitHub issue tracker |
+| 5 | Push to `feat/gas-check-placement`; await CI green (~35 min for the multipass perf job) | — |
+| 6 | F2: edit PR body to point at `c26bf7c` and the F6 issue (no thread mutation — Round-2 live query confirmed all 4 threads already resolved) | GitHub web/CLI |
+| 7 | F3: rewrite Risks/Evaluation section in PR body using numbers regenerated from the latest CI bot table (per "PR perf table integrity" rule, never paste from memory) | GitHub web/CLI |
+
+## Out-of-scope
+
+- Re-introducing call-site resolution / `ResolvedJumpTargets`: belongs in
+  a future PR with a real consumer (e.g. MIR direct-branch optimization).
+- Tuning the 25% perf threshold or adjusting individual bench tolerances:
+  that is a CI-config concern, not a code change.
+- Switching `addEdge` data structure: see F6 — follow-up only.
+
+## Quality gates
+
+Before pushing the F1+F4+F5 commit, the build must use the CI-faithful
+flag set (`.claude/rules/dtvm-build-config.md` /
+`.claude/rules/match_ci_cmake_flags`): in particular
+`-DZEN_ENABLE_JIT_PRECOMPILE_FALLBACK=ON` and `-DZEN_ENABLE_LIBEVM=ON`,
+otherwise interpreter / fallback paths run a different code shape than
+CI.
+
+1. `tools/format.sh check` clean.
+2. `cmake --build build --target dtvmapi -j$(nproc)` succeeds, no new
+   warnings.
+3. `evmone-unittests` multipass: 223/223 pass.
+4. `evmone-unittests` interpreter: 215/215 pass.
+5. `evmone-statetest --fork Cancun` multipass: 2723/2723 pass (current
+   baseline; the count must match — any drop is a regression).
+6. `evmone-statetest --fork Cancun` interpreter: must match the pass
+   count reported by the most recent CI green run on
+   `feat/gas-check-placement` (binary equality — record it once before
+   making the F1+F4+F5 commit so the local re-run can be compared
+   exactly, not just "all green").
+7. `ctest` from `build/` (the project's built-in EVM spec tests, per
+   `.claude/rules/dtvm-local-test.md`).
+8. CI green on the new push, including the matrix jobs:
+   `Build and test DTVM multipass on x86-64`,
+   `Build and test DTVM interpreter on x86-64`,
+   `Test DTVM-EVM JIT fallback in release mode with ctest on x86-64`,
+   `Test DTVM-EVM multipass evmtestsuite with gas register in release
+   mode with ctest on x86-64`,
+   `Performance Regression Check (interpreter)` and
+   `Performance Regression Check (multipass)`.
+   (~35 min for the multipass perf job.)
+
+Skip F3 (PR-body edits) until F1+F4+F5 commits land and CI passes, since
+the PR description should match the final state of the branch.

--- a/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
+++ b/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
@@ -1,0 +1,186 @@
+# Change: SPP CFG over-approximation via implicit dyn-pred count
+
+- **Status**: Implemented
+- **Date**: 2026-05-11
+- **Tier**: Light
+- **Parent PR**: builds on `feat/gas-check-placement` (PR #446)
+
+## Overview
+
+Replace the `O(D * J)` explicit over-approximation edges in
+`buildCFGEdges` (where `D` = #unresolved dynamic jumps and `J` = #JUMPDEST
+blocks) with an `O(D + J)` implicit predecessor count. The SPP shifting
+pass `lemma614Update` makes its single-vs-multi-predecessor decision via
+the new `effectivePredCount`, so behavior is equivalent for every pair
+(parent, JUMPDEST-successor) that the explicit representation would have
+materialized — without ever building the dense edge set.
+
+The static-only reachability gap that this creates (dyn-only JUMPDESTs
+become unreachable from the entry block) is closed by an explicit
+reachability stitch that seeds every JUMPDEST as a root before the
+dominator and loop analyses run.
+
+## Motivation
+
+The current `feat/gas-check-placement` representation builds a dense
+over-approximate CFG: every unresolved dynamic `JUMP`/`JUMPI` adds one
+edge to every JUMPDEST in the contract. This is `O(D * J)` edges, and
+`addEdge`'s `std::find` dedup makes each insertion `O(deg)`, so the
+total cost is `O(D * J^2 + J * D^2) = O(D * J * (D + J))`. For
+pathological dyn-heavy contracts the asymptotic blow-up is third-order.
+
+Independently, `splitCriticalEdges` then processes those same edges
+and (because every JUMPDEST has many predecessors in the over-approx
+graph) splits each one with another `O(deg)` erase + insert pair —
+contributing the same asymptotic cost a second time. PR #446 already
+gates the SPP pipeline on JIT-consumer modules to bound the runtime
+impact, but the per-module cost is still material when a large
+contract is JIT-compiled.
+
+The dense edges contribute nothing to SPP's local shift decision:
+`lemma614Update` refuses to shift into any successor with
+`effectivePredCount > 1`, and every JUMPDEST that the dynamic jump
+could reach has many predecessors after over-approximation. The edges
+are pure compile-time tax.
+
+## Design
+
+### Implicit predecessor count (replaces `D * J` edges)
+
+`GasBlock` gains one field:
+
+```cpp
+uint32_t ImplicitDynamicPredCount = 0;
+```
+
+Set on every JUMPDEST when the contract has at least one unresolved
+dynamic jump. The count equals `D`, matching the number of
+predecessors the explicit over-approximation would have produced.
+
+`effectivePredCount` folds the count in:
+
+```cpp
+static size_t effectivePredCount(const GasBlock &Block) {
+  size_t Count = Block.Preds.size();
+  if (Block.Start == 0) ++Count;
+  Count += Block.ImplicitDynamicPredCount;
+  return Count;
+}
+```
+
+`lemma614Update` reads `effectivePredCount` for every shift decision,
+so it sees an identical "multi-pred?" answer to the explicit case.
+`buildCFGEdges` no longer adds any edge from a dynamic-jump block; the
+SPP graph carries only static fall-through and resolved static-jump
+edges.
+
+### Reachability stitch (closes the dom/loop gap)
+
+After `computeReachable` runs from the entry block, every JUMPDEST is
+seeded into the reachable set and forward-propagated via `Succs`.
+Without this step, dyn-only JUMPDESTs (e.g. Solidity function return
+addresses, reached at runtime only via `PUSH ret; ... JUMP`) would
+remain unreachable in the static-only CFG, and `computeDominators` /
+`buildLoopsUsingDominance` would skip them — letting their static
+successor chains miss SPP shifting opportunities.
+
+The stitch is purely additive (sets only `Reachable[x] = 1`) and
+maintains the dominator monotonicity property required by SPP.
+
+### Compile-time complexity
+
+| Pass                  | Before (over-approx)        | After (implicit count)       |
+|-----------------------|-----------------------------|------------------------------|
+| `buildCFGEdges`       | `O(D * J^2 + J * D^2)`      | `O(N)`                       |
+| `splitCriticalEdges`  | `O(D * J^2)` on dyn edges   | `O(N)` (no dyn edges to split) |
+| `computeReachable`    | `O(N + E_dense)`            | `O(N) + reachability stitch` |
+| `computeDominators`   | Bitset width up by `+1` per JUMPDEST extra Pred | Same width, sparser graph |
+
+## Alternatives considered
+
+### Super-node (DynDispatch hub) — rejected
+
+A virtual `DynDispatch` block routing all dynamic jumps into one hub,
+then fanning out to all JUMPDESTs. `O(D + J)` edges, preserves
+reachability without a stitch, every standard pass sees a "real" CFG.
+
+Implemented and benchmarked side-by-side. Result on
+`evmone-unittests` for the `loop_full_of_jumpdests` test (single test,
+multipass mode):
+
+| Implementation | Wall time |
+|----------------|-----------|
+| `feat/gas-check-placement` (over-approx)  | 7.3 s |
+| **A** (implicit count, this PR)           | 3.3 s |
+| **B** (super-node)                        | 275 s |
+
+B's blow-up traces to `computeDominators` / `buildLoopsUsingDominance`
+on the dispatch hub: the hub creates a deeply irreducible CFG where
+the iterative dataflow takes super-linear passes to converge, and
+every back-edge into the hub triggers a `collectNaturalLoop` walk
+over every block transitively reachable from it. Patching the loop
+passes to special-case the hub re-introduces the structural
+asymmetry that motivated A in the first place. **B is unusable.**
+
+### Edge-budget fallback — rejected
+
+Keep the explicit over-approx but skip SPP when
+`D * J > kBudget`. Trades a complexity ceiling for an SPP cliff; on
+contracts that sit just over the budget the gas-check density jumps
+discontinuously. Solves a symptom rather than the root cause.
+
+## Impact
+
+### Performance (27 paper benches, `--benchmark_min_time=3x`, 5 reps)
+
+vs `feat/gas-check-placement` (PR #446) baseline:
+
+- **Geomean: 0.9727× (-2.73%)**
+- Arithmetic mean: -1.48%
+
+**Wins** (regressions from PR #446 reversed):
+
+| Benchmark | PR #446 vs upstream | A v2 vs PR #446 |
+|---|---|---|
+| `micro/jump_around/empty`       | +22.8% | **-53.1%** |
+| `micro/signextend/zero`         | -42.7% | -24.6% (further) |
+| `main/blake2b_huff/8415nulls`   | -5.3%  | -14.7% (further) |
+| `main/structarray_alloc/nfts_rank` | -6.2% | -4.9% (further) |
+| `main/snailtracer/benchmark`    | -      | -1.3% |
+| `main/weierstrudel/15`          | +17.5% | -2.5% |
+
+**Worst-case regressions** (vs PR #446):
+
+| Benchmark | A v2 vs PR #446 | Note |
+|---|---|---|
+| `main/sha1_shifts/empty`  | +27.0% (mean) | Single-outlier noise; median delta +2.7% |
+| `micro/memory_grow_mstore/by16` | +13.98% | Real |
+| `micro/memory_grow_mload/by32`  | +10.64% | Real |
+| `micro/loop_with_many_jumpdests/empty` | +6.81% | Real (was +48.5% in A v1 without reachability stitch) |
+
+All real regressions are well under the 25% CI gate. The
+`sha1_shifts/empty` mean is pulled up by one rep that hit 8.87us out
+of 5; the median is +2.7%.
+
+### Correctness
+
+- `evmone-unittests` multipass: **223/223 pass**, 8.4 s wall time
+  (vs 13 s baseline, 305 s for scheme B).
+- `tools/format.sh check`: clean.
+
+## Changed files
+
+- `src/evm/evm_cache.cpp` — `GasBlock::ImplicitDynamicPredCount` field;
+  `effectivePredCount` folds it in; `buildCFGEdges` stamps the count
+  on every JUMPDEST and skips the `D * J` edge-add loop; reachability
+  stitch in `buildGasChunksSPP` seeds every JUMPDEST as a root after
+  `computeReachable`.
+
+## Out of scope
+
+- The peripheral diagnostics about `GasChunkCostSPP` in clangd are
+  pre-existing for the PR #446 branch and unrelated to this change.
+- Re-introducing super-node / DynDispatch later — would require
+  rewriting `computeDominators` and `buildLoopsUsingDominance` to
+  treat dispatch hubs structurally, which is invasive and gives no
+  measurable benefit over the implicit-count representation.

--- a/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
+++ b/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
@@ -104,12 +104,14 @@ A virtual `DynDispatch` block routing all dynamic jumps into one hub,
 then fanning out to all JUMPDESTs. `O(D + J)` edges, preserves
 reachability without a stitch, every standard pass sees a "real" CFG.
 
-Implemented and benchmarked side-by-side. Result on
-`evmone-unittests` for the `loop_full_of_jumpdests` test (single test,
-multipass mode):
+Implemented and benchmarked side-by-side. Wall times are local
+single-machine measurements (`evmone-unittests` for the
+`loop_full_of_jumpdests` test, single test, multipass mode). They are
+**not currently tracked in CI** — a dedicated compile-time-dense
+benchmark lane is out of scope for this PR.
 
-| Implementation | Wall time |
-|----------------|-----------|
+| Implementation | Wall time (local) |
+|----------------|-------------------|
 | `feat/gas-check-placement` (over-approx)  | 7.3 s |
 | **A** (implicit count, this PR)           | 3.3 s |
 | **B** (super-node)                        | 275 s |

--- a/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
+++ b/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
@@ -176,6 +176,29 @@ of 5; the median is +2.7%.
   stitch in `buildGasChunksSPP` seeds every JUMPDEST as a root after
   `computeReachable`.
 
+### Performance — full PR #446 (with this optimization) vs `upstream/main`
+
+After rebasing `feat/gas-check-placement` onto current `upstream/main`
+(which now includes #458/#460/#482/#483 upstream perf work), the
+end-to-end picture on the same 27-bench paper filter changes:
+
+- **Geomean (10 reps): +1.15%** — basically flat
+- One bench (`main/blake2b_shifts/8415nulls`) appeared as +20.34% with
+  treatment CV 21.93%. A focused 20-rep re-measurement gave +0.25%
+  (CV 2.09%), confirming the 10-rep result was driven by a single
+  outlier iteration.
+- 0 benches above the ±25% CI gate.
+- Top wins: `blake2b_huff/8415nulls` −6.30%, `sha1_divs/5311` −5.22%,
+  `sha1_shifts/empty` −5.07%, `loop_with_many_jumpdests/empty` −4.84%.
+- Top regressions (within ±5% noise): `memory_grow_mstore/nogrow`
+  +3.91%, `signextend/one` +3.71% (down from +15.55% at 5 reps),
+  `memory_grow_mload/nogrow` +3.62%.
+
+The earlier −2.73% A-vs-PR-base geomean still holds — this change does
+improve over PR #446's pre-rebase head. But the cumulative PR #446
+benefit over current upstream/main has shrunk to noise because the
+intervening upstream perf commits closed most of the gap.
+
 ## Out of scope
 
 - The peripheral diagnostics about `GasChunkCostSPP` in clangd are

--- a/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
+++ b/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
@@ -182,24 +182,50 @@ of 5; the median is +2.7%.
 
 After rebasing `feat/gas-check-placement` onto current `upstream/main`
 (which now includes #458/#460/#482/#483 upstream perf work), the
-end-to-end picture on the same 27-bench paper filter changes:
+end-to-end picture on the same 27-bench paper filter is essentially
+flat:
 
-- **Geomean (10 reps): +1.15%** — basically flat
-- One bench (`main/blake2b_shifts/8415nulls`) appeared as +20.34% with
-  treatment CV 21.93%. A focused 20-rep re-measurement gave +0.25%
-  (CV 2.09%), confirming the 10-rep result was driven by a single
-  outlier iteration.
+- **27-bench 10-rep geomean: +1.15%** (treatment slower).
 - 0 benches above the ±25% CI gate.
-- Top wins: `blake2b_huff/8415nulls` −6.30%, `sha1_divs/5311` −5.22%,
-  `sha1_shifts/empty` −5.07%, `loop_with_many_jumpdests/empty` −4.84%.
-- Top regressions (within ±5% noise): `memory_grow_mstore/nogrow`
-  +3.91%, `signextend/one` +3.71% (down from +15.55% at 5 reps),
-  `memory_grow_mload/nogrow` +3.62%.
+- **Caveat — single-session sequential 10-rep is noisy**: a focused 20-rep
+  re-measurement on the four largest 10-rep movers showed they collapse
+  to evmone-bench's inter-binary drift band:
+
+  | Bench | 10-rep Δ | 20-rep Δ (focused) |
+  |---|---|---|
+  | `main/weierstrudel/1` | +3.51% | +0.55% (treat CV 2.19%) |
+  | `main/blake2b_huff/8415nulls` | −6.30% | +1.55% (flipped) |
+  | `micro/loop_with_many_jumpdests/empty` | −4.84% | −0.55% |
+  | `main/blake2b_shifts/8415nulls` | +20.34% (CV 21.93%) | +0.25% (CV 2.09%) |
+
+- Three of the four 10-rep "regression" benches above the noise band —
+  `micro/memory_grow_mstore/{nogrow,by1}`, `micro/memory_grow_mload/nogrow`
+  — contain **zero JUMP / JUMPI / JUMPDEST opcodes**, so PR #446's CFG
+  changes cannot affect them by construction. Those deltas are pure
+  drift artifacts.
 
 The earlier −2.73% A-vs-PR-base geomean still holds — this change does
 improve over PR #446's pre-rebase head. But the cumulative PR #446
-benefit over current upstream/main has shrunk to noise because the
-intervening upstream perf commits closed most of the gap.
+benefit over current upstream/main has shrunk to within drift band on
+this 27-bench corpus: the intervening upstream perf commits absorbed
+the absolute speedup, and the residual per-bench deltas are not
+statistically distinguishable from inter-binary system drift.
+
+### A note on the SPP→JIT cost-flow mechanism
+
+PR #446 is the first time SPP-shifted gas costs reach the JIT in any
+version of DTVM. SPP redistributes cost between blocks but preserves
+total gas across any path. For contracts with many JUMPDESTs targeted
+by dynamic jumps, the lemma 6.14 multi-pred guard prevents shifts
+INTO those JUMPDESTs but allows shifts OUT, which can mildly inflate
+the chunk-start metering immediate at each JUMPDEST. This theoretical
+effect would not be visible on the runtime side of the 27-bench
+corpus at current measurement precision (20-rep focused on
+`main/weierstrudel/1` — the most dyn-dispatch-heavy bench — shows
++0.55% delta, within CV). A future PR could gate `GasChunkCostSPP`
+to `nullptr` for JUMPDEST-density-heavy contracts if a measurable
+regression surfaces; nothing in the current corpus justifies the
+added gating logic.
 
 ## Out of scope
 

--- a/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
+++ b/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
@@ -134,18 +134,28 @@ bash docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/scaling_demo.sh
 ```
 
 The demo generates a synthetic contract (`CALLDATALOAD JUMP <N x JUMPDEST>
-STOP`) and times the full `buildBytecodeCache` call. Sample output on
-this machine:
+STOP`) and times the full `buildBytecodeCache` call.
 
-| N JUMPDESTs | cache build (ms) |
-|------------:|-----------------:|
-|         100 | 0.04 |
-|         500 | 0.13 |
-|       1,000 | 0.29 |
-|       2,000 | 0.66 |
-|       5,000 | 2.59 |
-|      10,000 | 10.02 |
-|      20,000 | 40.01 |
+**Intra-PR comparison** (the same demo cherry-picked onto commit
+`99f23a3`, which is the PR's head one commit BEFORE Phase 7 — both
+states run the SPP pipeline; the only difference is the
+over-approximation representation):
+
+| N JUMPDESTs | Pre-Phase-7 (D×J explicit edges) | Phase 7 (O(N) implicit count) | Speedup |
+|------------:|---------------------------------:|------------------------------:|--------:|
+|         100 |   0.07 ms |  0.05 ms | 1.4× |
+|         500 |   0.39 ms |  0.13 ms | 3.0× |
+|       1,000 |   1.01 ms |  0.29 ms | 3.4× |
+|       2,000 |   3.04 ms |  0.67 ms | 4.5× |
+|       5,000 |  19.66 ms |  2.71 ms | 7.2× |
+|      10,000 |  84.76 ms | 10.38 ms | 8.2× |
+|      20,000 | 345.94 ms | 43.68 ms | **7.9×** |
+
+Pre-Phase-7 wall clock grows ~4× per doubling of `N` (quadratic — the
+expected O(D × J²) shape of explicit-edge add + critical-edge split).
+Phase 7 grows 2–4× per doubling — sub-quadratic, with the residual
+super-linearity sourced from `computeDominators` and
+`buildLoopsUsingDominance` running on the now-larger reachable set.
 
 **Scope of the O(N) claim**: Phase 7 makes the CFG over-approximation
 step itself O(N) (one count stamp per JUMPDEST). The wall clock above

--- a/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
+++ b/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md
@@ -124,6 +124,39 @@ over every block transitively reachable from it. Patching the loop
 passes to special-case the hub re-introduces the structural
 asymmetry that motivated A in the first place. **B is unusable.**
 
+### Reproducing the scaling claim
+
+Build the manual demo and run the wrapper script:
+
+```bash
+cmake --build build --target evmCacheComplexityDemo
+bash docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/scaling_demo.sh
+```
+
+The demo generates a synthetic contract (`CALLDATALOAD JUMP <N x JUMPDEST>
+STOP`) and times the full `buildBytecodeCache` call. Sample output on
+this machine:
+
+| N JUMPDESTs | cache build (ms) |
+|------------:|-----------------:|
+|         100 | 0.04 |
+|         500 | 0.13 |
+|       1,000 | 0.29 |
+|       2,000 | 0.66 |
+|       5,000 | 2.59 |
+|      10,000 | 10.02 |
+|      20,000 | 40.01 |
+
+**Scope of the O(N) claim**: Phase 7 makes the CFG over-approximation
+step itself O(N) (one count stamp per JUMPDEST). The wall clock above
+includes the rest of the SPP pipeline — `computeDominators` and
+`buildLoopsUsingDominance` are iterative dataflow with super-linear
+worst-case behaviour and dominate the time at large N. The 4-second
+saving on `loop_full_of_jumpdests` (7.3 s → 3.3 s above) is the Phase 7
+contribution; the remaining 3.3 s is dom / loop analysis plus JIT
+compile, untouched by this PR. Cutting that further would require a
+separate dom-analysis change.
+
 ### Edge-budget fallback — rejected
 
 Keep the explicit over-approx but skip SPP when

--- a/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/review-fixes-r2.md
+++ b/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/review-fixes-r2.md
@@ -1,0 +1,262 @@
+# PR #446 Round-2 Review Response Plan
+
+- **Status**: Revised after round-1 review (Opus + Codex)
+- **Date**: 2026-05-12
+- **Parent change**: `README.md` (SPP CFG implicit-dyn-pred Phase 7)
+- **Branch**: `feat/gas-check-placement`
+
+This plan addresses the 2026-05-12 self-review of post-rebase PR #446,
+revised after round-1 dual-reviewer feedback. Round-1 surfaced four
+substantive corrections: R1.1 is not directly observable, R1.2 needs a
+stronger oracle, R2 is a real semantic change (not a perf guard), and
+R3's target should be the stale comment at evm_cache.cpp:1054-1059.
+
+## Blocking before merge
+
+### R1 — Targeted cache-builder unit tests for Phase 7 invariants
+
+**Symptom**: Phase 7 introduces two new mechanisms — `ImplicitDynamicPredCount`
+folded into `effectivePredCount`, and a reachability stitch that seeds every
+JUMPDEST as a BFS root after `computeReachable`. No test in `src/tests/`
+exercises either directly. The 223+215+2723 corpus pass empirically but
+won't isolate a regression in the stitch or implicit-pred logic.
+
+**Observability constraint** (from round-1 review): `struct GasBlock` and
+`ImplicitDynamicPredCount` are file-static in `src/evm/evm_cache.cpp` (line
+~197). Only `EVMBytecodeCache` arrays are exposed via `evm_cache.h`.
+**`GasChunkCostSPP[i] != 0` is not a valid oracle for "block was reached"**
+— `buildGasChunksSPP` writes every non-empty block's `Metering[Id]` into
+`GasChunkCostSPP` regardless of whether SPP analysis reached it
+(evm_cache.cpp:1207-1219). The only valid oracle is the **specific shifted
+value at PC**: when SPP analysis ran on a block, the shifted value differs
+from the unshifted base cost in a deterministic, hand-computable way.
+
+**Fix**: add a new test executable `evmCacheTests` to `src/tests/CMakeLists.txt`
+that includes `evm/evm_cache.h` directly and drives `buildBytecodeCache`.
+Use raw-hex bytecode fixtures.
+
+Three cases:
+
+1. **`Stitch_Reaches_DynOnly_JumpDest_Affects_SPP`**
+   Fixture: a contract where one JUMPDEST `A` has NO static predecessor
+   (only reachable via a dynamic JUMP elsewhere). `A` has a successor `S`
+   with `effectivePredCount(S) == 1` and a non-terminator cost that
+   lemma 6.14 would shift back into `A`.
+
+   **Oracle caveat (round-2 review)**: `computeReverseTopo`
+   (evm_cache.cpp:697-735) iterates every block without filtering by
+   `Reachable[]`, so the negative-control claim "without stitch, S not
+   in RevTopo" would be wrong. What actually changes when the stitch
+   fires is `computeDominators` input (Reachable-gated at
+   evm_cache.cpp:630-633): with stitch, A's dom-set is computed against
+   a live forward CFG; without stitch, A is self-dom.
+   `findBackEdgesUsingDominators` and the loop-aware shift path then
+   diverge.
+
+   Oracle: build the cache twice — once with the stitch live (current
+   code) and once with a test-local stitch-off path that no-ops the
+   seed loop. Assert `GasChunkCostSPP[A.Start]` differs between the two.
+   This is a "stitch toggles observable behavior" assertion; it does NOT
+   require hand-computing the exact shifted value, but does require a
+   stitch-off variant accessible to the test (a `#ifdef
+   DTVM_TEST_STITCH_OFF` block, or duplicate the build path in the test
+   TU with the seed loop disabled). If the toggle mechanic proves too
+   invasive, skip case 1 and rely on cases 2 and 3 below.
+
+2. **`No_Shift_Into_Implicit_MultiPred_JumpDest`**
+   Fixture: a JUMPDEST `B` with exactly 1 explicit static predecessor AND
+   ≥ 1 implicit dyn-jump source elsewhere in the contract.
+   - lemma 6.14 INTO `B`: `effectivePredCount(B) = 1 + DynamicJumpCount ≥ 2`,
+     should refuse to shift cost from B's predecessor INTO B.
+   - Assertion: `GasChunkCostSPP[predOf_B.Start]` is NOT modified by a
+     shift that would have moved cost into `B`. Concretely, the shifted
+     value at the predecessor should not include any contribution from
+     `B`'s base cost.
+
+3. **`Shift_OUT_From_MultiPred_JumpDest_Still_Works`** (added per round-1
+   reviewer note)
+   Fixture: a JUMPDEST `M` that has multiple implicit dyn-pred (so
+   `effectivePredCount(M) > 1`, no shift INTO M), but has at least one
+   successor `T` with `effectivePredCount(T) == 1`.
+   - lemma 6.14 looks at M's successors (evm_cache.cpp:960-972). The
+     check is on `effectivePredCount(Blocks[Succ])`, NOT on M itself. So
+     shifting cost from `T` back into `M` IS still allowed.
+   - Assertion: `GasChunkCostSPP[M.Start]` reflects the shift FROM T, i.e.
+     is greater than `GasChunkCost[M.Start]` (M's unshifted base cost).
+
+**Verification**:
+- New test target builds and links cleanly.
+- All three cases pass; explicitly disabling the stitch (debug experiment)
+  must make case 1 fail (oracle is meaningful).
+- `tools/format.sh check` clean.
+- Existing 223/215/2723 corpus unaffected.
+
+**Out of scope**: bytecode fuzzing. Targeted hand-crafted fixtures only.
+
+### R2 — Restrict stitch BFS seeding to dyn-target JUMPDESTs only
+
+**Re-framed per round-1 review**: this is a **semantic change**, not a
+perf guard. The current stitch (evm_cache.cpp:1066-1092) seeds every
+JUMPDEST as a BFS root, including:
+
+1. JUMPDESTs in no-dyn-jump contracts that are statically dead (no pred).
+2. JUMPDESTs in mixed contracts (dyn + static) that have no static or
+   implicit-dyn predecessor — i.e. genuinely-dead JUMPDESTs that no jump
+   targets at all.
+
+Pre-Phase-7, both classes were unreachable in `Reachable[]` and therefore
+ignored by `computeDominators` / `lemma614Update`. Post-Phase-7, both
+classes are now in `Reachable[]`, their dom-tree positions get computed
+(evm_cache.cpp:630-657), they enter `RevTopo`, and `lemma614Update` is
+called on them (evm_cache.cpp:1127-1132 has no `Reachable[]` gate). So
+their loop / backedge / SPP decisions are now potentially different.
+
+**Why this blocks**: silent semantic change on a class of contracts the
+post-rebase 27-bench corpus doesn't isolate. The behavior change is
+benign in most cases (dead JUMPDESTs have no out-flow, so no cost shifts
+through them), but it widens the dom/loop analysis input set in ways the
+review can't fully predict.
+
+**Fix**: change the stitch seed set from "all JUMPDESTs" to "only JUMPDESTs
+with `ImplicitDynamicPredCount > 0`". Implementation: inside the stitch
+loop (currently evm_cache.cpp:1076-1080), gate the `if (Reachable[JdId] == 0)`
+seed with `if (Blocks[JdId].ImplicitDynamicPredCount > 0)`. This restores
+pre-Phase-7 behavior on truly-dead JUMPDESTs while still rescuing real
+dyn-targets.
+
+**Verification**:
+- `Reachable[]` is internal to `buildGasChunksSPP`; the public header
+  only exposes `GasChunkCost{,SPP}`, `JumpDestMap`, `PushValueMap`,
+  `GasChunkEnd` (evm_cache.h:18-36). So the test asserts on cache state
+  delta, not on `Reachable[]` directly.
+- Fixture: contract with no dyn-jumps + one statically-dead JUMPDEST
+  `D`. With R2's gate, `D.ImplicitDynamicPredCount == 0`, the stitch
+  skips it, and `D`'s `Metering[]` value remains its unshifted base
+  cost (no `lemma614Update` call considers shifting into `D` because
+  no block has `D` in its Succs). Assertion:
+  `GasChunkCostSPP[D.Start] == GasChunkCost[D.Start]` (no shift).
+  Without the gate (regression case), `D` is in `Reachable[]`,
+  `computeDominators` may treat its position differently, and a
+  shift may alter `GasChunkCostSPP[D.Start]`. The before/after is the
+  observable delta. Implement as a unit test in `evmCacheTests`.
+- Existing tests pass.
+
+**Out of scope**: revisiting whether the dom/loop analyses should run on
+unreachable nodes at all. The conservative move here is to preserve
+pre-Phase-7 behavior on the dead-island class.
+
+### R3 — Fix the stale CFG comment block at evm_cache.cpp:1054-1059
+
+**Symptom**: the comment block above the `buildCFGEdges` call site at
+`evm_cache.cpp:1054-1059` reads:
+
+```
+// Build CFG with over-approximation for all unresolved dynamic jumps.
+// Static jumps (PUSH → JUMP) get precise single-target edges; dynamic
+// jumps get edges to every JUMPDEST. This is intentionally conservative —
+// ...
+```
+
+The text "dynamic jumps get edges to every JUMPDEST" is **wrong** post-
+Phase-7. Inside `buildCFGEdges` (evm_cache.cpp:446-447) the new behavior
+is explicitly "No explicit Succs/Preds edges added" for dyn jumps. A
+future contributor reading the call-site comment will be misled.
+
+**Why this blocks**: stale documentation lures contributors into
+re-introducing the D × J explicit edges (undoing Phase 7) "to match the
+documented behavior".
+
+**Fix**: replace the call-site comment block (1054-1059) with one that
+matches the new implementation. Suggested text:
+
+```
+// Build CFG. Static jumps (PUSH → JUMP) get precise single-target edges.
+// For unresolved dynamic jumps the CFG is kept sound by stamping each
+// JUMPDEST with ImplicitDynamicPredCount instead of materialising the
+// D × |JUMPDEST| explicit edges — that count is folded into
+// `effectivePredCount`, so `lemma614Update`'s "shift only into
+// single-effective-pred successors" check behaves identically to the
+// old explicit-edge representation. The `splitCriticalEdges` pass below
+// operates on explicit Succs/Preds and therefore never sees dyn-jump →
+// JUMPDEST edges; that is intentional because the multi-predecessor
+// guard in `lemma614Update` (with implicit count folded INTO
+// effectivePredCount) blocks shifts whenever effective preds > 1.
+```
+
+**Wording rationale (round-2 review note)**: an earlier draft said "any
+`ImplicitDynamicPredCount > 0` rejects shifts INTO". That is wrong when
+`ImplicitDynamicPredCount == 1` and the JUMPDEST has no explicit static
+pred — `effectivePredCount` would be 1 and the guard would NOT fire. In
+practice that case is moot (no block has the JUMPDEST in its Succs when
+all entries are dyn, so no `lemma614Update` call considers shifting
+into it), but the comment must phrase the invariant in terms of
+`effectivePredCount > 1` to be technically correct.
+
+**Verification**: comment correct vs implementation. No code change.
+
+## Non-blocking nice-to-have
+
+### R5 — Soften the `loop_full_of_jumpdests` compile-time claim
+
+**Symptom**: `docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md`
+claims "7.3s → 3.3s" without noting that this is a local single-machine
+measurement, not regression-protected by CI.
+
+**Fix**: update the README phrasing to "7.3s → 3.3s on a local
+single-machine run; not currently tracked in CI". Defer adding a
+compile-time bench lane to a separate PR.
+
+### R6 — Optional paranoid assert in implicit-pred stamp loop
+
+**Symptom**: `buildCFGEdges` stamps `ImplicitDynamicPredCount` on every
+block ID in `JumpDestBlocks` without verifying each ID is actually a
+JUMPDEST opcode.
+
+**Fix (if cheap)**: add `ZEN_ASSERT(Blocks[JdId].LastOpcode == evmc::OP_JUMPDEST)`
+before the stamp. Skip if `ZEN_ASSERT` is not available in this TU
+without dragging in extra includes.
+
+## Dropped
+
+### R4 — Document duplicated `isGasChunkTerminator` check — **dropped**
+
+Round-1 review: the comment block above `effectivePredCount` (~line
+930-937) already documents the multi-pred guarantee, and the
+`MinSucc = 0` rationale is already commented at evm_cache.cpp:963-967.
+Adding another comment is noise per `.claude/rules/cpp-code-style.md`
+("Only include essential comments").
+
+## Execution order
+
+1. **R3** (comment-only) — lowest risk, no code behavior change. Land
+   first so any subsequent diff stays small.
+2. **R2** (stitch-gate) — code change. Verify via fixture that
+   statically-dead JUMPDESTs return to `Reachable[]=0`.
+3. **R1** (3 unit tests). Build `evmCacheTests` and ensure all three
+   cases pass against the post-R2 implementation.
+4. **R5** (doc softening) — one-line phrase change.
+5. **R6** (assert) — optional, decide at execution time based on header
+   reach.
+
+After each step: `tools/format.sh check`, build target, run unit tests.
+
+## Verification gate before commit
+
+- New `evmCacheTests` target builds and all 3 cases pass.
+- `tools/format.sh check` clean.
+- `cmake --build build --target dtvmapi -j$(nproc)` clean (no new warnings).
+- `evmone-unittests` multipass: 223/223 pass.
+- `evmone-statetest --fork Cancun` multipass: smoke run.
+
+## Risks
+
+- **R1 fixture authoring** is the largest unknown. Hand-computing the
+  expected shifted SPP value requires careful bytecode design. If
+  difficulty exceeds budget, fall back to a single "stitch toggles
+  observable behavior" assertion (case 1 only).
+- **R2 semantic change** may surface in the existing 2723 statetest
+  corpus. If so, this becomes a 3-way decision: revert R2, narrow the
+  guard further, or accept the semantic broadening. Run statetest after
+  R2 lands.
+- **R3, R5, R6** carry no runtime risk.
+

--- a/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/scaling_demo.sh
+++ b/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/scaling_demo.sh
@@ -1,27 +1,7 @@
 #!/usr/bin/env bash
-# Demonstrate the cache-build wall clock as JUMPDEST count grows.
-# Generates synthetic contracts of the form
-#   CALLDATALOAD JUMP <N x JUMPDEST> STOP
-# (one dynamic jump, N JUMPDESTs — exercises the Phase 7 implicit-dyn-pred
-# stamping and the reachability stitch on every JUMPDEST.)
-#
-# Build the demo binary first:
-#   cmake --build build --target evmCacheComplexityDemo
-#
-# What Phase 7 changed: the per-JUMPDEST over-approximation step that used
-# to materialise D*J explicit edges is now O(N) (one count stamp per
-# JUMPDEST). The dominator and loop analyses that run AFTER buildCFGEdges
-# are unaffected by this PR and remain super-linear (~O(N*alpha(N)) for
-# the iterative dom dataflow). The wall clock you see below is the
-# WHOLE pipeline, so the residual super-linearity is the dom analysis,
-# not Phase 7.
-#
-# Reference point: `evmone-unittests` wall-clock for
-# `loop_full_of_jumpdests` (24556 JUMPDESTs, multipass mode) dropped from
-# 7.3s (pre-Phase-7, with explicit D*J edges + critical-edge split) to
-# 3.3s (post-Phase-7). The 4s saving is the Phase 7 contribution; the
-# remaining 3.3s is dom analysis + JIT compile + test body, unaffected by
-# this PR.
+# Sweep buildBytecodeCache wall-clock across N JUMPDESTs. Background and
+# numbers live in README.md alongside this script.
+# Prereq: cmake --build build --target evmCacheComplexityDemo
 
 set -euo pipefail
 

--- a/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/scaling_demo.sh
+++ b/docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/scaling_demo.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Demonstrate the cache-build wall clock as JUMPDEST count grows.
+# Generates synthetic contracts of the form
+#   CALLDATALOAD JUMP <N x JUMPDEST> STOP
+# (one dynamic jump, N JUMPDESTs — exercises the Phase 7 implicit-dyn-pred
+# stamping and the reachability stitch on every JUMPDEST.)
+#
+# Build the demo binary first:
+#   cmake --build build --target evmCacheComplexityDemo
+#
+# What Phase 7 changed: the per-JUMPDEST over-approximation step that used
+# to materialise D*J explicit edges is now O(N) (one count stamp per
+# JUMPDEST). The dominator and loop analyses that run AFTER buildCFGEdges
+# are unaffected by this PR and remain super-linear (~O(N*alpha(N)) for
+# the iterative dom dataflow). The wall clock you see below is the
+# WHOLE pipeline, so the residual super-linearity is the dom analysis,
+# not Phase 7.
+#
+# Reference point: `evmone-unittests` wall-clock for
+# `loop_full_of_jumpdests` (24556 JUMPDESTs, multipass mode) dropped from
+# 7.3s (pre-Phase-7, with explicit D*J edges + critical-edge split) to
+# 3.3s (post-Phase-7). The 4s saving is the Phase 7 contribution; the
+# remaining 3.3s is dom analysis + JIT compile + test body, unaffected by
+# this PR.
+
+set -euo pipefail
+
+DEMO=${EVMCACHE_DEMO:-build/evmCacheComplexityDemo}
+if [[ ! -x "$DEMO" ]]; then
+  echo "demo binary not found at $DEMO" >&2
+  echo "build it with: cmake --build build --target evmCacheComplexityDemo" >&2
+  exit 1
+fi
+
+echo "n_jumpdests,build_ms"
+for N in 100 500 1000 2000 5000 10000 20000; do
+  "$DEMO" "$N"
+done

--- a/docs/design/evm-gas-mechanism.md
+++ b/docs/design/evm-gas-mechanism.md
@@ -18,9 +18,11 @@ unchanged.
 
 Both execution engines read from a single
 `zen::evm::EVMBytecodeCache` (`src/evm/evm_cache.h`). The cache is
-built lazily on first access via `EVMModule::initBytecodeCache`
-(`src/runtime/evm_module.cpp:117-135`) and exposes four parallel
-arrays indexed by program counter (PC):
+built lazily on first access — `EVMModule::initBytecodeCache` is
+defined at `src/runtime/evm_module.cpp:133-136`; the SPP-gating site
+that flips `CacheNeedsSPP` lives at `src/runtime/evm_module.cpp:117`.
+The cache exposes five parallel arrays indexed by program counter
+(PC):
 
 | Field            | Indexed by | Meaning                                                                                 |
 | ---------------- | ---------- | --------------------------------------------------------------------------------------- |
@@ -30,12 +32,18 @@ arrays indexed by program counter (PC):
 | `GasChunkCost`   | chunk-start PC | **Unshifted** sum of opcode gas costs in the chunk (interpreter consumer).         |
 | `GasChunkCostSPP`| chunk-start PC | **SPP-shifted** chunk cost (JIT consumer). Empty when SPP is disabled for this module. |
 
-A "gas chunk" is a maximal straight-line region with no internal
-control-flow boundary that can change gas obligations: it ends at
-`JUMP`/`JUMPI`/`STOP`/`RETURN`/`REVERT`/`SELFDESTRUCT`/`INVALID`,
-just before a `JUMPDEST`, before `SSTORE`/`CALL`/`CREATE`/`GAS`
-(opcodes whose actual cost depends on runtime state), or at the end
-of the bytecode.
+A "gas chunk" is a maximal straight-line region whose static gas
+cost can be summed once at chunk construction. It ends at any
+**gas-chunk terminator** (`isGasChunkTerminator` at
+`src/evm/evm_cache.cpp:41-62`): the control-flow exits
+`STOP`/`RETURN`/`REVERT`/`SELFDESTRUCT`/`INVALID`/`JUMP`/`JUMPI` and
+the gas-sensitive opcodes
+`SSTORE`/`CALL`/`CALLCODE`/`DELEGATECALL`/`STATICCALL`/`CREATE`/
+`CREATE2`/`GAS`. The terminator is **inside** its chunk — its static
+cost is included in `GasChunkCost` (`evm_cache.cpp:329`) and a fresh
+chunk starts at the *next* PC (`evm_cache.cpp:291-296`). A chunk also
+ends just before a `JUMPDEST` (since `JUMPDEST` itself begins a new
+chunk) and at the end of the bytecode.
 
 ```mermaid
 flowchart LR
@@ -43,10 +51,10 @@ flowchart LR
     JD[JumpDestMap]
     PV[PushValueMap]
     CE[GasChunkEnd]
-    CC[GasChunkCost\n(unshifted)]
-    SPP[GasChunkCostSPP\n(shifted, optional)]
+    CC["GasChunkCost<br/>(unshifted)"]
+    SPP["GasChunkCostSPP<br/>(shifted, optional)"]
 
-    Bytecode --> Builder["buildBytecodeCache\n(src/evm/evm_cache.cpp)"]
+    Bytecode --> Builder["buildBytecodeCache<br/>(src/evm/evm_cache.cpp)"]
     Builder --> JD
     Builder --> PV
     Builder --> CE
@@ -58,7 +66,7 @@ flowchart LR
     CE --> Interpreter
     CC --> Interpreter
 
-    JD --> JIT["Multipass JIT\n(EVMMirBuilder)"]
+    JD --> JIT["Multipass JIT<br/>(EVMMirBuilder)"]
     PV --> JIT
     CE --> JIT
     CC --> JIT
@@ -81,20 +89,18 @@ path** first:
 
 ```mermaid
 flowchart TD
-    Start([outer iter\nPc = ChunkStartPc]) --> Q1{ChunkStartPc\nis a chunk start?\n(GasChunkEnd[Pc] > Pc)}
-    Q1 -- "no" --> Slow["Per-opcode dispatch\n(switch/handler call)\nchargeGas(opcode metric)"]
-    Slow --> SlowOOG{gas < cost?}
-    SlowOOG -- "yes" --> OOG[setStatus(EVMC_OUT_OF_GAS)\nbreak]
-    SlowOOG -- "no" --> Pcpp[Frame->Pc++]
+    Start(["outer iter<br/>Pc = ChunkStartPc"]) --> Cond{"GasChunkEnd[Pc] &gt; Pc<br/>AND<br/>gas &gt;= GasChunkCost[Pc]?"}
+    Cond -- "no (either side)" --> Slow["Per-opcode dispatch<br/>(switch/handler call,<br/>line 1610+)<br/>handler invokes chargeGas"]
+    Slow --> SlowOOG{"chargeGas:<br/>gas &lt; opcode cost?"}
+    SlowOOG -- "yes" --> OOG["setStatus(EVMC_OUT_OF_GAS)<br/>break"]
+    SlowOOG -- "no" --> Pcpp["Frame->Pc++"]
     Pcpp --> Start
 
-    Q1 -- "yes" --> Q2{Frame->Msg.gas\n>= GasChunkCost[Pc]?}
-    Q2 -- "no" --> OOG
-    Q2 -- "yes" --> Pre["Frame->Msg.gas -= GasChunkCost[Pc]\n(pre-charge entire chunk)"]
-    Pre --> CG["Computed-goto fast path\nuntil Pc >= ChunkEnd"]
-    CG --> Restart{control-flow\nopcode hit?}
+    Cond -- "yes" --> Pre["Frame->Msg.gas -= GasChunkCost[Pc]<br/>(pre-charge entire chunk)"]
+    Pre --> CG["Computed-goto fast path<br/>until Pc &gt;= ChunkEnd"]
+    CG --> Restart{"control-flow<br/>opcode hit?"}
     Restart -- "no" --> Start
-    Restart -- "yes (JUMP/JUMPI/...)\nupdate Pc, restart" --> Start
+    Restart -- "yes (JUMP/JUMPI/...)<br/>update Pc, restart" --> Start
 ```
 
 Key properties:
@@ -104,15 +110,21 @@ Key properties:
   computed-goto loop simply executes opcodes, advances `Pc`, and
   checks `Pc >= ChunkEnd` to exit
   (`DISPATCH_NEXT` macro at `src/evm/interpreter.cpp:525`).
-- For opcodes whose cost depends on runtime state (`SSTORE`, `CALL*`,
-  `CREATE*`, dynamic memory growth), a chunk boundary is forced
-  before them so their dynamic gas can be charged separately by the
-  per-handler `chargeGas` calls
-  (`src/evm/interpreter.cpp:33-50`).
+- Opcodes whose behaviour depends on `gas_left` at runtime
+  (`SSTORE`, `CALL*`, `CREATE*`, `GAS`) are gas-chunk terminators —
+  each is the **last** opcode of its chunk, so the chunk's static
+  pre-charge has been applied before the handler runs and any
+  dynamic delta the handler charges (via `chargeGas` at
+  `src/evm/interpreter.cpp:33-50`) is layered on top of an accurate
+  `gas_left` value.
+- Memory expansion is **not** a chunk boundary: opcodes that touch
+  memory (`MLOAD`, `MSTORE`, `MSTORE8`, `KECCAK256`, the various
+  `*COPY` opcodes, `RETURN`, `REVERT`, …) charge their dynamic
+  expansion delta inline by calling `expandMemoryAndChargeGas`
+  (`src/evm/opcode_handlers.cpp:261`) from within the handler.
 - The interpreter intentionally consumes the **unshifted** cost
-  (PR #371). Shifting costs across blocks would charge gas for an
-  opcode before that opcode runs, which is observable to users via
-  the `GAS` opcode mid-chunk and via `gas_left` reported by callbacks.
+  (PR #371). The cache must keep an unshifted column available
+  regardless of whether SPP runs.
 
 ## Multipass JIT mode
 
@@ -121,48 +133,59 @@ The JIT lowers EVM bytecode to dMIR via `EVMMirBuilder`
 is woven into MIR generation by two helpers:
 
 - `meterOpcode(Opcode, PC)` — emit the gas check for one opcode at
-  `PC` (`src/compiler/evm_frontend/evm_mir_compiler.cpp:528`).
+  `PC` (`src/compiler/evm_frontend/evm_mir_compiler.cpp:524`).
 - `meterOpcodeRange(StartPC, EndPCExclusive)` — emit the gas check
   for a contiguous PC range, used by the JUMPDEST run optimization
-  (`src/compiler/evm_frontend/evm_mir_compiler.cpp:548`).
+  (`src/compiler/evm_frontend/evm_mir_compiler.cpp:544`).
 
 Both ultimately call `meterGas(Cost)` to emit the actual dMIR
-sequence (`src/compiler/evm_frontend/evm_mir_compiler.cpp:607`):
+sequence (`src/compiler/evm_frontend/evm_mir_compiler.cpp:607`,
+short-circuits when `GasCost == 0` at line 608):
 
 ```mermaid
 flowchart TD
-    A["meterOpcode(Op, PC)"] --> B{GasMeteringEnabled?}
-    B -- "no" --> X([return])
-    B -- "yes" --> C{PC < GasChunkSize\n&& GasChunkEnd[PC] > PC?}
-    C -- "no (mid-chunk PC)" --> D["Cost = InstructionMetrics[Op].gas_cost\nmeterGas(Cost)"]
-    C -- "yes (chunk start)" --> E["Cost = GasChunkCostSPP[PC]\n  ?? GasChunkCost[PC]\nmeterGas(Cost)"]
-    D --> Emit
-    E --> Emit
+    A["meterOpcode(Op, PC)"] --> B{"GasMeteringEnabled?"}
+    B -- "no" --> X(["return (no MIR)"])
+    B -- "yes" --> Cache{"Chunk cache populated?<br/>(GasChunkEnd &amp;&amp; GasChunkCost<br/>&amp;&amp; PC &lt; GasChunkSize)"}
+    Cache -- "no (cache absent)" --> PerOp["Cost = InstructionMetrics[Op].gas_cost<br/>meterGas(Cost)"]
+    Cache -- "yes" --> ChunkStart{"GasChunkEnd[PC] &gt; PC?<br/>(this PC is a chunk start)"}
+    ChunkStart -- "no (mid-chunk PC)" --> Skip(["return (no MIR;<br/>chunk start already paid)"])
+    ChunkStart -- "yes" --> Sel["Cost = GasChunkCostSPP[PC]<br/>  ?? GasChunkCost[PC]<br/>meterGas(Cost)"]
+    PerOp --> Emit
+    Sel --> Emit
 
-    Emit["meterGas(Cost)\nemit dMIR:\n  CurrentGas = load gas\n  IsOutOfGas = (CurrentGas < Cost)\n  brif IsOutOfGas, OOGBlock, ContinueBlock\n  NewGas = CurrentGas - Cost\n  store NewGas"]
-    Emit --> Cont([fall through to opcode lowering])
+    Emit["meterGas(Cost) emits dMIR:<br/>  CurrentGas = load gas<br/>  IsOutOfGas = (CurrentGas &lt; Cost)<br/>  brif IsOutOfGas, OOGBlock, ContinueBlock<br/>  NewGas = CurrentGas - Cost<br/>  store NewGas"]
+    Emit --> Cont(["fall through to opcode lowering"])
 ```
 
 Two consequences:
 
 1. The JIT emits **at most one gas check per chunk** — the call at
    the chunk-start opcode covers every opcode up to (but not
-   including) the next chunk start. Calls inside the chunk see
-   `GasChunkEnd[PC] == 0` and short-circuit out of `meterOpcode`.
-   The `JUMPDEST` run suffix-sum precompute
-   (`JumpDestRunLastPC`/`JumpDestRunSkipCost`,
-   `evm_mir_compiler.cpp:548-572`) lets the dispatcher skip a whole
-   run of consecutive `JUMPDEST`s with one `meterGas` call.
+   including) the next chunk start. Calls at mid-chunk PCs see
+   `GasChunkEnd[PC] == 0` and return without emitting any MIR
+   (`evm_mir_compiler.cpp:529, 537`). The fast path at line 553-572
+   in `meterOpcodeRange` consumes a precomputed
+   `JumpDestRunLastPC`/`JumpDestRunSkipCost` table; the table itself
+   is populated when the JUMPDEST run jump-table is materialized
+   (`evm_mir_compiler.cpp:1297-1335`), so dispatching across a run
+   of consecutive `JUMPDEST`s costs one `meterGas` call.
 2. The OOG branch is shared across all gas checks in the function
    via `getOrCreateExceptionSetBB(ErrorCode::GasLimitExceeded)`,
    keeping the cold path out of the hot block layout
    (`evm_mir_compiler.cpp:626, 663`).
 
 When the build is configured with `ZEN_ENABLE_EVM_GAS_REGISTER`, the
-gas value lives in a virtual register instead of being reloaded from
-memory on every check; the synchronization to `EVMInstance` happens
-only at `CALL`/`CREATE`/return boundaries
-(`evm_mir_compiler.cpp:614-642`).
+gas value lives in a virtual register (`GasRegVar`,
+`evm_mir_compiler.cpp:614-642`) instead of being reloaded from
+memory on every `meterGas`. Synchronization back to `EVMInstance`
+happens at any host-call boundary that may read or update gas —
+not just `CALL*`/`CREATE*`/return, but also runtime helpers such as
+the balance/code/keccak/memory-load handlers (`syncGasToMemory`
+calls at `evm_mir_compiler.cpp:3556, 3623, 3638, 3652, 3745, 3776,
+3857, 3976, 4054, 4136`; `syncGasToMemoryFull` is invoked at module
+return / `RETURN` / `REVERT` / `STOP` /
+`SELFDESTRUCT` paths around lines 1246, 4167-4259).
 
 ## SPP cost shifting
 
@@ -182,6 +205,12 @@ After SPP (min successor = 5 charged at A):
                 /                \
        Block B' (0)           Block C' (2)
 ```
+
+(The diagram assumes B and C each have only A as predecessor and
+neither ends with a gas-chunk terminator — `lemma614Update` only
+shifts when those preconditions hold; see the
+`effectivePredCount == 1` and `isGasChunkTerminator` guards at
+`evm_cache.cpp:940, 944, 966`.)
 
 Per-path totals are preserved: A→B is `3+5 = 8` before and
 `8+0 = 8` after; A→C is `3+7 = 10` before and `8+2 = 10` after. The
@@ -287,13 +316,13 @@ unshifted array and remains correct.
 
 ## Failure mode summary
 
-| Trigger                                               | Where                                                              | Result                                       |
-| ----------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
-| Interpreter chunk-start, gas < `GasChunkCost[Pc]`     | `interpreter.cpp:397-398`                                          | Exit outer loop, `setStatus(EVMC_OUT_OF_GAS)` |
-| Interpreter slow path, gas < per-opcode cost          | `chargeGas` at `interpreter.cpp:33-50`                             | Same                                         |
-| JIT chunk-start `meterGas`, gas < `Cost`              | `meterGas` `IsOutOfGas` branch (`evm_mir_compiler.cpp:622-631`)    | Branch to shared `OutOfGasBB`                 |
-| JIT mid-chunk per-opcode `meterGas`, gas < `Cost`     | Same code path, just smaller `Cost`                                 | Same shared `OutOfGasBB`                      |
-| Dynamic-cost opcode (SSTORE/CALL*/CREATE*) underpaid  | Forced chunk boundary; charged by handler call                     | Returns OOG status to dispatcher              |
+| Trigger                                                       | Where                                                              | Result                                       |
+| ------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
+| Interpreter, gas insufficient for full chunk pre-charge       | Combined check at `interpreter.cpp:397-398`                        | Skip fast path; fall through to slow path    |
+| Interpreter slow path, gas < per-opcode cost                  | `chargeGas` at `interpreter.cpp:33-50`                             | `setStatus(EVMC_OUT_OF_GAS)`, exit outer loop |
+| JIT chunk-start `meterGas`, gas < `Cost`                      | `meterGas` `IsOutOfGas` branch (`evm_mir_compiler.cpp:622-631`)    | Branch to shared `OutOfGasBB`                 |
+| JIT mid-chunk per-opcode `meterGas`, gas < `Cost`             | Same code path, just smaller `Cost`                                 | Same shared `OutOfGasBB`                      |
+| Dynamic-cost opcode (`SSTORE`/`CALL*`/`CREATE*`) underpaid    | Forced chunk boundary; charged by handler call                     | Returns OOG status to dispatcher              |
 
 ## References
 

--- a/docs/design/evm-gas-mechanism.md
+++ b/docs/design/evm-gas-mechanism.md
@@ -1,0 +1,312 @@
+# EVM Gas Mechanism (Interpreter and JIT)
+
+This document describes how DTVM accounts for EVM gas in both the
+interpreter and the multipass JIT, and how the SPP (Structured
+Precharging Pass) shifts charges along the control-flow graph for the
+JIT consumer while keeping the interpreter's per-block totals
+unchanged.
+
+## Goals
+
+- Charge each EVM execution path the exact gas the spec requires.
+- Detect Out-Of-Gas (OOG) before any state change occurs.
+- Amortize the per-opcode "is there enough gas?" check across
+  straight-line code so the hot path reduces to one comparison per
+  basic block (interpreter) or per chunk start (JIT).
+
+## Shared data: the bytecode cache
+
+Both execution engines read from a single
+`zen::evm::EVMBytecodeCache` (`src/evm/evm_cache.h`). The cache is
+built lazily on first access via `EVMModule::initBytecodeCache`
+(`src/runtime/evm_module.cpp:117-135`) and exposes four parallel
+arrays indexed by program counter (PC):
+
+| Field            | Indexed by | Meaning                                                                                 |
+| ---------------- | ---------- | --------------------------------------------------------------------------------------- |
+| `JumpDestMap`    | PC         | 1 if a `JUMPDEST` opcode begins at this PC, else 0.                                     |
+| `PushValueMap`   | PC         | The 256-bit immediate decoded from a `PUSH*` at this PC (otherwise 0).                  |
+| `GasChunkEnd`    | chunk-start PC | Exclusive end PC of the gas chunk that starts here. Zero for non-chunk-start PCs.  |
+| `GasChunkCost`   | chunk-start PC | **Unshifted** sum of opcode gas costs in the chunk (interpreter consumer).         |
+| `GasChunkCostSPP`| chunk-start PC | **SPP-shifted** chunk cost (JIT consumer). Empty when SPP is disabled for this module. |
+
+A "gas chunk" is a maximal straight-line region with no internal
+control-flow boundary that can change gas obligations: it ends at
+`JUMP`/`JUMPI`/`STOP`/`RETURN`/`REVERT`/`SELFDESTRUCT`/`INVALID`,
+just before a `JUMPDEST`, before `SSTORE`/`CALL`/`CREATE`/`GAS`
+(opcodes whose actual cost depends on runtime state), or at the end
+of the bytecode.
+
+```mermaid
+flowchart LR
+    Bytecode["EVM bytecode"]
+    JD[JumpDestMap]
+    PV[PushValueMap]
+    CE[GasChunkEnd]
+    CC[GasChunkCost\n(unshifted)]
+    SPP[GasChunkCostSPP\n(shifted, optional)]
+
+    Bytecode --> Builder["buildBytecodeCache\n(src/evm/evm_cache.cpp)"]
+    Builder --> JD
+    Builder --> PV
+    Builder --> CE
+    Builder --> CC
+    Builder -. "EnableSPP=true" .-> SPP
+
+    JD --> Interpreter
+    PV --> Interpreter
+    CE --> Interpreter
+    CC --> Interpreter
+
+    JD --> JIT["Multipass JIT\n(EVMMirBuilder)"]
+    PV --> JIT
+    CE --> JIT
+    CC --> JIT
+    SPP --> JIT
+```
+
+The two consumers read disjoint chunk-cost arrays so neither
+perturbs the other. Concretely:
+
+- The interpreter reads only `GasChunkCost` (`src/evm/interpreter.cpp:382`).
+- The JIT prefers `GasChunkCostSPP` when non-null and falls back to
+  `GasChunkCost` otherwise (`src/compiler/evm_frontend/evm_mir_compiler.cpp:534, 578, 1315`).
+
+## Interpreter mode
+
+The interpreter runs the dispatch loop in
+`BaseInterpreter::interpret` (`src/evm/interpreter.cpp:362`). Each
+outer iteration starts at `Frame->Pc` and tries the **chunk fast
+path** first:
+
+```mermaid
+flowchart TD
+    Start([outer iter\nPc = ChunkStartPc]) --> Q1{ChunkStartPc\nis a chunk start?\n(GasChunkEnd[Pc] > Pc)}
+    Q1 -- "no" --> Slow["Per-opcode dispatch\n(switch/handler call)\nchargeGas(opcode metric)"]
+    Slow --> SlowOOG{gas < cost?}
+    SlowOOG -- "yes" --> OOG[setStatus(EVMC_OUT_OF_GAS)\nbreak]
+    SlowOOG -- "no" --> Pcpp[Frame->Pc++]
+    Pcpp --> Start
+
+    Q1 -- "yes" --> Q2{Frame->Msg.gas\n>= GasChunkCost[Pc]?}
+    Q2 -- "no" --> OOG
+    Q2 -- "yes" --> Pre["Frame->Msg.gas -= GasChunkCost[Pc]\n(pre-charge entire chunk)"]
+    Pre --> CG["Computed-goto fast path\nuntil Pc >= ChunkEnd"]
+    CG --> Restart{control-flow\nopcode hit?}
+    Restart -- "no" --> Start
+    Restart -- "yes (JUMP/JUMPI/...)\nupdate Pc, restart" --> Start
+```
+
+Key properties:
+
+- Inside a chunk, **no gas check happens per opcode** — the chunk's
+  total has already been deducted at the chunk start. The
+  computed-goto loop simply executes opcodes, advances `Pc`, and
+  checks `Pc >= ChunkEnd` to exit
+  (`DISPATCH_NEXT` macro at `src/evm/interpreter.cpp:525`).
+- For opcodes whose cost depends on runtime state (`SSTORE`, `CALL*`,
+  `CREATE*`, dynamic memory growth), a chunk boundary is forced
+  before them so their dynamic gas can be charged separately by the
+  per-handler `chargeGas` calls
+  (`src/evm/interpreter.cpp:33-50`).
+- The interpreter intentionally consumes the **unshifted** cost
+  (PR #371). Shifting costs across blocks would charge gas for an
+  opcode before that opcode runs, which is observable to users via
+  the `GAS` opcode mid-chunk and via `gas_left` reported by callbacks.
+
+## Multipass JIT mode
+
+The JIT lowers EVM bytecode to dMIR via `EVMMirBuilder`
+(`src/compiler/evm_frontend/evm_mir_compiler.{h,cpp}`). Gas accounting
+is woven into MIR generation by two helpers:
+
+- `meterOpcode(Opcode, PC)` — emit the gas check for one opcode at
+  `PC` (`src/compiler/evm_frontend/evm_mir_compiler.cpp:528`).
+- `meterOpcodeRange(StartPC, EndPCExclusive)` — emit the gas check
+  for a contiguous PC range, used by the JUMPDEST run optimization
+  (`src/compiler/evm_frontend/evm_mir_compiler.cpp:548`).
+
+Both ultimately call `meterGas(Cost)` to emit the actual dMIR
+sequence (`src/compiler/evm_frontend/evm_mir_compiler.cpp:607`):
+
+```mermaid
+flowchart TD
+    A["meterOpcode(Op, PC)"] --> B{GasMeteringEnabled?}
+    B -- "no" --> X([return])
+    B -- "yes" --> C{PC < GasChunkSize\n&& GasChunkEnd[PC] > PC?}
+    C -- "no (mid-chunk PC)" --> D["Cost = InstructionMetrics[Op].gas_cost\nmeterGas(Cost)"]
+    C -- "yes (chunk start)" --> E["Cost = GasChunkCostSPP[PC]\n  ?? GasChunkCost[PC]\nmeterGas(Cost)"]
+    D --> Emit
+    E --> Emit
+
+    Emit["meterGas(Cost)\nemit dMIR:\n  CurrentGas = load gas\n  IsOutOfGas = (CurrentGas < Cost)\n  brif IsOutOfGas, OOGBlock, ContinueBlock\n  NewGas = CurrentGas - Cost\n  store NewGas"]
+    Emit --> Cont([fall through to opcode lowering])
+```
+
+Two consequences:
+
+1. The JIT emits **at most one gas check per chunk** — the call at
+   the chunk-start opcode covers every opcode up to (but not
+   including) the next chunk start. Calls inside the chunk see
+   `GasChunkEnd[PC] == 0` and short-circuit out of `meterOpcode`.
+   The `JUMPDEST` run suffix-sum precompute
+   (`JumpDestRunLastPC`/`JumpDestRunSkipCost`,
+   `evm_mir_compiler.cpp:548-572`) lets the dispatcher skip a whole
+   run of consecutive `JUMPDEST`s with one `meterGas` call.
+2. The OOG branch is shared across all gas checks in the function
+   via `getOrCreateExceptionSetBB(ErrorCode::GasLimitExceeded)`,
+   keeping the cold path out of the hot block layout
+   (`evm_mir_compiler.cpp:626, 663`).
+
+When the build is configured with `ZEN_ENABLE_EVM_GAS_REGISTER`, the
+gas value lives in a virtual register instead of being reloaded from
+memory on every check; the synchronization to `EVMInstance` happens
+only at `CALL`/`CREATE`/return boundaries
+(`evm_mir_compiler.cpp:614-642`).
+
+## SPP cost shifting
+
+The Structured Precharging Pass — implemented as `lemma614Update` in
+`src/evm/evm_cache.cpp:919` — moves gas costs **backwards** along the
+CFG. For each non-cycle node, it charges the minimum successor cost
+upfront, so the consumer only pays the residual at runtime:
+
+```
+                 Block A (cost = 3)
+                /                \
+       Block B (5)            Block C (7)
+
+After SPP (min successor = 5 charged at A):
+
+                 Block A' (cost = 3 + 5 = 8)
+                /                \
+       Block B' (0)           Block C' (2)
+```
+
+Per-path totals are preserved: A→B is `3+5 = 8` before and
+`8+0 = 8` after; A→C is `3+7 = 10` before and `8+2 = 10` after. The
+benefit is that B's chunk now starts with cost zero, which lets
+`meterGas` short-circuit and emit no dMIR at all
+(`evm_mir_compiler.cpp:608`), and C's chunk only needs to charge the
+residual `2`. The JIT therefore emits fewer non-trivial gas checks
+on the hot path and shrinks the OOG fan-out.
+
+Soundness on cycles: the shift never crosses back-edges or
+gas-chunk terminators (`SSTORE`/`CALL*`/`CREATE*`/`GAS`), so dynamic
+gas is always charged at the correct point
+(`evm_cache.cpp:421-427, 919-960`).
+
+### Why a separate `GasChunkCostSPP` array
+
+The interpreter's chunk fast path was specified against the
+**unshifted** per-block cost in PR #371 and the cache must continue
+to honour that contract. To enable SPP for the JIT without
+disturbing the interpreter, the cache exposes two parallel arrays:
+
+- `GasChunkCost` — unshifted, written from `Blocks[Id].Cost`
+  (`evm_cache.cpp:1161`), consumed by the interpreter.
+- `GasChunkCostSPP` — shifted, written from the metering function
+  `Metering[Id]` (`evm_cache.cpp:1165`), consumed by the JIT.
+
+The shifted variant is sound for the JIT because SPP refuses to
+shift cost across **gas-sensitive terminators**: `GAS`, `CALL*`,
+`CREATE*` (`isGasSensitiveTerminator` and `isGasChunkTerminator`
+checks at `evm_cache.cpp:944, 966`). Each of these opcodes ends its
+own chunk, so by the time it executes the chunk's cost — shifted or
+not — has already been deducted at the chunk-start `meterGas`, and
+the value the opcode reads (e.g. `GAS`) reflects the spec-mandated
+remaining gas. Cost from the *successor* chunk never leaks back
+across the terminator.
+
+### Mixed-precision CFG
+
+The SPP pass needs a sound CFG to compute "minimum successor cost"
+correctly:
+
+```mermaid
+flowchart LR
+    subgraph Static[Static jump]
+      P1[PUSH dest_pc] --> J1[JUMP]
+      J1 -. resolved .-> D1[JUMPDEST at dest_pc]
+    end
+
+    subgraph Dynamic[Dynamic jump]
+      X[stack-derived target] --> J2[JUMP]
+      J2 -. over-approx .-> D2[every JUMPDEST]
+    end
+```
+
+- `PUSH n; JUMP` resolves to a single edge to `JUMPDEST` at PC `n`
+  (`resolveConstantJumpTarget` in `evm_cache.cpp`).
+- Every other dynamic `JUMP` gets edges to **all** `JUMPDEST`
+  blocks (`buildCFGEdges`, `evm_cache.cpp:386-429`).
+
+Narrowing dynamic-jump edges using partial call-site information
+would under-approximate the CFG and let SPP shift charges along
+runtime-impossible edges, which breaks the per-path total invariant.
+The over-approximation is intentional and documented inline
+(`evm_cache.cpp:419-427`).
+
+## Pipeline gating
+
+The SPP CFG construction and shifting pass is significant compile-
+time work and is only useful for the JIT consumer. Interpreter-only
+modules skip it via `EVMModule::CacheNeedsSPP`:
+
+```mermaid
+sequenceDiagram
+    participant Loader as EVMModule::create
+    participant Mod as EVMModule
+    participant Cache as EVMBytecodeCache
+    participant JIT as performEVMJITCompile
+
+    Loader->>Mod: construct (CacheNeedsSPP=false)
+    alt RunMode != InterpMode
+        Loader->>Mod: EVMAnalyzer.analyze()
+        alt JIT-suitable
+            Loader->>Mod: CacheNeedsSPP = true
+            Loader->>JIT: performEVMJITCompile(Mod)
+            JIT->>Cache: getBytecodeCache()
+            Cache->>Cache: buildBytecodeCache(EnableSPP=true)
+            Note right of Cache: builds CFG, runs SPP,<br/>fills GasChunkCostSPP
+            Cache-->>JIT: cache (with SPP)
+        end
+    end
+
+    Note over Loader,Cache: First call to interpreter only:
+    Loader->>Cache: getBytecodeCache()
+    Cache->>Cache: buildBytecodeCache(EnableSPP=false)
+    Note right of Cache: skips CFG/SPP,<br/>GasChunkCostSPP stays empty
+```
+
+`evm_compiler.cpp` passes `nullptr` for the SPP pointer when the
+array is empty
+(`src/compiler/evm_compiler.cpp:70-74`), so a JIT compilation that
+runs without SPP (e.g. JIT bypass paths) cleanly falls back to the
+unshifted array and remains correct.
+
+## Failure mode summary
+
+| Trigger                                               | Where                                                              | Result                                       |
+| ----------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
+| Interpreter chunk-start, gas < `GasChunkCost[Pc]`     | `interpreter.cpp:397-398`                                          | Exit outer loop, `setStatus(EVMC_OUT_OF_GAS)` |
+| Interpreter slow path, gas < per-opcode cost          | `chargeGas` at `interpreter.cpp:33-50`                             | Same                                         |
+| JIT chunk-start `meterGas`, gas < `Cost`              | `meterGas` `IsOutOfGas` branch (`evm_mir_compiler.cpp:622-631`)    | Branch to shared `OutOfGasBB`                 |
+| JIT mid-chunk per-opcode `meterGas`, gas < `Cost`     | Same code path, just smaller `Cost`                                 | Same shared `OutOfGasBB`                      |
+| Dynamic-cost opcode (SSTORE/CALL*/CREATE*) underpaid  | Forced chunk boundary; charged by handler call                     | Returns OOG status to dispatcher              |
+
+## References
+
+- `src/evm/evm_cache.{h,cpp}` — bytecode cache, CFG construction,
+  `buildGasChunksSPP`, `lemma614Update`.
+- `src/evm/interpreter.cpp` — chunk fast path (line 395), per-opcode
+  `chargeGas` (line 33).
+- `src/compiler/evm_frontend/evm_mir_compiler.{h,cpp}` —
+  `meterOpcode`, `meterOpcodeRange`, `meterGas`.
+- `src/runtime/evm_module.{h,cpp}` — `CacheNeedsSPP` gating before
+  `performEVMJITCompile`.
+- `src/compiler/evm_compiler.cpp:70-74` — JIT-side `nullptr` fallback
+  for empty `GasChunkCostSPP`.
+- `docs/changes/2026-04-05-gas-check-placement/README.md` — design
+  notes and benchmark results for the mixed-CFG / dual-array split.
+- `docs/modules/evm/spec.md` — module spec for the EVM bytecode cache.

--- a/src/compiler/evm_compiler.cpp
+++ b/src/compiler/evm_compiler.cpp
@@ -69,8 +69,13 @@ void EagerEVMJITCompiler::compile() {
   Ctx.setMemoryLinearStrideSkipLeadingZeroLimbStores(
       EVMMod->getMemoryLinearStrideSkipLeadingZeroLimbStores());
   const auto &Cache = EVMMod->getBytecodeCache();
+  // GasChunkCostSPP is only allocated when the SPP metering pipeline runs
+  // (i.e. this module will be JIT-compiled). Pass nullptr when the array is
+  // empty so the JIT falls back to the unshifted GasChunkCost automatically.
+  const uint64_t *CostSPPPtr =
+      Cache.GasChunkCostSPP.empty() ? nullptr : Cache.GasChunkCostSPP.data();
   Ctx.setGasChunkInfo(Cache.GasChunkEnd.data(), Cache.GasChunkCost.data(),
-                      Cache.GasChunkCostSPP.data(), EVMMod->CodeSize);
+                      CostSPPPtr, EVMMod->CodeSize);
 
   MModule Mod(Ctx);
   buildEVMFunction(Ctx, Mod, *EVMMod);

--- a/src/compiler/evm_compiler.cpp
+++ b/src/compiler/evm_compiler.cpp
@@ -70,7 +70,7 @@ void EagerEVMJITCompiler::compile() {
       EVMMod->getMemoryLinearStrideSkipLeadingZeroLimbStores());
   const auto &Cache = EVMMod->getBytecodeCache();
   Ctx.setGasChunkInfo(Cache.GasChunkEnd.data(), Cache.GasChunkCost.data(),
-                      EVMMod->CodeSize);
+                      Cache.GasChunkCostSPP.data(), EVMMod->CodeSize);
 
   MModule Mod(Ctx);
   buildEVMFunction(Ctx, Mod, *EVMMod);

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -78,6 +78,7 @@ EVMFrontendContext::EVMFrontendContext(const EVMFrontendContext &OtherCtx)
       BytecodeSize(OtherCtx.BytecodeSize),
       GasMeteringEnabled(OtherCtx.GasMeteringEnabled),
       GasChunkEnd(OtherCtx.GasChunkEnd), GasChunkCost(OtherCtx.GasChunkCost),
+      GasChunkCostSPP(OtherCtx.GasChunkCostSPP),
       GasChunkSize(OtherCtx.GasChunkSize), Revision(OtherCtx.Revision),
       MemoryLinearStrideSkipLeadingZeroLimbStores(
           OtherCtx.MemoryLinearStrideSkipLeadingZeroLimbStores)
@@ -393,6 +394,7 @@ void EVMMirBuilder::initEVM(CompilerContext *Context) {
 
   GasChunkEnd = EvmCtx->getGasChunkEnd();
   GasChunkCost = EvmCtx->getGasChunkCost();
+  GasChunkCostSPP = EvmCtx->getGasChunkCostSPP();
   GasChunkSize = EvmCtx->getGasChunkSize();
 
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
@@ -527,7 +529,12 @@ void EVMMirBuilder::meterOpcode(evmc_opcode Opcode, uint64_t PC) {
   }
   if (GasChunkEnd && GasChunkCost && PC < GasChunkSize) {
     if (GasChunkEnd[PC] > PC) {
-      meterGas(GasChunkCost[PC]);
+      // Prefer SPP-shifted cost when available — it preserves per-path totals
+      // while reducing the number of non-zero entries the JIT must emit a
+      // gas check for.
+      const uint64_t Cost =
+          GasChunkCostSPP ? GasChunkCostSPP[PC] : GasChunkCost[PC];
+      meterGas(Cost);
     }
     return;
   }
@@ -570,7 +577,7 @@ void EVMMirBuilder::meterOpcodeRange(uint64_t StartPC,
     uint64_t Cost = 0;
     if (GasChunkEnd && GasChunkCost && PC < GasChunkSize &&
         GasChunkEnd[PC] > PC) {
-      Cost = GasChunkCost[PC];
+      Cost = GasChunkCostSPP ? GasChunkCostSPP[PC] : GasChunkCost[PC];
     } else {
       const uint8_t Opcode = static_cast<uint8_t>(Bytecode[PC]);
       Cost = static_cast<uint64_t>(InstructionMetrics[Opcode].gas_cost);
@@ -1307,7 +1314,7 @@ void EVMMirBuilder::createJumpTable() {
             uint64_t Cost = 0;
             if (GasChunkEnd && GasChunkCost && Pc < GasChunkSize &&
                 GasChunkEnd[Pc] > Pc) {
-              Cost = GasChunkCost[Pc];
+              Cost = GasChunkCostSPP ? GasChunkCostSPP[Pc] : GasChunkCost[Pc];
             } else {
               // All bytes in the run are JUMPDEST opcode bytes (PUSH payload is
               // skipped in the scan above), so the fallback is a constant.

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -66,13 +66,15 @@ public:
   bool isGasMeteringEnabled() const { return GasMeteringEnabled; }
 
   void setGasChunkInfo(const uint32_t *ChunkEnd, const uint64_t *ChunkCost,
-                       size_t Size) {
+                       const uint64_t *ChunkCostSPP, size_t Size) {
     GasChunkEnd = ChunkEnd;
     GasChunkCost = ChunkCost;
+    GasChunkCostSPP = ChunkCostSPP;
     GasChunkSize = Size;
   }
   const uint32_t *getGasChunkEnd() const { return GasChunkEnd; }
   const uint64_t *getGasChunkCost() const { return GasChunkCost; }
+  const uint64_t *getGasChunkCostSPP() const { return GasChunkCostSPP; }
   size_t getGasChunkSize() const { return GasChunkSize; }
   bool hasGasChunks() const {
     return GasChunkEnd && GasChunkCost && GasChunkSize > 0;
@@ -98,6 +100,7 @@ private:
   bool GasMeteringEnabled = false;
   const uint32_t *GasChunkEnd = nullptr;
   const uint64_t *GasChunkCost = nullptr;
+  const uint64_t *GasChunkCostSPP = nullptr;
   size_t GasChunkSize = 0;
   evmc_revision Revision = zen::evm::DEFAULT_REVISION;
   uint8_t MemoryLinearStrideSkipLeadingZeroLimbStores = 0;
@@ -1275,6 +1278,7 @@ private:
   // Chunk gas metering
   const uint32_t *GasChunkEnd = nullptr;
   const uint64_t *GasChunkCost = nullptr;
+  const uint64_t *GasChunkCostSPP = nullptr;
   size_t GasChunkSize = 0;
 
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER

--- a/src/evm/evm_cache.cpp
+++ b/src/evm/evm_cache.cpp
@@ -192,10 +192,8 @@ struct GasBlock {
   uint32_t End = 0;
   uint32_t LastPc = 0;
   uint32_t PrevPc = UINT32_MAX;
-  uint32_t Prev2Pc = UINT32_MAX;
   uint8_t LastOpcode = 0;
   uint8_t PrevOpcode = 0;
-  uint8_t Prev2Opcode = 0;
   uint64_t Cost = 0;
   std::vector<uint32_t> Succs;
   std::vector<uint32_t> Preds;
@@ -320,8 +318,6 @@ static void buildGasBlocks(const zen::common::Byte *Code, size_t CodeSize,
       }
 
       const uint8_t CurOpcodeU8 = static_cast<uint8_t>(Code[CurPc]);
-      Block.Prev2Pc = Block.PrevPc;
-      Block.Prev2Opcode = Block.PrevOpcode;
       Block.PrevPc = Block.LastPc;
       Block.PrevOpcode = Block.LastOpcode;
       Block.LastPc = static_cast<uint32_t>(CurPc);
@@ -386,6 +382,11 @@ static bool resolveConstantJumpTarget(const std::vector<uint8_t> &JumpDestMap,
 // Build CFG edges for all blocks. Static jumps (PUSH → JUMP) get precise
 // single-target edges; all other dynamic jumps get over-approximated edges
 // to every JUMPDEST to keep the CFG sound for SPP metering.
+//
+// After this pass, JUMPDEST blocks may have many predecessors. That is the
+// intentional partner to lemma614Update's effectivePredCount > 1 guard,
+// which refuses to shift gas across edges with multiple predecessors and
+// so absorbs the over-approximation soundly.
 static void buildCFGEdges(std::vector<GasBlock> &Blocks,
                           const std::vector<uint32_t> &BlockAtPc,
                           const std::vector<uint8_t> &JumpDestMap,

--- a/src/evm/evm_cache.cpp
+++ b/src/evm/evm_cache.cpp
@@ -197,6 +197,11 @@ struct GasBlock {
   uint64_t Cost = 0;
   std::vector<uint32_t> Succs;
   std::vector<uint32_t> Preds;
+  // Count of dynamic-jump blocks in this contract that could land here at
+  // runtime. Only nonzero for JUMPDEST blocks when the contract has at
+  // least one unresolved dynamic jump. Carried separately so we avoid
+  // materialising D*J explicit over-approximation edges (see buildCFGEdges).
+  uint32_t ImplicitDynamicPredCount = 0;
 };
 
 static void addEdge(std::vector<GasBlock> &Blocks, uint32_t From, uint32_t To) {
@@ -380,19 +385,40 @@ static bool resolveConstantJumpTarget(const std::vector<uint8_t> &JumpDestMap,
 }
 
 // Build CFG edges for all blocks. Static jumps (PUSH → JUMP) get precise
-// single-target edges; all other dynamic jumps get over-approximated edges
-// to every JUMPDEST to keep the CFG sound for SPP metering.
-//
-// After this pass, JUMPDEST blocks may have many predecessors. That is the
-// intentional partner to lemma614Update's effectivePredCount > 1 guard,
-// which refuses to shift gas across edges with multiple predecessors and
-// so absorbs the over-approximation soundly.
+// single-target edges. For each unresolved dynamic jump we DO NOT add the
+// D*|JUMPDEST| explicit over-approximation edges (which previously made the
+// pass quadratic-to-cubic in pathological contracts). Instead we record on
+// every JUMPDEST how many dynamic-jump blocks could land there at runtime
+// via `ImplicitDynamicPredCount`, and `effectivePredCount` folds that count
+// into its multi-predecessor check. SPP decisions are identical: a JUMPDEST
+// that is a potential dynamic-jump target sees `effectivePredCount > 1` and
+// `lemma614Update` refuses to shift gas across that edge, exactly as it
+// would have done against an explicit over-approximated `Preds` set.
 static void buildCFGEdges(std::vector<GasBlock> &Blocks,
                           const std::vector<uint32_t> &BlockAtPc,
                           const std::vector<uint8_t> &JumpDestMap,
                           const std::vector<intx::uint256> &PushValueMap,
                           const std::vector<uint32_t> &JumpDestBlocks,
                           size_t CodeSize) {
+  // Count unresolved dynamic jumps once so we can stamp every JUMPDEST with
+  // the right implicit-predecessor count in O(N) instead of O(D*J).
+  uint32_t DynamicJumpCount = 0;
+  for (const auto &Block : Blocks) {
+    if (!isJumpOpcode(Block.LastOpcode)) {
+      continue;
+    }
+    uint32_t DestPc = 0;
+    if (!resolveConstantJumpTarget(JumpDestMap, PushValueMap, CodeSize, Block,
+                                   DestPc)) {
+      ++DynamicJumpCount;
+    }
+  }
+  if (DynamicJumpCount > 0) {
+    for (uint32_t JdId : JumpDestBlocks) {
+      Blocks[JdId].ImplicitDynamicPredCount = DynamicJumpCount;
+    }
+  }
+
   for (size_t BlockId = 0; BlockId < Blocks.size(); ++BlockId) {
     auto &Block = Blocks[BlockId];
     const bool IsTerminator = isControlFlowTerminator(Block.LastOpcode);
@@ -416,15 +442,9 @@ static void buildCFGEdges(std::vector<GasBlock> &Blocks,
         if (SuccId != UINT32_MAX) {
           addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
         }
-      } else {
-        // Dynamic jump: over-approximate to all jump destinations.
-        // This keeps the CFG sound — under-approximation would let
-        // lemma614Update shift gas along edges that don't exist at
-        // runtime, causing unsafe metering on missed paths.
-        for (uint32_t SuccId : JumpDestBlocks) {
-          addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
-        }
       }
+      // Dynamic jump: handled by the implicit-predecessor count stamped onto
+      // every JUMPDEST above. No explicit Succs/Preds edges added.
     }
   }
 }
@@ -909,11 +929,18 @@ static bool buildLoopsUsingDominance(
 
 // Effective predecessor count: the entry block (Start == 0) is always reachable
 // from the program start, adding an implicit path not represented in the CFG.
+//
+// Blocks with `ImplicitDynamicPredCount > 0` (every JUMPDEST in a contract
+// that has at least one dynamic jump) carry the over-approximated dynamic
+// predecessors as a count instead of explicit edges; folding them in here
+// keeps `lemma614Update`'s "shift only into single-pred successors" check
+// equivalent to the explicit over-approximation.
 static size_t effectivePredCount(const GasBlock &Block) {
   size_t Count = Block.Preds.size();
   if (Block.Start == 0) {
     ++Count;
   }
+  Count += Block.ImplicitDynamicPredCount;
   return Count;
 }
 
@@ -1036,7 +1063,33 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
   // Split critical edges (required for safe SPP optimization)
   splitCriticalEdges(Blocks, CodeSize);
 
-  const std::vector<uint8_t> Reachable = computeReachable(Blocks, 0);
+  std::vector<uint8_t> Reachable = computeReachable(Blocks, 0);
+  // In the implicit-dyn-pred representation, JUMPDESTs reached only via a
+  // dynamic JUMP have no explicit predecessor edge from any block reachable
+  // via static control flow, so the static-only walk above misses them.
+  // Seed them as roots and propagate forward via Succs so the dominator
+  // and loop analyses still treat them (and their static successors) as
+  // live nodes — without this, SPP would skip cost shifting through every
+  // dyn-only function-return / dispatcher-target chunk.
+  {
+    std::vector<uint32_t> Stack;
+    for (uint32_t JdId : JumpDestBlocks) {
+      if (Reachable[JdId] == 0) {
+        Reachable[JdId] = 1;
+        Stack.push_back(JdId);
+      }
+    }
+    while (!Stack.empty()) {
+      const uint32_t Node = Stack.back();
+      Stack.pop_back();
+      for (uint32_t Succ : Blocks[Node].Succs) {
+        if (Reachable[Succ] == 0) {
+          Reachable[Succ] = 1;
+          Stack.push_back(Succ);
+        }
+      }
+    }
+  }
   const std::vector<std::vector<uint64_t>> Dom =
       computeDominators(Blocks, Reachable);
 

--- a/src/evm/evm_cache.cpp
+++ b/src/evm/evm_cache.cpp
@@ -192,8 +192,10 @@ struct GasBlock {
   uint32_t End = 0;
   uint32_t LastPc = 0;
   uint32_t PrevPc = UINT32_MAX;
+  uint32_t Prev2Pc = UINT32_MAX;
   uint8_t LastOpcode = 0;
   uint8_t PrevOpcode = 0;
+  uint8_t Prev2Opcode = 0;
   uint64_t Cost = 0;
   std::vector<uint32_t> Succs;
   std::vector<uint32_t> Preds;
@@ -318,6 +320,8 @@ static void buildGasBlocks(const zen::common::Byte *Code, size_t CodeSize,
       }
 
       const uint8_t CurOpcodeU8 = static_cast<uint8_t>(Code[CurPc]);
+      Block.Prev2Pc = Block.PrevPc;
+      Block.Prev2Opcode = Block.PrevOpcode;
       Block.PrevPc = Block.LastPc;
       Block.PrevOpcode = Block.LastOpcode;
       Block.LastPc = static_cast<uint32_t>(CurPc);
@@ -338,6 +342,27 @@ static void buildGasBlocks(const zen::common::Byte *Code, size_t CodeSize,
   }
 }
 
+// Decode a PUSH immediate at PushPc and validate it as a JUMPDEST address.
+// Returns true and sets DestPc on success.
+static bool decodePushAsJumpDest(const std::vector<intx::uint256> &PushValueMap,
+                                 const std::vector<uint8_t> &JumpDestMap,
+                                 size_t CodeSize, uint32_t PushPc,
+                                 uint32_t &DestPc) {
+  const intx::uint256 Value = PushValueMap[PushPc];
+  if ((Value >> 64) != 0) {
+    return false;
+  }
+  const uint64_t Dest = static_cast<uint64_t>(Value);
+  if (Dest >= CodeSize) {
+    return false;
+  }
+  if (JumpDestMap[Dest] == 0) {
+    return false;
+  }
+  DestPc = static_cast<uint32_t>(Dest);
+  return true;
+}
+
 static bool resolveConstantJumpTarget(const std::vector<uint8_t> &JumpDestMap,
                                       const std::vector<intx::uint256> &PushMap,
                                       size_t CodeSize, const GasBlock &Block,
@@ -354,22 +379,69 @@ static bool resolveConstantJumpTarget(const std::vector<uint8_t> &JumpDestMap,
     return false;
   }
 
-  const intx::uint256 Value = PushMap[Block.PrevPc];
-  if ((Value >> 64) != 0) {
-    return false;
-  }
+  return decodePushAsJumpDest(PushMap, JumpDestMap, CodeSize, Block.PrevPc,
+                              DestPc);
+}
 
-  const uint64_t Dest = static_cast<uint64_t>(Value);
-  if (Dest >= CodeSize) {
-    return false;
-  }
+// Build CFG edges for all blocks.
+// When ResolvedTargets is null, uses over-approximation (all JUMPDESTs) for
+// unresolved dynamic jumps. When non-null, uses resolved targets for known
+// SWAPn→JUMP return patterns and falls back to over-approximation for the rest.
+static void
+buildCFGEdges(std::vector<GasBlock> &Blocks,
+              const std::vector<uint32_t> &BlockAtPc,
+              const std::vector<uint8_t> &JumpDestMap,
+              const std::vector<intx::uint256> &PushValueMap,
+              const std::vector<uint32_t> &JumpDestBlocks, size_t CodeSize,
+              const std::unordered_map<uint32_t, std::vector<uint32_t>>
+                  *ResolvedTargets) {
+  for (size_t BlockId = 0; BlockId < Blocks.size(); ++BlockId) {
+    auto &Block = Blocks[BlockId];
+    const bool IsTerminator = isControlFlowTerminator(Block.LastOpcode);
 
-  if (JumpDestMap[Dest] == 0) {
-    return false;
-  }
+    // Add fallthrough edge for non-terminating opcodes (CALL/CREATE/GAS,
+    // JUMPI included via the generic !IsTerminator path).
+    if (!IsTerminator && Block.End < CodeSize) {
+      const uint32_t SuccId = BlockAtPc[Block.End];
+      if (SuccId != UINT32_MAX) {
+        addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
+      }
+    }
 
-  DestPc = static_cast<uint32_t>(Dest);
-  return true;
+    // Add jump target edge(s).
+    if (isJumpOpcode(Block.LastOpcode)) {
+      uint32_t DestPc = 0;
+      if (resolveConstantJumpTarget(JumpDestMap, PushValueMap, CodeSize, Block,
+                                    DestPc)) {
+        // Static (constant) jump: single known target.
+        const uint32_t SuccId = BlockAtPc[DestPc];
+        if (SuccId != UINT32_MAX) {
+          addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
+        }
+      } else if (ResolvedTargets != nullptr) {
+        // Second-pass: use call-site resolved targets if available.
+        auto It = ResolvedTargets->find(Block.LastPc);
+        if (It != ResolvedTargets->end()) {
+          for (uint32_t TargetPc : It->second) {
+            const uint32_t SuccId = BlockAtPc[TargetPc];
+            if (SuccId != UINT32_MAX) {
+              addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
+            }
+          }
+        } else {
+          // Still unresolved: over-approx to all jump destinations.
+          for (uint32_t SuccId : JumpDestBlocks) {
+            addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
+          }
+        }
+      } else {
+        // First-pass (no resolved targets yet): over-approx.
+        for (uint32_t SuccId : JumpDestBlocks) {
+          addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
+        }
+      }
+    }
+  }
 }
 
 static size_t bitsetWordCount(size_t NumBits) { return (NumBits + 63) / 64; }
@@ -876,10 +948,17 @@ static bool lemma614Update(uint32_t NodeId, const std::vector<GasBlock> &Blocks,
       continue;
     }
     if (AllowedMask && !bitsetTest(*AllowedMask, Succ)) {
+      // Non-back-edge successor excluded from shifting — its path would
+      // see the inflated parent cost without compensation.
+      MinSucc = 0;
       continue;
     }
-    // Only consider successors with exactly one effective predecessor.
     if (effectivePredCount(Blocks[Succ]) != 1) {
+      MinSucc = 0;
+      continue;
+    }
+    if (isGasChunkTerminator(Blocks[Succ].LastOpcode)) {
+      MinSucc = 0;
       continue;
     }
     MinSucc = std::min(MinSucc, Metering[Succ]);
@@ -900,10 +979,165 @@ static bool lemma614Update(uint32_t NodeId, const std::vector<GasBlock> &Blocks,
     if (effectivePredCount(Blocks[Succ]) != 1) {
       continue;
     }
+    if (isGasChunkTerminator(Blocks[Succ].LastOpcode)) {
+      continue;
+    }
     Metering[Succ] -= MinSucc;
   }
 
   return true;
+}
+
+static constexpr size_t MAX_REVERSE_REACHABILITY_DEPTH = 200;
+
+// Check if opcode is a SWAP instruction (SWAP1-SWAP16).
+static bool isSwapOpcode(uint8_t OpcodeU8) {
+  return OpcodeU8 >= static_cast<uint8_t>(evmc_opcode::OP_SWAP1) &&
+         OpcodeU8 <= static_cast<uint8_t>(evmc_opcode::OP_SWAP16);
+}
+
+// Resolve jump targets for function-return patterns (SWAPn → JUMP) using
+// call-site enumeration. For each unresolved JUMP preceded by SWAPn, find
+// the containing function's entry JUMPDEST via reverse reachability, then
+// collect return addresses from all call sites targeting that entry.
+//
+// Call site pattern: PUSH <ret_addr> → PUSH <func_entry> → JUMP
+// Return pattern: SWAPn → JUMP (return address was pushed by caller)
+static void resolveCallSiteTargets(
+    const std::vector<GasBlock> &Blocks, const std::vector<uint32_t> &BlockAtPc,
+    const std::vector<uint8_t> &JumpDestMap,
+    const std::vector<intx::uint256> &PushValueMap, size_t CodeSize,
+    std::unordered_map<uint32_t, std::vector<uint32_t>> &ResolvedTargets) {
+
+  // Step 1: Identify call sites (PUSH ret → PUSH func → JUMP).
+  // Map from function entry PC → list of return address PCs.
+  std::unordered_map<uint32_t, std::vector<uint32_t>> CallTargets;
+  for (const auto &Block : Blocks) {
+    if (Block.LastOpcode != static_cast<uint8_t>(evmc_opcode::OP_JUMP)) {
+      continue;
+    }
+    // Need at least 3 instructions: PUSH ret, PUSH func, JUMP
+    // Check: PrevOpcode is PUSH (func entry), and the instruction before
+    // PrevPc is also a PUSH (return addr).
+    if (!isPushOpcode(Block.PrevOpcode) || Block.PrevPc == UINT32_MAX) {
+      continue;
+    }
+
+    const uint32_t Prev2Pc = Block.Prev2Pc;
+    const uint8_t Prev2Opcode = Block.Prev2Opcode;
+
+    if (!isPushOpcode(Prev2Opcode) || Prev2Pc == UINT32_MAX) {
+      continue;
+    }
+
+    // Verify contiguous instruction sequence: PUSH ret → PUSH func → JUMP
+    if (Prev2Pc + opcodeLen(Prev2Opcode) != Block.PrevPc) {
+      continue;
+    }
+    if (Block.PrevPc + opcodeLen(Block.PrevOpcode) != Block.LastPc) {
+      continue;
+    }
+
+    // Decode function entry and return address
+    uint32_t FuncEntry = 0;
+    if (!decodePushAsJumpDest(PushValueMap, JumpDestMap, CodeSize, Block.PrevPc,
+                              FuncEntry)) {
+      continue;
+    }
+
+    uint32_t RetAddr = 0;
+    if (!decodePushAsJumpDest(PushValueMap, JumpDestMap, CodeSize, Prev2Pc,
+                              RetAddr)) {
+      continue;
+    }
+
+    CallTargets[FuncEntry].push_back(RetAddr);
+  }
+
+  if (CallTargets.empty()) {
+    return;
+  }
+
+  // Step 2: For each SWAPn → JUMP block, find function entry via reverse
+  // reachability, then resolve targets from call sites.
+  std::vector<uint8_t> VisitedGen(Blocks.size(), 0);
+  uint8_t Generation = 0;
+  for (size_t BlockId = 0; BlockId < Blocks.size(); ++BlockId) {
+    const auto &Block = Blocks[BlockId];
+    if (Block.LastOpcode != static_cast<uint8_t>(evmc_opcode::OP_JUMP)) {
+      continue;
+    }
+    // Skip already-resolved (PUSH → JUMP)
+    if (isPushOpcode(Block.PrevOpcode)) {
+      continue;
+    }
+    // Must be SWAPn → JUMP
+    if (!isSwapOpcode(Block.PrevOpcode)) {
+      continue;
+    }
+
+    ++Generation;
+    if (Generation == 0) { // overflow: reset
+      std::fill(VisitedGen.begin(), VisitedGen.end(), 0);
+      Generation = 1;
+    }
+
+    // Reverse reachability: walk backward from this block to find a
+    // JUMPDEST that is a known call target.
+    uint32_t FuncEntry = UINT32_MAX;
+    {
+      std::vector<uint32_t> Worklist;
+      Worklist.push_back(static_cast<uint32_t>(BlockId));
+      size_t Limit = MAX_REVERSE_REACHABILITY_DEPTH;
+      while (!Worklist.empty() && Limit-- > 0) {
+        uint32_t Bid = Worklist.back();
+        Worklist.pop_back();
+        if (VisitedGen[Bid] == Generation) {
+          continue;
+        }
+        VisitedGen[Bid] = Generation;
+        // Check if this block starts at a call-target JUMPDEST
+        if (Blocks[Bid].Start < CodeSize &&
+            JumpDestMap[Blocks[Bid].Start] != 0 &&
+            CallTargets.count(Blocks[Bid].Start) != 0) {
+          FuncEntry = Blocks[Bid].Start;
+          break;
+        }
+        for (uint32_t Pid : Blocks[Bid].Preds) {
+          if (VisitedGen[Pid] != Generation) {
+            Worklist.push_back(Pid);
+          }
+        }
+      }
+    }
+
+    if (FuncEntry == UINT32_MAX) {
+      continue;
+    }
+
+    // Collect return addresses from all call sites targeting this function.
+    const auto &RetAddrs = CallTargets[FuncEntry];
+    std::vector<uint32_t> ValidTargets;
+    for (uint32_t Ra : RetAddrs) {
+      if (Ra < CodeSize && JumpDestMap[Ra] != 0) {
+        const uint32_t TargetBlock = BlockAtPc[Ra];
+        if (TargetBlock != UINT32_MAX) {
+          ValidTargets.push_back(Ra);
+        }
+      }
+    }
+
+    // Deduplicate targets — a function called multiple times from the same
+    // return address would produce duplicates, blocking the size()==1
+    // direct-branch optimization.
+    std::sort(ValidTargets.begin(), ValidTargets.end());
+    ValidTargets.erase(std::unique(ValidTargets.begin(), ValidTargets.end()),
+                       ValidTargets.end());
+
+    if (!ValidTargets.empty()) {
+      ResolvedTargets[Block.LastPc] = std::move(ValidTargets);
+    }
+  }
 }
 
 static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
@@ -920,27 +1154,8 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
     return true;
   }
 
-  bool HasDynamicJump = false;
-  for (const auto &Block : Blocks) {
-    if (!isJumpOpcode(Block.LastOpcode)) {
-      continue;
-    }
-    uint32_t DestPc = 0;
-    if (!resolveConstantJumpTarget(JumpDestMap, PushValueMap, CodeSize, Block,
-                                   DestPc)) {
-      HasDynamicJump = true;
-      break;
-    }
-  }
-  if (HasDynamicJump) {
-    for (const auto &Block : Blocks) {
-      if (Block.Start < CodeSize) {
-        GasChunkEnd[Block.Start] = Block.End;
-        GasChunkCost[Block.Start] = Block.Cost;
-      }
-    }
-    return true;
-  }
+  // Always build CFG — no early exit for dynamic jumps.
+  // Unresolved jumps get over-approximated edges to all JUMPDESTs.
 
   std::vector<uint32_t> JumpDestBlocks;
   if (!JumpDestMap.empty()) {
@@ -960,36 +1175,29 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
     }
   }
 
-  // Build CFG
-  for (size_t BlockId = 0; BlockId < Blocks.size(); ++BlockId) {
-    auto &Block = Blocks[BlockId];
-    const bool IsTerminator = isControlFlowTerminator(Block.LastOpcode);
+  // Build initial CFG with over-approximation for unresolved jumps.
+  // This is needed before call-site enumeration because reverse reachability
+  // requires predecessor edges.
+  buildCFGEdges(Blocks, BlockAtPc, JumpDestMap, PushValueMap, JumpDestBlocks,
+                CodeSize, nullptr);
 
-    // Add fallthrough edge for non-terminating opcodes (CALL/CREATE/GAS
-    // included).
-    if (!IsTerminator && Block.End < CodeSize) {
-      const uint32_t SuccId = BlockAtPc[Block.End];
-      if (SuccId != UINT32_MAX) {
-        addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
-      }
-    }
+  // Resolve function-return jump targets via call-site enumeration.
+  // This uses the initial CFG (with over-approximated edges) for reverse
+  // reachability to find function entries.
+  std::unordered_map<uint32_t, std::vector<uint32_t>> ResolvedTargets;
+  resolveCallSiteTargets(Blocks, BlockAtPc, JumpDestMap, PushValueMap, CodeSize,
+                         ResolvedTargets);
 
-    // Add jump edge (if static jump)
-    if (isJumpOpcode(Block.LastOpcode)) {
-      uint32_t DestPc = 0;
-      if (resolveConstantJumpTarget(JumpDestMap, PushValueMap, CodeSize, Block,
-                                    DestPc)) {
-        const uint32_t SuccId = BlockAtPc[DestPc];
-        if (SuccId != UINT32_MAX) {
-          addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
-        }
-      } else {
-        // Dynamic jump: over-approx to all jump destinations.
-        for (uint32_t SuccId : JumpDestBlocks) {
-          addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
-        }
-      }
+  // If call-site enumeration resolved any targets, rebuild CFG with
+  // precise edges for those jumps.
+  if (!ResolvedTargets.empty()) {
+    // Clear all edges and rebuild with refined edges
+    for (auto &Block : Blocks) {
+      Block.Succs.clear();
+      Block.Preds.clear();
     }
+    buildCFGEdges(Blocks, BlockAtPc, JumpDestMap, PushValueMap, JumpDestBlocks,
+                  CodeSize, &ResolvedTargets);
   }
 
   // Split critical edges (required for safe SPP optimization)

--- a/src/evm/evm_cache.cpp
+++ b/src/evm/evm_cache.cpp
@@ -972,172 +972,14 @@ static bool lemma614Update(uint32_t NodeId, const std::vector<GasBlock> &Blocks,
   return true;
 }
 
-static constexpr size_t MAX_REVERSE_REACHABILITY_DEPTH = 200;
-
-// Check if opcode is a SWAP instruction (SWAP1-SWAP16).
-static bool isSwapOpcode(uint8_t OpcodeU8) {
-  return OpcodeU8 >= static_cast<uint8_t>(evmc_opcode::OP_SWAP1) &&
-         OpcodeU8 <= static_cast<uint8_t>(evmc_opcode::OP_SWAP16);
-}
-
-// Resolve jump targets for function-return patterns (SWAPn → JUMP) using
-// call-site enumeration. For each unresolved JUMP preceded by SWAPn, find
-// the containing function's entry JUMPDEST via reverse reachability, then
-// collect return addresses from all call sites targeting that entry.
-//
-// Call site pattern: PUSH <ret_addr> → PUSH <func_entry> → JUMP
-// Return pattern: SWAPn → JUMP (return address was pushed by caller)
-static void resolveCallSiteTargets(
-    const std::vector<GasBlock> &Blocks, const std::vector<uint32_t> &BlockAtPc,
-    const std::vector<uint8_t> &JumpDestMap,
-    const std::vector<intx::uint256> &PushValueMap, size_t CodeSize,
-    std::unordered_map<uint32_t, std::vector<uint32_t>> &ResolvedTargets) {
-
-  // Step 1: Identify call sites (PUSH ret → PUSH func → JUMP).
-  // Map from function entry PC → list of return address PCs.
-  std::unordered_map<uint32_t, std::vector<uint32_t>> CallTargets;
-  for (const auto &Block : Blocks) {
-    if (Block.LastOpcode != static_cast<uint8_t>(evmc_opcode::OP_JUMP)) {
-      continue;
-    }
-    // Need at least 3 instructions: PUSH ret, PUSH func, JUMP
-    // Check: PrevOpcode is PUSH (func entry), and the instruction before
-    // PrevPc is also a PUSH (return addr).
-    if (!isPushOpcode(Block.PrevOpcode) || Block.PrevPc == UINT32_MAX) {
-      continue;
-    }
-
-    const uint32_t Prev2Pc = Block.Prev2Pc;
-    const uint8_t Prev2Opcode = Block.Prev2Opcode;
-
-    if (!isPushOpcode(Prev2Opcode) || Prev2Pc == UINT32_MAX) {
-      continue;
-    }
-
-    // Verify contiguous instruction sequence: PUSH ret → PUSH func → JUMP
-    if (Prev2Pc + opcodeLen(Prev2Opcode) != Block.PrevPc) {
-      continue;
-    }
-    if (Block.PrevPc + opcodeLen(Block.PrevOpcode) != Block.LastPc) {
-      continue;
-    }
-
-    // Decode function entry and return address
-    uint32_t FuncEntry = 0;
-    if (!decodePushAsJumpDest(PushValueMap, JumpDestMap, CodeSize, Block.PrevPc,
-                              FuncEntry)) {
-      continue;
-    }
-
-    uint32_t RetAddr = 0;
-    if (!decodePushAsJumpDest(PushValueMap, JumpDestMap, CodeSize, Prev2Pc,
-                              RetAddr)) {
-      continue;
-    }
-
-    CallTargets[FuncEntry].push_back(RetAddr);
-  }
-
-  if (CallTargets.empty()) {
-    return;
-  }
-
-  // Step 2: For each SWAPn → JUMP block, find function entry via reverse
-  // reachability, then resolve targets from call sites.
-  std::vector<uint8_t> VisitedGen(Blocks.size(), 0);
-  uint8_t Generation = 0;
-  for (size_t BlockId = 0; BlockId < Blocks.size(); ++BlockId) {
-    const auto &Block = Blocks[BlockId];
-    if (Block.LastOpcode != static_cast<uint8_t>(evmc_opcode::OP_JUMP)) {
-      continue;
-    }
-    // Skip already-resolved (PUSH → JUMP)
-    if (isPushOpcode(Block.PrevOpcode)) {
-      continue;
-    }
-    // Must be SWAPn → JUMP
-    if (!isSwapOpcode(Block.PrevOpcode)) {
-      continue;
-    }
-
-    ++Generation;
-    if (Generation == 0) { // overflow: reset
-      std::fill(VisitedGen.begin(), VisitedGen.end(), 0);
-      Generation = 1;
-    }
-
-    // Reverse reachability: walk backward from this block to find a
-    // JUMPDEST that is a known call target.
-    // NOTE: predecessor edges include over-approximate dynamic jump edges from
-    // the first-pass CFG, so the BFS may cross function boundaries and find a
-    // wrong entry. This is acceptable because resolved targets are only used
-    // with a runtime guard (JumpTarget == constant?) — wrong resolution just
-    // misses an optimization, never causes miscompilation.
-    uint32_t FuncEntry = UINT32_MAX;
-    {
-      std::vector<uint32_t> Worklist;
-      Worklist.push_back(static_cast<uint32_t>(BlockId));
-      size_t Limit = MAX_REVERSE_REACHABILITY_DEPTH;
-      while (!Worklist.empty() && Limit-- > 0) {
-        uint32_t Bid = Worklist.back();
-        Worklist.pop_back();
-        if (VisitedGen[Bid] == Generation) {
-          continue;
-        }
-        VisitedGen[Bid] = Generation;
-        // Check if this block starts at a call-target JUMPDEST
-        if (Blocks[Bid].Start < CodeSize &&
-            JumpDestMap[Blocks[Bid].Start] != 0 &&
-            CallTargets.count(Blocks[Bid].Start) != 0) {
-          FuncEntry = Blocks[Bid].Start;
-          break;
-        }
-        for (uint32_t Pid : Blocks[Bid].Preds) {
-          if (VisitedGen[Pid] != Generation) {
-            Worklist.push_back(Pid);
-          }
-        }
-      }
-    }
-
-    if (FuncEntry == UINT32_MAX) {
-      continue;
-    }
-
-    // Collect return addresses from all call sites targeting this function.
-    const auto &RetAddrs = CallTargets[FuncEntry];
-    std::vector<uint32_t> ValidTargets;
-    for (uint32_t Ra : RetAddrs) {
-      if (Ra < CodeSize && JumpDestMap[Ra] != 0) {
-        const uint32_t TargetBlock = BlockAtPc[Ra];
-        if (TargetBlock != UINT32_MAX) {
-          ValidTargets.push_back(Ra);
-        }
-      }
-    }
-
-    // Deduplicate targets — a function called multiple times from the same
-    // return address would produce duplicates, blocking the size()==1
-    // direct-branch optimization.
-    std::sort(ValidTargets.begin(), ValidTargets.end());
-    ValidTargets.erase(std::unique(ValidTargets.begin(), ValidTargets.end()),
-                       ValidTargets.end());
-
-    if (!ValidTargets.empty()) {
-      ResolvedTargets[Block.LastPc] = std::move(ValidTargets);
-    }
-  }
-}
-
-static bool buildGasChunksSPP(
-    const zen::common::Byte *Code, size_t CodeSize,
-    const evmc_instruction_metrics *MetricsTable,
-    const std::vector<uint8_t> &JumpDestMap,
-    const std::vector<intx::uint256> &PushValueMap,
-    std::vector<uint32_t> &GasChunkEnd, std::vector<uint64_t> &GasChunkCost,
-    std::vector<uint64_t> &GasChunkCostSPP,
-    std::unordered_map<uint32_t, std::vector<uint32_t>> &ResolvedJumpTargets,
-    bool EnableSPP) {
+static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
+                              const evmc_instruction_metrics *MetricsTable,
+                              const std::vector<uint8_t> &JumpDestMap,
+                              const std::vector<intx::uint256> &PushValueMap,
+                              std::vector<uint32_t> &GasChunkEnd,
+                              std::vector<uint64_t> &GasChunkCost,
+                              std::vector<uint64_t> &GasChunkCostSPP,
+                              bool EnableSPP) {
   std::vector<GasBlock> Blocks;
   std::vector<uint32_t> BlockAtPc;
   buildGasBlocks(Code, CodeSize, MetricsTable, Blocks, BlockAtPc);
@@ -1189,14 +1031,6 @@ static bool buildGasChunksSPP(
   // gas along non-existent edges and produce unsafe metering.
   buildCFGEdges(Blocks, BlockAtPc, JumpDestMap, PushValueMap, JumpDestBlocks,
                 CodeSize);
-
-  // Resolve function-return jump targets via call-site enumeration.
-  // The resolved targets are NOT used to refine CFG edges (see above) but
-  // are exported through the cache for downstream consumers such as the MIR
-  // compiler's direct-branch optimization (guarded by a runtime check).
-  std::unordered_map<uint32_t, std::vector<uint32_t>> ResolvedTargets;
-  resolveCallSiteTargets(Blocks, BlockAtPc, JumpDestMap, PushValueMap, CodeSize,
-                         ResolvedTargets);
 
   // Split critical edges (required for safe SPP optimization)
   splitCriticalEdges(Blocks, CodeSize);
@@ -1331,10 +1165,6 @@ static bool buildGasChunksSPP(
     GasChunkCostSPP[Blocks[Id].Start] = Metering[Id];
   }
 
-  // Export resolved jump targets for downstream consumers (e.g. MIR
-  // direct-branch optimization with runtime guard).
-  ResolvedJumpTargets = std::move(ResolvedTargets);
-
   return true;
 }
 
@@ -1361,8 +1191,7 @@ void buildBytecodeCache(EVMBytecodeCache &Cache, const common::Byte *Code,
 
   buildGasChunksSPP(Code, CodeSize, MetricsTable, Cache.JumpDestMap,
                     Cache.PushValueMap, Cache.GasChunkEnd, Cache.GasChunkCost,
-                    Cache.GasChunkCostSPP, Cache.ResolvedJumpTargets,
-                    EnableSPP);
+                    Cache.GasChunkCostSPP, EnableSPP);
 }
 
 } // namespace zen::evm

--- a/src/evm/evm_cache.cpp
+++ b/src/evm/evm_cache.cpp
@@ -383,18 +383,15 @@ static bool resolveConstantJumpTarget(const std::vector<uint8_t> &JumpDestMap,
                               DestPc);
 }
 
-// Build CFG edges for all blocks.
-// When ResolvedTargets is null, uses over-approximation (all JUMPDESTs) for
-// unresolved dynamic jumps. When non-null, uses resolved targets for known
-// SWAPn→JUMP return patterns and falls back to over-approximation for the rest.
-static void
-buildCFGEdges(std::vector<GasBlock> &Blocks,
-              const std::vector<uint32_t> &BlockAtPc,
-              const std::vector<uint8_t> &JumpDestMap,
-              const std::vector<intx::uint256> &PushValueMap,
-              const std::vector<uint32_t> &JumpDestBlocks, size_t CodeSize,
-              const std::unordered_map<uint32_t, std::vector<uint32_t>>
-                  *ResolvedTargets) {
+// Build CFG edges for all blocks. Static jumps (PUSH → JUMP) get precise
+// single-target edges; all other dynamic jumps get over-approximated edges
+// to every JUMPDEST to keep the CFG sound for SPP metering.
+static void buildCFGEdges(std::vector<GasBlock> &Blocks,
+                          const std::vector<uint32_t> &BlockAtPc,
+                          const std::vector<uint8_t> &JumpDestMap,
+                          const std::vector<intx::uint256> &PushValueMap,
+                          const std::vector<uint32_t> &JumpDestBlocks,
+                          size_t CodeSize) {
   for (size_t BlockId = 0; BlockId < Blocks.size(); ++BlockId) {
     auto &Block = Blocks[BlockId];
     const bool IsTerminator = isControlFlowTerminator(Block.LastOpcode);
@@ -418,24 +415,11 @@ buildCFGEdges(std::vector<GasBlock> &Blocks,
         if (SuccId != UINT32_MAX) {
           addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
         }
-      } else if (ResolvedTargets != nullptr) {
-        // Second-pass: use call-site resolved targets if available.
-        auto It = ResolvedTargets->find(Block.LastPc);
-        if (It != ResolvedTargets->end()) {
-          for (uint32_t TargetPc : It->second) {
-            const uint32_t SuccId = BlockAtPc[TargetPc];
-            if (SuccId != UINT32_MAX) {
-              addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
-            }
-          }
-        } else {
-          // Still unresolved: over-approx to all jump destinations.
-          for (uint32_t SuccId : JumpDestBlocks) {
-            addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
-          }
-        }
       } else {
-        // First-pass (no resolved targets yet): over-approx.
+        // Dynamic jump: over-approximate to all jump destinations.
+        // This keeps the CFG sound — under-approximation would let
+        // lemma614Update shift gas along edges that don't exist at
+        // runtime, causing unsafe metering on missed paths.
         for (uint32_t SuccId : JumpDestBlocks) {
           addEdge(Blocks, static_cast<uint32_t>(BlockId), SuccId);
         }
@@ -1084,6 +1068,11 @@ static void resolveCallSiteTargets(
 
     // Reverse reachability: walk backward from this block to find a
     // JUMPDEST that is a known call target.
+    // NOTE: predecessor edges include over-approximate dynamic jump edges from
+    // the first-pass CFG, so the BFS may cross function boundaries and find a
+    // wrong entry. This is acceptable because resolved targets are only used
+    // with a runtime guard (JumpTarget == constant?) — wrong resolution just
+    // misses an optimization, never causes miscompilation.
     uint32_t FuncEntry = UINT32_MAX;
     {
       std::vector<uint32_t> Worklist;
@@ -1140,14 +1129,15 @@ static void resolveCallSiteTargets(
   }
 }
 
-static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
-                              const evmc_instruction_metrics *MetricsTable,
-                              const std::vector<uint8_t> &JumpDestMap,
-                              const std::vector<intx::uint256> &PushValueMap,
-                              std::vector<uint32_t> &GasChunkEnd,
-                              std::vector<uint64_t> &GasChunkCost,
-                              std::vector<uint64_t> &GasChunkCostSPP,
-                              bool EnableSPP) {
+static bool buildGasChunksSPP(
+    const zen::common::Byte *Code, size_t CodeSize,
+    const evmc_instruction_metrics *MetricsTable,
+    const std::vector<uint8_t> &JumpDestMap,
+    const std::vector<intx::uint256> &PushValueMap,
+    std::vector<uint32_t> &GasChunkEnd, std::vector<uint64_t> &GasChunkCost,
+    std::vector<uint64_t> &GasChunkCostSPP,
+    std::unordered_map<uint32_t, std::vector<uint32_t>> &ResolvedJumpTargets,
+    bool EnableSPP) {
   std::vector<GasBlock> Blocks;
   std::vector<uint32_t> BlockAtPc;
   buildGasBlocks(Code, CodeSize, MetricsTable, Blocks, BlockAtPc);
@@ -1191,30 +1181,22 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
     }
   }
 
-  // Build initial CFG with over-approximation for unresolved jumps.
-  // This is needed before call-site enumeration because reverse reachability
-  // requires predecessor edges.
+  // Build CFG with over-approximation for all unresolved dynamic jumps.
+  // Static jumps (PUSH → JUMP) get precise single-target edges; dynamic
+  // jumps get edges to every JUMPDEST. This is intentionally conservative —
+  // using call-site-resolved targets to narrow edges would under-approximate
+  // the CFG when resolution is incomplete, causing lemma614Update to shift
+  // gas along non-existent edges and produce unsafe metering.
   buildCFGEdges(Blocks, BlockAtPc, JumpDestMap, PushValueMap, JumpDestBlocks,
-                CodeSize, nullptr);
+                CodeSize);
 
   // Resolve function-return jump targets via call-site enumeration.
-  // This uses the initial CFG (with over-approximated edges) for reverse
-  // reachability to find function entries.
+  // The resolved targets are NOT used to refine CFG edges (see above) but
+  // are exported through the cache for downstream consumers such as the MIR
+  // compiler's direct-branch optimization (guarded by a runtime check).
   std::unordered_map<uint32_t, std::vector<uint32_t>> ResolvedTargets;
   resolveCallSiteTargets(Blocks, BlockAtPc, JumpDestMap, PushValueMap, CodeSize,
                          ResolvedTargets);
-
-  // If call-site enumeration resolved any targets, rebuild CFG with
-  // precise edges for those jumps.
-  if (!ResolvedTargets.empty()) {
-    // Clear all edges and rebuild with refined edges
-    for (auto &Block : Blocks) {
-      Block.Succs.clear();
-      Block.Preds.clear();
-    }
-    buildCFGEdges(Blocks, BlockAtPc, JumpDestMap, PushValueMap, JumpDestBlocks,
-                  CodeSize, &ResolvedTargets);
-  }
 
   // Split critical edges (required for safe SPP optimization)
   splitCriticalEdges(Blocks, CodeSize);
@@ -1349,6 +1331,10 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
     GasChunkCostSPP[Blocks[Id].Start] = Metering[Id];
   }
 
+  // Export resolved jump targets for downstream consumers (e.g. MIR
+  // direct-branch optimization with runtime guard).
+  ResolvedJumpTargets = std::move(ResolvedTargets);
+
   return true;
 }
 
@@ -1375,7 +1361,8 @@ void buildBytecodeCache(EVMBytecodeCache &Cache, const common::Byte *Code,
 
   buildGasChunksSPP(Code, CodeSize, MetricsTable, Cache.JumpDestMap,
                     Cache.PushValueMap, Cache.GasChunkEnd, Cache.GasChunkCost,
-                    Cache.GasChunkCostSPP, EnableSPP);
+                    Cache.GasChunkCostSPP, Cache.ResolvedJumpTargets,
+                    EnableSPP);
 }
 
 } // namespace zen::evm

--- a/src/evm/evm_cache.cpp
+++ b/src/evm/evm_cache.cpp
@@ -1146,12 +1146,27 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
                               const std::vector<intx::uint256> &PushValueMap,
                               std::vector<uint32_t> &GasChunkEnd,
                               std::vector<uint64_t> &GasChunkCost,
-                              std::vector<uint64_t> &GasChunkCostSPP) {
+                              std::vector<uint64_t> &GasChunkCostSPP,
+                              bool EnableSPP) {
   std::vector<GasBlock> Blocks;
   std::vector<uint32_t> BlockAtPc;
   buildGasBlocks(Code, CodeSize, MetricsTable, Blocks, BlockAtPc);
 
   if (Blocks.empty()) {
+    return true;
+  }
+
+  if (!EnableSPP) {
+    // Interpreter-only fast path: emit unshifted per-block costs and skip
+    // the expensive CFG / call-site / metering pipeline. The JIT consumer
+    // path (which would read GasChunkCostSPP) is never wired up for this
+    // module, so no SPP-shifted values are needed.
+    for (const auto &Block : Blocks) {
+      if (Block.Start < CodeSize) {
+        GasChunkEnd[Block.Start] = Block.End;
+        GasChunkCost[Block.Start] = Block.Cost;
+      }
+    }
     return true;
   }
 
@@ -1340,12 +1355,16 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
 } // namespace
 
 void buildBytecodeCache(EVMBytecodeCache &Cache, const common::Byte *Code,
-                        size_t CodeSize, evmc_revision Rev) {
+                        size_t CodeSize, evmc_revision Rev, bool EnableSPP) {
   Cache.JumpDestMap.assign(CodeSize, 0);
   Cache.PushValueMap.resize(CodeSize);
   Cache.GasChunkEnd.assign(CodeSize, 0);
   Cache.GasChunkCost.assign(CodeSize, 0);
-  Cache.GasChunkCostSPP.assign(CodeSize, 0);
+  if (EnableSPP) {
+    Cache.GasChunkCostSPP.assign(CodeSize, 0);
+  } else {
+    Cache.GasChunkCostSPP.clear();
+  }
 
   buildJumpDestMapAndPushCache(Code, CodeSize, Cache.JumpDestMap,
                                Cache.PushValueMap);
@@ -1356,7 +1375,7 @@ void buildBytecodeCache(EVMBytecodeCache &Cache, const common::Byte *Code,
 
   buildGasChunksSPP(Code, CodeSize, MetricsTable, Cache.JumpDestMap,
                     Cache.PushValueMap, Cache.GasChunkEnd, Cache.GasChunkCost,
-                    Cache.GasChunkCostSPP);
+                    Cache.GasChunkCostSPP, EnableSPP);
 }
 
 } // namespace zen::evm

--- a/src/evm/evm_cache.cpp
+++ b/src/evm/evm_cache.cpp
@@ -1145,7 +1145,8 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
                               const std::vector<uint8_t> &JumpDestMap,
                               const std::vector<intx::uint256> &PushValueMap,
                               std::vector<uint32_t> &GasChunkEnd,
-                              std::vector<uint64_t> &GasChunkCost) {
+                              std::vector<uint64_t> &GasChunkCost,
+                              std::vector<uint64_t> &GasChunkCostSPP) {
   std::vector<GasBlock> Blocks;
   std::vector<uint32_t> BlockAtPc;
   buildGasBlocks(Code, CodeSize, MetricsTable, Blocks, BlockAtPc);
@@ -1327,6 +1328,10 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
     }
     GasChunkEnd[Blocks[Id].Start] = Blocks[Id].End;
     GasChunkCost[Blocks[Id].Start] = Blocks[Id].Cost;
+    // Export SPP-shifted cost on a separate output array so the JIT can read
+    // it without perturbing the interpreter fast path, which continues to see
+    // the unshifted per-block cost above.
+    GasChunkCostSPP[Blocks[Id].Start] = Metering[Id];
   }
 
   return true;
@@ -1340,6 +1345,7 @@ void buildBytecodeCache(EVMBytecodeCache &Cache, const common::Byte *Code,
   Cache.PushValueMap.resize(CodeSize);
   Cache.GasChunkEnd.assign(CodeSize, 0);
   Cache.GasChunkCost.assign(CodeSize, 0);
+  Cache.GasChunkCostSPP.assign(CodeSize, 0);
 
   buildJumpDestMapAndPushCache(Code, CodeSize, Cache.JumpDestMap,
                                Cache.PushValueMap);
@@ -1349,7 +1355,8 @@ void buildBytecodeCache(EVMBytecodeCache &Cache, const common::Byte *Code,
   }
 
   buildGasChunksSPP(Code, CodeSize, MetricsTable, Cache.JumpDestMap,
-                    Cache.PushValueMap, Cache.GasChunkEnd, Cache.GasChunkCost);
+                    Cache.PushValueMap, Cache.GasChunkEnd, Cache.GasChunkCost,
+                    Cache.GasChunkCostSPP);
 }
 
 } // namespace zen::evm

--- a/src/evm/evm_cache.cpp
+++ b/src/evm/evm_cache.cpp
@@ -1051,29 +1051,45 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
     }
   }
 
-  // Build CFG with over-approximation for all unresolved dynamic jumps.
-  // Static jumps (PUSH → JUMP) get precise single-target edges; dynamic
-  // jumps get edges to every JUMPDEST. This is intentionally conservative —
-  // using call-site-resolved targets to narrow edges would under-approximate
-  // the CFG when resolution is incomplete, causing lemma614Update to shift
-  // gas along non-existent edges and produce unsafe metering.
+  // Build CFG. Static jumps (PUSH -> JUMP) get precise single-target
+  // edges. For unresolved dynamic jumps, the CFG is kept sound by
+  // stamping each JUMPDEST with ImplicitDynamicPredCount instead of
+  // materialising the D * |JUMPDEST| explicit edges - that count is
+  // folded into `effectivePredCount`, so `lemma614Update`'s "shift only
+  // into single-effective-pred successors" check behaves identically
+  // to the old explicit-edge representation. Narrowing dynamic jumps
+  // with partial call-site resolution would under-approximate the CFG
+  // and let SPP shift gas along non-existent edges, producing unsafe
+  // metering, so the over-approximation is intentional.
   buildCFGEdges(Blocks, BlockAtPc, JumpDestMap, PushValueMap, JumpDestBlocks,
                 CodeSize);
 
-  // Split critical edges (required for safe SPP optimization)
+  // Split critical edges (required for safe SPP optimization). This pass
+  // operates on explicit Succs/Preds and therefore never sees dyn-jump ->
+  // JUMPDEST edges - that is intentional: the multi-predecessor guard in
+  // `lemma614Update` (with ImplicitDynamicPredCount folded into
+  // `effectivePredCount`) blocks shifts whenever effective preds > 1, so
+  // splitting the implicit edges would be a no-op for soundness.
   splitCriticalEdges(Blocks, CodeSize);
 
   std::vector<uint8_t> Reachable = computeReachable(Blocks, 0);
   // In the implicit-dyn-pred representation, JUMPDESTs reached only via a
   // dynamic JUMP have no explicit predecessor edge from any block reachable
   // via static control flow, so the static-only walk above misses them.
-  // Seed them as roots and propagate forward via Succs so the dominator
-  // and loop analyses still treat them (and their static successors) as
-  // live nodes — without this, SPP would skip cost shifting through every
-  // dyn-only function-return / dispatcher-target chunk.
+  // Seed each *dyn-target* JUMPDEST as a root and propagate forward via
+  // Succs so the dominator and loop analyses still treat them (and their
+  // static successors) as live nodes - without this, SPP would skip cost
+  // shifting through every dyn-only function-return / dispatcher-target
+  // chunk. The `ImplicitDynamicPredCount > 0` gate restricts the seed to
+  // JUMPDESTs the dynamic-jump count actually targets; statically-dead
+  // JUMPDESTs (no static pred and no dyn-jump in the contract) are NOT
+  // revived, preserving pre-Phase-7 behavior on that class.
   {
     std::vector<uint32_t> Stack;
     for (uint32_t JdId : JumpDestBlocks) {
+      if (Blocks[JdId].ImplicitDynamicPredCount == 0) {
+        continue;
+      }
       if (Reachable[JdId] == 0) {
         Reachable[JdId] = 1;
         Stack.push_back(JdId);

--- a/src/evm/evm_cache.cpp
+++ b/src/evm/evm_cache.cpp
@@ -1051,39 +1051,22 @@ static bool buildGasChunksSPP(const zen::common::Byte *Code, size_t CodeSize,
     }
   }
 
-  // Build CFG. Static jumps (PUSH -> JUMP) get precise single-target
-  // edges. For unresolved dynamic jumps, the CFG is kept sound by
-  // stamping each JUMPDEST with ImplicitDynamicPredCount instead of
-  // materialising the D * |JUMPDEST| explicit edges - that count is
-  // folded into `effectivePredCount`, so `lemma614Update`'s "shift only
-  // into single-effective-pred successors" check behaves identically
-  // to the old explicit-edge representation. Narrowing dynamic jumps
-  // with partial call-site resolution would under-approximate the CFG
-  // and let SPP shift gas along non-existent edges, producing unsafe
-  // metering, so the over-approximation is intentional.
+  // Static jumps get precise single-target edges. For unresolved dynamic
+  // jumps, the CFG over-approximation is encoded as
+  // ImplicitDynamicPredCount on each JUMPDEST (folded into
+  // effectivePredCount). Narrowing to partial call-site resolution would
+  // under-approximate the CFG and let SPP shift gas along non-existent
+  // edges, producing unsafe metering.
   buildCFGEdges(Blocks, BlockAtPc, JumpDestMap, PushValueMap, JumpDestBlocks,
                 CodeSize);
 
-  // Split critical edges (required for safe SPP optimization). This pass
-  // operates on explicit Succs/Preds and therefore never sees dyn-jump ->
-  // JUMPDEST edges - that is intentional: the multi-predecessor guard in
-  // `lemma614Update` (with ImplicitDynamicPredCount folded into
-  // `effectivePredCount`) blocks shifts whenever effective preds > 1, so
-  // splitting the implicit edges would be a no-op for soundness.
   splitCriticalEdges(Blocks, CodeSize);
 
   std::vector<uint8_t> Reachable = computeReachable(Blocks, 0);
-  // In the implicit-dyn-pred representation, JUMPDESTs reached only via a
-  // dynamic JUMP have no explicit predecessor edge from any block reachable
-  // via static control flow, so the static-only walk above misses them.
-  // Seed each *dyn-target* JUMPDEST as a root and propagate forward via
-  // Succs so the dominator and loop analyses still treat them (and their
-  // static successors) as live nodes - without this, SPP would skip cost
-  // shifting through every dyn-only function-return / dispatcher-target
-  // chunk. The `ImplicitDynamicPredCount > 0` gate restricts the seed to
-  // JUMPDESTs the dynamic-jump count actually targets; statically-dead
-  // JUMPDESTs (no static pred and no dyn-jump in the contract) are NOT
-  // revived, preserving pre-Phase-7 behavior on that class.
+  // Seed dyn-target JUMPDESTs as reachability roots so dom/loop analyses
+  // include them and their static successors. Statically-dead JUMPDESTs
+  // (no static pred, no dyn-jump in the contract) are intentionally left
+  // unreachable.
   {
     std::vector<uint32_t> Stack;
     for (uint32_t JdId : JumpDestBlocks) {

--- a/src/evm/evm_cache.h
+++ b/src/evm/evm_cache.h
@@ -11,6 +11,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <unordered_map>
 #include <vector>
 
 namespace zen::evm {
@@ -25,6 +26,10 @@ struct EVMBytecodeCache {
   // Per-chunk-start SPP-shifted gas cost for the multipass JIT. Produced by
   // buildGasChunksSPP's metering pass; never read by the interpreter.
   std::vector<uint64_t> GasChunkCostSPP;
+  // Call-site-resolved jump targets for SWAPn→JUMP return patterns. Maps
+  // jump PC → list of resolved return address PCs. Used by the MIR compiler
+  // for direct-branch optimization (with runtime guard, not CFG refinement).
+  std::unordered_map<uint32_t, std::vector<uint32_t>> ResolvedJumpTargets;
 };
 
 // Build the bytecode cache. When EnableSPP is true, the expensive SPP

--- a/src/evm/evm_cache.h
+++ b/src/evm/evm_cache.h
@@ -19,7 +19,12 @@ struct EVMBytecodeCache {
   std::vector<uint8_t> JumpDestMap;
   std::vector<intx::uint256> PushValueMap;
   std::vector<uint32_t> GasChunkEnd;
+  // Per-chunk-start unshifted gas cost. Interpreter reads this — it must
+  // equal the original block base cost (see PR #371).
   std::vector<uint64_t> GasChunkCost;
+  // Per-chunk-start SPP-shifted gas cost for the multipass JIT. Produced by
+  // buildGasChunksSPP's metering pass; never read by the interpreter.
+  std::vector<uint64_t> GasChunkCostSPP;
 };
 
 void buildBytecodeCache(EVMBytecodeCache &Cache, const common::Byte *Code,

--- a/src/evm/evm_cache.h
+++ b/src/evm/evm_cache.h
@@ -27,8 +27,13 @@ struct EVMBytecodeCache {
   std::vector<uint64_t> GasChunkCostSPP;
 };
 
+// Build the bytecode cache. When EnableSPP is true, the expensive SPP
+// metering pipeline runs and GasChunkCostSPP is populated with shifted
+// per-chunk costs for the multipass JIT. When false (interpreter-only
+// modules), the pipeline is skipped and GasChunkCostSPP stays empty.
 void buildBytecodeCache(EVMBytecodeCache &Cache, const common::Byte *Code,
-                        size_t CodeSize, evmc_revision Rev);
+                        size_t CodeSize, evmc_revision Rev,
+                        bool EnableSPP = false);
 
 } // namespace zen::evm
 

--- a/src/evm/evm_cache.h
+++ b/src/evm/evm_cache.h
@@ -11,7 +11,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <unordered_map>
 #include <vector>
 
 namespace zen::evm {
@@ -26,10 +25,6 @@ struct EVMBytecodeCache {
   // Per-chunk-start SPP-shifted gas cost for the multipass JIT. Produced by
   // buildGasChunksSPP's metering pass; never read by the interpreter.
   std::vector<uint64_t> GasChunkCostSPP;
-  // Call-site-resolved jump targets for SWAPn→JUMP return patterns. Maps
-  // jump PC → list of resolved return address PCs. Used by the MIR compiler
-  // for direct-branch optimization (with runtime guard, not CFG refinement).
-  std::unordered_map<uint32_t, std::vector<uint32_t>> ResolvedJumpTargets;
 };
 
 // Build the bytecode cache. When EnableSPP is true, the expensive SPP

--- a/src/evm/evm_cache.md
+++ b/src/evm/evm_cache.md
@@ -7,7 +7,8 @@ This document describes the bytecode cache built by `buildBytecodeCache()` in `s
 - `JumpDestMap[pc]` (`uint8_t`): `1` if `Code[pc]` is `OP_JUMPDEST` and this byte is an opcode byte (not inside PUSH data).
 - `PushValueMap[pc]` (`intx::uint256`): decoded immediate for `PUSH1..PUSH32` at `pc`. Unused entries are `0`.
 - `GasChunkEnd[pc]` (`uint32_t`): for a chunk start `pc`, the exclusive end PC of the chunk; otherwise `0`.
-- `GasChunkCost[pc]` (`uint64_t`): metering cost charged at block start `pc` (SPP-shifted in optimized mode); otherwise `0`.
+- `GasChunkCost[pc]` (`uint64_t`): unshifted base gas cost of the block starting at `pc` (sum of EVMC base costs of opcodes in the block); otherwise `0`. Read by the interpreter.
+- `GasChunkCostSPP[pc]` (`uint64_t`): SPP-shifted gas cost of the block starting at `pc`. Populated only when the SPP metering pipeline runs (JIT-consumer modules); otherwise the array is empty. Read by the multipass JIT.
 
 ## Build Algorithm
 
@@ -62,7 +63,12 @@ using a linear-time SPP pass:
     to the loop nodes in local reverse-topological order.
 
 This moves common costs earlier, reducing the number of non-zero charge points.
-The resulting `m` is stored in `GasChunkCost` at each block start.
+The resulting shifted value `m(s)` is stored in `GasChunkCostSPP[s]` at each
+block start; `GasChunkCost[s]` continues to hold the unshifted base cost so
+the interpreter fast path is unaffected. The SPP pipeline only runs for
+modules that will be JIT-compiled (gated by `EnableSPP` in
+`buildBytecodeCache`); for interpreter-only modules `GasChunkCostSPP` is
+left empty and the CFG / metering work is skipped.
 
 If the CFG is not suitable for linear SPP (e.g., dominance-based loop analysis
 fails), we still run SPP updates once per node in reverse topological order
@@ -96,14 +102,16 @@ zero bytes on the right, matching the EVM encoding.
 
 ### Correctness of chunk gas charging
 
-In SPP mode, `GasChunkCost[s]` is the shifted metering value `m(s)`. Lemma 6.14
-updates move cost along CFG edges while preserving total base cost on every
-path. Over-approximating dynamic jumps keeps the optimization safe (it may
-reduce shifts but never undercharges). Splitting critical edges ensures that
-cost is only moved along edges where the local update is valid. When loop
-analysis fails, the reverse-topological updates still preserve correctness
-without fast-forward.
-
-The fast path is still used only when `gas_left >= GasChunkCost[s]`, so base-cost
-out-of-gas cannot occur inside a block. Dynamic/extra gas is charged inside
-opcode handlers as before (memory expansion, cold access, keccak word cost, etc).
+`GasChunkCost[s]` is always the unshifted base cost of block `s`, so the
+interpreter's fast path enters a chunk only when `gas_left >= GasChunkCost[s]`
+and base-cost out-of-gas cannot occur inside a block. The multipass JIT reads
+the shifted value `m(s)` from `GasChunkCostSPP[s]`. Lemma 6.14 updates move
+cost along CFG edges while preserving total base cost on every path.
+Over-approximating dynamic jumps to all `JUMPDEST`s keeps the optimization
+safe — narrowing those edges with partial call-site resolution would
+under-approximate the CFG and let the SPP pass shift gas along edges that
+don't exist at runtime, producing unsafe metering. Splitting critical edges
+ensures that cost is only moved along edges where the local update is valid.
+When loop analysis fails, the reverse-topological updates still preserve
+correctness without fast-forward. Dynamic/extra gas is charged inside opcode
+handlers as before (memory expansion, cold access, keccak word cost, etc).

--- a/src/runtime/evm_module.cpp
+++ b/src/runtime/evm_module.cpp
@@ -114,6 +114,9 @@ EVMModule::newEVMModule(Runtime &RT, CodeHolderUniquePtr CodeHolder,
     if (!Mod->ShouldFallbackToInterp)
 #endif // ZEN_ENABLE_JIT_PRECOMPILE_FALLBACK
     {
+      // JIT is about to compile this module — mark the bytecode cache so the
+      // SPP metering pipeline runs on first access.
+      Mod->CacheNeedsSPP = true;
       action::performEVMJITCompile(*Mod);
     }
   }
@@ -130,7 +133,8 @@ const evm::EVMBytecodeCache &EVMModule::getBytecodeCache() const {
 }
 
 void EVMModule::initBytecodeCache() const {
-  evm::buildBytecodeCache(BytecodeCache, Code, CodeSize, Revision);
+  evm::buildBytecodeCache(BytecodeCache, Code, CodeSize, Revision,
+                          CacheNeedsSPP);
 }
 
 } // namespace zen::runtime

--- a/src/runtime/evm_module.h
+++ b/src/runtime/evm_module.h
@@ -105,6 +105,11 @@ private:
   // buildBytecodeCache runs the expensive SPP metering pipeline so the JIT
   // can read shifted gas costs from GasChunkCostSPP. When false, only the
   // cheap per-block pass runs — interpreter-only modules pay nothing extra.
+  //
+  // Must be set before any getBytecodeCache() call: once the cache is
+  // built, the EnableSPP decision is fixed for the lifetime of the
+  // module. Future lazy / on-demand JIT paths must flip this flag before
+  // triggering the lazy cache build.
   bool CacheNeedsSPP = false;
   evmc_revision Revision = zen::evm::DEFAULT_REVISION;
   EVMMemorySpecializationProfile MemoryProfile = {};

--- a/src/runtime/evm_module.h
+++ b/src/runtime/evm_module.h
@@ -101,6 +101,11 @@ private:
   void initBytecodeCache() const;
   mutable bool BytecodeCacheInitialized = false;
   mutable evm::EVMBytecodeCache BytecodeCache;
+  // Whether this module will be consumed by the multipass JIT. When true,
+  // buildBytecodeCache runs the expensive SPP metering pipeline so the JIT
+  // can read shifted gas costs from GasChunkCostSPP. When false, only the
+  // cheap per-block pass runs — interpreter-only modules pay nothing extra.
+  bool CacheNeedsSPP = false;
   evmc_revision Revision = zen::evm::DEFAULT_REVISION;
   EVMMemorySpecializationProfile MemoryProfile = {};
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -61,10 +61,10 @@ if(ZEN_ENABLE_SPEC_TEST)
     add_subdirectory(mpt)
     add_executable(evmInterpTests evm_interp_tests.cpp)
     add_executable(evmCacheTests evm_cache_tests.cpp)
-    # Manual demo binary — not registered with ctest. Run from build/ at any
-    # time to see cache-build wall-clock at a chosen JUMPDEST count; see
-    # docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/.
+    # Build-only target: never receives ASan even in ASan builds so its
+    # wall-clock measurement is not distorted by sanitizer overhead.
     add_executable(evmCacheComplexityDemo evm_cache_complexity_demo.cpp)
+    target_link_libraries(evmCacheComplexityDemo PRIVATE dtvmcore)
     if(ZEN_ENABLE_MULTIPASS_JIT)
       add_executable(evmJitFrontendTests evm_jit_frontend_tests.cpp)
     endif()
@@ -105,7 +105,6 @@ if(ZEN_ENABLE_SPEC_TEST)
     if(ZEN_ENABLE_EVM)
       target_compile_options(evmInterpTests PRIVATE -fsanitize=address)
       target_compile_options(evmCacheTests PRIVATE -fsanitize=address)
-      target_compile_options(evmCacheComplexityDemo PRIVATE -fsanitize=address)
       if(ZEN_ENABLE_MULTIPASS_JIT)
         target_compile_options(evmJitFrontendTests PRIVATE -fsanitize=address)
       endif()
@@ -135,9 +134,6 @@ if(ZEN_ENABLE_SPEC_TEST)
           evmCacheTests
           PRIVATE dtvmcore gtest_main -fsanitize=address
           PUBLIC ${GTEST_BOTH_LIBRARIES}
-        )
-        target_link_libraries(
-          evmCacheComplexityDemo PRIVATE dtvmcore -fsanitize=address
         )
         if(ZEN_ENABLE_MULTIPASS_JIT)
           target_link_libraries(
@@ -199,10 +195,6 @@ if(ZEN_ENABLE_SPEC_TEST)
           evmCacheTests
           PRIVATE dtvmcore gtest_main -fsanitize=address -static-libasan
           PUBLIC ${GTEST_BOTH_LIBRARIES}
-        )
-        target_link_libraries(
-          evmCacheComplexityDemo PRIVATE dtvmcore -fsanitize=address
-                                         -static-libasan
         )
         if(ZEN_ENABLE_MULTIPASS_JIT)
           target_link_libraries(
@@ -274,7 +266,6 @@ if(ZEN_ENABLE_SPEC_TEST)
         PRIVATE dtvmcore gtest_main
         PUBLIC ${GTEST_BOTH_LIBRARIES}
       )
-      target_link_libraries(evmCacheComplexityDemo PRIVATE dtvmcore)
       if(ZEN_ENABLE_MULTIPASS_JIT)
         target_link_libraries(
           evmJitFrontendTests

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ if(ZEN_ENABLE_SPEC_TEST)
   if(ZEN_ENABLE_EVM)
     add_subdirectory(mpt)
     add_executable(evmInterpTests evm_interp_tests.cpp)
+    add_executable(evmCacheTests evm_cache_tests.cpp)
     if(ZEN_ENABLE_MULTIPASS_JIT)
       add_executable(evmJitFrontendTests evm_jit_frontend_tests.cpp)
     endif()
@@ -99,6 +100,7 @@ if(ZEN_ENABLE_SPEC_TEST)
 
     if(ZEN_ENABLE_EVM)
       target_compile_options(evmInterpTests PRIVATE -fsanitize=address)
+      target_compile_options(evmCacheTests PRIVATE -fsanitize=address)
       if(ZEN_ENABLE_MULTIPASS_JIT)
         target_compile_options(evmJitFrontendTests PRIVATE -fsanitize=address)
       endif()
@@ -122,6 +124,11 @@ if(ZEN_ENABLE_SPEC_TEST)
         target_link_libraries(
           evmInterpTests
           PRIVATE dtvmcore rapidjson yaml-cpp gtest_main -fsanitize=address
+          PUBLIC ${GTEST_BOTH_LIBRARIES}
+        )
+        target_link_libraries(
+          evmCacheTests
+          PRIVATE dtvmcore gtest_main -fsanitize=address
           PUBLIC ${GTEST_BOTH_LIBRARIES}
         )
         if(ZEN_ENABLE_MULTIPASS_JIT)
@@ -178,6 +185,11 @@ if(ZEN_ENABLE_SPEC_TEST)
                   gtest_main
                   -fsanitize=address
                   -static-libasan
+          PUBLIC ${GTEST_BOTH_LIBRARIES}
+        )
+        target_link_libraries(
+          evmCacheTests
+          PRIVATE dtvmcore gtest_main -fsanitize=address -static-libasan
           PUBLIC ${GTEST_BOTH_LIBRARIES}
         )
         if(ZEN_ENABLE_MULTIPASS_JIT)
@@ -245,6 +257,11 @@ if(ZEN_ENABLE_SPEC_TEST)
         PRIVATE dtvmcore rapidjson yaml-cpp gtest_main
         PUBLIC ${GTEST_BOTH_LIBRARIES}
       )
+      target_link_libraries(
+        evmCacheTests
+        PRIVATE dtvmcore gtest_main
+        PUBLIC ${GTEST_BOTH_LIBRARIES}
+      )
       if(ZEN_ENABLE_MULTIPASS_JIT)
         target_link_libraries(
           evmJitFrontendTests
@@ -292,6 +309,7 @@ if(ZEN_ENABLE_SPEC_TEST)
 
   if(ZEN_ENABLE_EVM)
     add_test(NAME evmInterpTests COMMAND evmInterpTests)
+    add_test(NAME evmCacheTests COMMAND evmCacheTests)
     if(ZEN_ENABLE_MULTIPASS_JIT)
       add_test(NAME evmJitFrontendTests COMMAND evmJitFrontendTests)
     endif()

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -61,6 +61,10 @@ if(ZEN_ENABLE_SPEC_TEST)
     add_subdirectory(mpt)
     add_executable(evmInterpTests evm_interp_tests.cpp)
     add_executable(evmCacheTests evm_cache_tests.cpp)
+    # Manual demo binary — not registered with ctest. Run from build/ at any
+    # time to see cache-build wall-clock at a chosen JUMPDEST count; see
+    # docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/.
+    add_executable(evmCacheComplexityDemo evm_cache_complexity_demo.cpp)
     if(ZEN_ENABLE_MULTIPASS_JIT)
       add_executable(evmJitFrontendTests evm_jit_frontend_tests.cpp)
     endif()
@@ -101,6 +105,7 @@ if(ZEN_ENABLE_SPEC_TEST)
     if(ZEN_ENABLE_EVM)
       target_compile_options(evmInterpTests PRIVATE -fsanitize=address)
       target_compile_options(evmCacheTests PRIVATE -fsanitize=address)
+      target_compile_options(evmCacheComplexityDemo PRIVATE -fsanitize=address)
       if(ZEN_ENABLE_MULTIPASS_JIT)
         target_compile_options(evmJitFrontendTests PRIVATE -fsanitize=address)
       endif()
@@ -130,6 +135,9 @@ if(ZEN_ENABLE_SPEC_TEST)
           evmCacheTests
           PRIVATE dtvmcore gtest_main -fsanitize=address
           PUBLIC ${GTEST_BOTH_LIBRARIES}
+        )
+        target_link_libraries(
+          evmCacheComplexityDemo PRIVATE dtvmcore -fsanitize=address
         )
         if(ZEN_ENABLE_MULTIPASS_JIT)
           target_link_libraries(
@@ -191,6 +199,10 @@ if(ZEN_ENABLE_SPEC_TEST)
           evmCacheTests
           PRIVATE dtvmcore gtest_main -fsanitize=address -static-libasan
           PUBLIC ${GTEST_BOTH_LIBRARIES}
+        )
+        target_link_libraries(
+          evmCacheComplexityDemo PRIVATE dtvmcore -fsanitize=address
+                                         -static-libasan
         )
         if(ZEN_ENABLE_MULTIPASS_JIT)
           target_link_libraries(
@@ -262,6 +274,7 @@ if(ZEN_ENABLE_SPEC_TEST)
         PRIVATE dtvmcore gtest_main
         PUBLIC ${GTEST_BOTH_LIBRARIES}
       )
+      target_link_libraries(evmCacheComplexityDemo PRIVATE dtvmcore)
       if(ZEN_ENABLE_MULTIPASS_JIT)
         target_link_libraries(
           evmJitFrontendTests

--- a/src/tests/evm_cache_complexity_demo.cpp
+++ b/src/tests/evm_cache_complexity_demo.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 the DTVM authors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Standalone demo: time `buildBytecodeCache` on a synthetic contract with
+// N JUMPDESTs reached via one dynamic JUMP. Exercises the Phase 7
+// `ImplicitDynamicPredCount` path end-to-end and lets a caller observe
+// the O(N) cache-build wall-clock empirically.
+//
+// Usage: evmCacheComplexityDemo <n_jumpdests>
+// Output: one CSV row "<n_jumpdests>,<build_ms>" to stdout.
+//
+// See docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/scaling_demo.sh
+// for a wrapper that tabulates multiple sizes.
+
+#include "evm/evm_cache.h"
+
+#include <evmc/evmc.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Build a contract with exactly N JUMPDESTs reachable only via one
+// dynamic JUMP, so every JUMPDEST gets stamped with
+// ImplicitDynamicPredCount = 1 (Phase 7 path).
+//
+// Layout:
+//   PC 0  CALLDATALOAD          (cost 3, unresolvable push -> dyn jump)
+//   PC 1  JUMP                  (block terminator; dyn jump)
+//   PC 2..(N+1)  JUMPDEST       (N JUMPDESTs in sequence)
+//   PC N+2  STOP
+std::vector<uint8_t> makeDynDispatchContract(size_t NumJumpDests) {
+  std::vector<uint8_t> Code;
+  Code.reserve(NumJumpDests + 3);
+  Code.push_back(0x35); // CALLDATALOAD
+  Code.push_back(0x56); // JUMP (dyn)
+  for (size_t I = 0; I < NumJumpDests; ++I) {
+    Code.push_back(0x5b); // JUMPDEST
+  }
+  Code.push_back(0x00); // STOP
+  return Code;
+}
+
+double timeCacheBuildMs(const std::vector<uint8_t> &Code) {
+  using Clock = std::chrono::steady_clock;
+  const auto Start = Clock::now();
+  zen::evm::EVMBytecodeCache Cache;
+  zen::evm::buildBytecodeCache(Cache,
+                               reinterpret_cast<const std::byte *>(Code.data()),
+                               Code.size(), EVMC_CANCUN, /*EnableSPP=*/true);
+  const auto End = Clock::now();
+  return std::chrono::duration<double, std::milli>(End - Start).count();
+}
+
+} // namespace
+
+int main(int Argc, char **Argv) {
+  if (Argc != 2) {
+    std::fprintf(stderr, "usage: %s <n_jumpdests>\n", Argv[0]);
+    return 2;
+  }
+  const size_t N = static_cast<size_t>(std::stoull(Argv[1]));
+  const auto Code = makeDynDispatchContract(N);
+  const double Ms = timeCacheBuildMs(Code);
+  std::printf("%zu,%.3f\n", N, Ms);
+  return 0;
+}

--- a/src/tests/evm_cache_complexity_demo.cpp
+++ b/src/tests/evm_cache_complexity_demo.cpp
@@ -1,20 +1,15 @@
 // Copyright (C) 2025 the DTVM authors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Standalone demo: time `buildBytecodeCache` on a synthetic contract with
-// N JUMPDESTs reached via one dynamic JUMP. Exercises the Phase 7
-// `ImplicitDynamicPredCount` path end-to-end and lets a caller observe
-// the O(N) cache-build wall-clock empirically.
-//
-// Usage: evmCacheComplexityDemo <n_jumpdests>
-// Output: one CSV row "<n_jumpdests>,<build_ms>" to stdout.
-//
-// See docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/scaling_demo.sh
-// for a wrapper that tabulates multiple sizes.
+// Time buildBytecodeCache on a CALLDATALOAD JUMP <N x JUMPDEST> STOP
+// contract. Usage: evmCacheComplexityDemo <n_jumpdests>
+// Output: "<n_jumpdests>,<build_ms>" on stdout.
 
 #include "evm/evm_cache.h"
+#include "platform/platform.h"
 
 #include <evmc/evmc.h>
+#include <evmc/instructions.h>
 
 #include <chrono>
 #include <cstddef>
@@ -26,29 +21,26 @@
 
 namespace {
 
-// Build a contract with exactly N JUMPDESTs reachable only via one
-// dynamic JUMP, so every JUMPDEST gets stamped with
-// ImplicitDynamicPredCount = 1 (Phase 7 path).
-//
-// Layout:
-//   PC 0  CALLDATALOAD          (cost 3, unresolvable push -> dyn jump)
-//   PC 1  JUMP                  (block terminator; dyn jump)
-//   PC 2..(N+1)  JUMPDEST       (N JUMPDESTs in sequence)
-//   PC N+2  STOP
+constexpr uint8_t OP_STOP = static_cast<uint8_t>(evmc_opcode::OP_STOP);
+constexpr uint8_t OP_CALLDATALOAD =
+    static_cast<uint8_t>(evmc_opcode::OP_CALLDATALOAD);
+constexpr uint8_t OP_JUMP = static_cast<uint8_t>(evmc_opcode::OP_JUMP);
+constexpr uint8_t OP_JUMPDEST = static_cast<uint8_t>(evmc_opcode::OP_JUMPDEST);
+
 std::vector<uint8_t> makeDynDispatchContract(size_t NumJumpDests) {
   std::vector<uint8_t> Code;
   Code.reserve(NumJumpDests + 3);
-  Code.push_back(0x35); // CALLDATALOAD
-  Code.push_back(0x56); // JUMP (dyn)
+  Code.push_back(OP_CALLDATALOAD);
+  Code.push_back(OP_JUMP);
   for (size_t I = 0; I < NumJumpDests; ++I) {
-    Code.push_back(0x5b); // JUMPDEST
+    Code.push_back(OP_JUMPDEST);
   }
-  Code.push_back(0x00); // STOP
+  Code.push_back(OP_STOP);
   return Code;
 }
 
 double timeCacheBuildMs(const std::vector<uint8_t> &Code) {
-  using Clock = std::chrono::steady_clock;
+  using Clock = zen::common::SteadyClock;
   const auto Start = Clock::now();
   zen::evm::EVMBytecodeCache Cache;
   zen::evm::buildBytecodeCache(Cache,

--- a/src/tests/evm_cache_tests.cpp
+++ b/src/tests/evm_cache_tests.cpp
@@ -1,14 +1,13 @@
 // Copyright (C) 2025 the DTVM authors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Targeted regression tests for Phase 7 of PR #446 — implicit-dyn-pred
-// representation and reachability stitch inside `buildBytecodeCache`'s
-// SPP pipeline. See
-// `docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/review-fixes-r2.md`.
+// Regression tests for buildBytecodeCache's SPP pipeline: implicit
+// dyn-pred count + reachability stitch on dyn-target JUMPDESTs.
 
 #include "evm/evm_cache.h"
 
 #include <evmc/evmc.h>
+#include <evmc/instructions.h>
 #include <gtest/gtest.h>
 
 #include <cstddef>
@@ -20,14 +19,14 @@ namespace {
 using zen::evm::buildBytecodeCache;
 using zen::evm::EVMBytecodeCache;
 
-// EVM opcodes used by the fixtures below.
-constexpr uint8_t OP_STOP = 0x00;
-constexpr uint8_t OP_ADD = 0x01;
-constexpr uint8_t OP_CALLDATALOAD = 0x35;
-constexpr uint8_t OP_POP = 0x50;
-constexpr uint8_t OP_JUMP = 0x56;
-constexpr uint8_t OP_JUMPDEST = 0x5b;
-constexpr uint8_t OP_PUSH1 = 0x60;
+constexpr uint8_t OP_STOP = static_cast<uint8_t>(evmc_opcode::OP_STOP);
+constexpr uint8_t OP_ADD = static_cast<uint8_t>(evmc_opcode::OP_ADD);
+constexpr uint8_t OP_CALLDATALOAD =
+    static_cast<uint8_t>(evmc_opcode::OP_CALLDATALOAD);
+constexpr uint8_t OP_POP = static_cast<uint8_t>(evmc_opcode::OP_POP);
+constexpr uint8_t OP_JUMP = static_cast<uint8_t>(evmc_opcode::OP_JUMP);
+constexpr uint8_t OP_JUMPDEST = static_cast<uint8_t>(evmc_opcode::OP_JUMPDEST);
+constexpr uint8_t OP_PUSH1 = static_cast<uint8_t>(evmc_opcode::OP_PUSH1);
 
 EVMBytecodeCache buildSPPCache(const std::vector<uint8_t> &Code) {
   EVMBytecodeCache Cache;
@@ -43,40 +42,23 @@ EVMBytecodeCache buildNoSPPCache(const std::vector<uint8_t> &Code) {
   return Cache;
 }
 
-// Fixture 1 (smoke): contract with NO dynamic jumps + one statically-dead
-// JUMPDEST. Verifies the cache builds without crashing on this class and
-// that base/SPP costs match on a dead block. NOTE: this case is not a
-// strict R2-gate oracle by itself — the dead JUMPDEST has empty Succs
-// (STOP terminates the block) so `lemma614Update` cannot shift cost
-// out of it regardless of whether the stitch ran. R2 gate verification
-// is covered indirectly by R2 not regressing existing test corpora.
+// Smoke: no dynamic jumps + a statically-dead JUMPDEST must not crash;
+// SPP must leave the dead block's cost unchanged (empty Succs, nothing
+// to shift out).
 TEST(EVMCacheImplicitDynPred, BuildsCleanly_NoDynJumpWithDeadJumpDest) {
   const std::vector<uint8_t> Code = {OP_STOP, OP_JUMPDEST, OP_ADD, OP_STOP};
   const EVMBytecodeCache Cache = buildSPPCache(Code);
 
   ASSERT_EQ(Cache.GasChunkCost.size(), Code.size());
   ASSERT_EQ(Cache.GasChunkCostSPP.size(), Code.size());
-  // JUMPDEST(1) + ADD(3) = 4 gas. STOP terminates the block.
+  // JUMPDEST(1) + ADD(3) = 4 gas.
   EXPECT_EQ(Cache.GasChunkCost[1], 4u);
-  EXPECT_EQ(Cache.GasChunkCostSPP[1], Cache.GasChunkCost[1])
-      << "On a dead JUMPDEST with empty Succs, SPP must leave the cost "
-         "unchanged.";
+  EXPECT_EQ(Cache.GasChunkCostSPP[1], Cache.GasChunkCost[1]);
 }
 
-// Fixture 2: contract with an unresolvable dynamic JUMP. Every JUMPDEST
-// is implicitly a dyn target, so `ImplicitDynamicPredCount > 0` and the
-// stitch keeps them in dom-analysis input.
-// Layout (block boundaries marked):
-//   PC 0  CALLDATALOAD       block B0: unresolvable -> dyn jump
-//   PC 1  JUMP                                  (B0 ends here)
-//   PC 2  JUMPDEST  <-- B1 (dyn target)
-//   PC 3  ADD                                   (B1 continues)
-//   PC 4  POP                                   (B1 continues)
-//   PC 5  STOP                                  (B1 ends)
-// Expectation: `GasChunkCostSPP[2]` is populated (non-zero) because the
-// dyn-target JUMPDEST is now in Reachable[] via the stitch. Without the
-// stitch (pre-Phase-7 behavior) the JUMPDEST was unreachable and would
-// receive no SPP work. The post-Phase-7 + R2 gate path keeps it.
+// A JUMPDEST reachable only via an unresolved dynamic jump must still
+// land in dom-analysis input via the reachability stitch, so its SPP
+// entry is populated.
 TEST(EVMCacheImplicitDynPred, DynTargetJumpDest_StitchedIntoSPP) {
   const std::vector<uint8_t> Code = {
       OP_CALLDATALOAD, OP_JUMP, OP_JUMPDEST, OP_ADD, OP_POP, OP_STOP,
@@ -85,49 +67,26 @@ TEST(EVMCacheImplicitDynPred, DynTargetJumpDest_StitchedIntoSPP) {
 
   ASSERT_EQ(Cache.GasChunkCost.size(), Code.size());
   ASSERT_EQ(Cache.GasChunkCostSPP.size(), Code.size());
-  // Block at PC 2 = JUMPDEST(1) + ADD(3) + POP(2) + STOP(0) = 6 gas.
+  // JUMPDEST(1) + ADD(3) + POP(2) + STOP(0) = 6 gas.
   EXPECT_EQ(Cache.GasChunkCost[2], 6u);
-  // Block has empty Succs (STOP terminates), so `lemma614Update` keeps
-  // its cost unshifted. The metering pass still writes the array entry,
-  // demonstrating the dom/loop analysis included this dyn-target chunk
-  // (without the stitch the block would be unreachable in `Reachable[]`
-  // and not in the dom-tree input, though it would remain in RevTopo).
   EXPECT_EQ(Cache.GasChunkCostSPP[2], Cache.GasChunkCost[2]);
-  // The dyn-jump source at block 0 has CALLDATALOAD(3) + JUMP(8) = 11
-  // gas and a terminator JUMP, so it carries no shift either.
+  // CALLDATALOAD(3) + JUMP(8) = 11 gas.
   EXPECT_EQ(Cache.GasChunkCost[0], 11u);
 }
 
-// Fixture 3: interpreter-only path (EnableSPP=false) must leave
-// `GasChunkCostSPP` empty so the JIT-consumer fall-through at
-// `evm_compiler.cpp:73` (Cache.GasChunkCostSPP.empty() ? nullptr) keeps
-// the unshifted array as the source.
+// EnableSPP=false must leave GasChunkCostSPP empty so the JIT-consumer
+// fall-through hands the unshifted cost array to downstream code.
 TEST(EVMCacheImplicitDynPred, InterpreterOnly_LeavesSPPArrayEmpty) {
   const std::vector<uint8_t> Code = {OP_PUSH1, 0x05,        OP_JUMP, OP_PUSH1,
                                      0x00,     OP_JUMPDEST, OP_STOP};
   const EVMBytecodeCache Cache = buildNoSPPCache(Code);
 
-  // GasChunkCost is always populated.
   ASSERT_EQ(Cache.GasChunkCost.size(), Code.size());
-  // GasChunkCostSPP must be empty when EnableSPP=false (clear() path in
-  // buildBytecodeCache).
-  EXPECT_TRUE(Cache.GasChunkCostSPP.empty())
-      << "Interpreter-only build must skip SPP allocation (CacheNeedsSPP "
-         "lifecycle invariant).";
+  EXPECT_TRUE(Cache.GasChunkCostSPP.empty());
 }
 
-// Fixture 4: contract with two dynamic JUMPs targeting one JUMPDEST. The
-// JUMPDEST's `ImplicitDynamicPredCount == 2`, so even if a single static
-// predecessor were added the effective predecessor count (>= 3) blocks
-// any `lemma614Update` shift INTO that JUMPDEST.
-//   PC 0  CALLDATALOAD          block B0
-//   PC 1  JUMP                  (B0 ends, dyn jump #1)
-//   PC 2  JUMPDEST  <-- B1      first JUMPDEST
-//   PC 3  CALLDATALOAD          block continues
-//   PC 4  JUMP                  (dyn jump #2; B1 ends here)
-//   PC 5  JUMPDEST  <-- B2      second JUMPDEST (dyn target of both jumps)
-//   PC 6  POP
-//   PC 7  STOP
+// Two dynamic JUMPs => ImplicitDynamicPredCount == 2 on each JUMPDEST.
+// effectivePredCount must block any lemma614 shift INTO either JUMPDEST.
 TEST(EVMCacheImplicitDynPred, MultipleDynJumps_BothTargetsCounted) {
   const std::vector<uint8_t> Code = {
       OP_CALLDATALOAD, OP_JUMP,     OP_JUMPDEST, OP_CALLDATALOAD,
@@ -137,15 +96,10 @@ TEST(EVMCacheImplicitDynPred, MultipleDynJumps_BothTargetsCounted) {
 
   ASSERT_EQ(Cache.GasChunkCost.size(), Code.size());
   ASSERT_EQ(Cache.GasChunkCostSPP.size(), Code.size());
-  // JumpDestMap recognises both JUMPDESTs.
   EXPECT_EQ(Cache.JumpDestMap[2], 1u);
   EXPECT_EQ(Cache.JumpDestMap[5], 1u);
-  // Both JUMPDESTs at PC 2 and PC 5 must have non-zero base cost
-  // (JUMPDEST opcode costs 1 gas, plus whatever follows in the block).
   EXPECT_GT(Cache.GasChunkCost[2], 0u);
   EXPECT_GT(Cache.GasChunkCost[5], 0u);
-  // No shift opportunities on either JUMPDEST block (B1 ends with the
-  // second dyn JUMP, B2 ends with STOP). SPP value must match base.
   EXPECT_EQ(Cache.GasChunkCostSPP[2], Cache.GasChunkCost[2]);
   EXPECT_EQ(Cache.GasChunkCostSPP[5], Cache.GasChunkCost[5]);
 }

--- a/src/tests/evm_cache_tests.cpp
+++ b/src/tests/evm_cache_tests.cpp
@@ -1,0 +1,153 @@
+// Copyright (C) 2025 the DTVM authors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Targeted regression tests for Phase 7 of PR #446 — implicit-dyn-pred
+// representation and reachability stitch inside `buildBytecodeCache`'s
+// SPP pipeline. See
+// `docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/review-fixes-r2.md`.
+
+#include "evm/evm_cache.h"
+
+#include <evmc/evmc.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+using zen::evm::buildBytecodeCache;
+using zen::evm::EVMBytecodeCache;
+
+// EVM opcodes used by the fixtures below.
+constexpr uint8_t OP_STOP = 0x00;
+constexpr uint8_t OP_ADD = 0x01;
+constexpr uint8_t OP_CALLDATALOAD = 0x35;
+constexpr uint8_t OP_POP = 0x50;
+constexpr uint8_t OP_JUMP = 0x56;
+constexpr uint8_t OP_JUMPDEST = 0x5b;
+constexpr uint8_t OP_PUSH1 = 0x60;
+
+EVMBytecodeCache buildSPPCache(const std::vector<uint8_t> &Code) {
+  EVMBytecodeCache Cache;
+  buildBytecodeCache(Cache, reinterpret_cast<const std::byte *>(Code.data()),
+                     Code.size(), EVMC_CANCUN, /*EnableSPP=*/true);
+  return Cache;
+}
+
+EVMBytecodeCache buildNoSPPCache(const std::vector<uint8_t> &Code) {
+  EVMBytecodeCache Cache;
+  buildBytecodeCache(Cache, reinterpret_cast<const std::byte *>(Code.data()),
+                     Code.size(), EVMC_CANCUN, /*EnableSPP=*/false);
+  return Cache;
+}
+
+// Fixture 1 (smoke): contract with NO dynamic jumps + one statically-dead
+// JUMPDEST. Verifies the cache builds without crashing on this class and
+// that base/SPP costs match on a dead block. NOTE: this case is not a
+// strict R2-gate oracle by itself — the dead JUMPDEST has empty Succs
+// (STOP terminates the block) so `lemma614Update` cannot shift cost
+// out of it regardless of whether the stitch ran. R2 gate verification
+// is covered indirectly by R2 not regressing existing test corpora.
+TEST(EVMCacheImplicitDynPred, BuildsCleanly_NoDynJumpWithDeadJumpDest) {
+  const std::vector<uint8_t> Code = {OP_STOP, OP_JUMPDEST, OP_ADD, OP_STOP};
+  const EVMBytecodeCache Cache = buildSPPCache(Code);
+
+  ASSERT_EQ(Cache.GasChunkCost.size(), Code.size());
+  ASSERT_EQ(Cache.GasChunkCostSPP.size(), Code.size());
+  // JUMPDEST(1) + ADD(3) = 4 gas. STOP terminates the block.
+  EXPECT_EQ(Cache.GasChunkCost[1], 4u);
+  EXPECT_EQ(Cache.GasChunkCostSPP[1], Cache.GasChunkCost[1])
+      << "On a dead JUMPDEST with empty Succs, SPP must leave the cost "
+         "unchanged.";
+}
+
+// Fixture 2: contract with an unresolvable dynamic JUMP. Every JUMPDEST
+// is implicitly a dyn target, so `ImplicitDynamicPredCount > 0` and the
+// stitch keeps them in dom-analysis input.
+// Layout (block boundaries marked):
+//   PC 0  CALLDATALOAD       block B0: unresolvable -> dyn jump
+//   PC 1  JUMP                                  (B0 ends here)
+//   PC 2  JUMPDEST  <-- B1 (dyn target)
+//   PC 3  ADD                                   (B1 continues)
+//   PC 4  POP                                   (B1 continues)
+//   PC 5  STOP                                  (B1 ends)
+// Expectation: `GasChunkCostSPP[2]` is populated (non-zero) because the
+// dyn-target JUMPDEST is now in Reachable[] via the stitch. Without the
+// stitch (pre-Phase-7 behavior) the JUMPDEST was unreachable and would
+// receive no SPP work. The post-Phase-7 + R2 gate path keeps it.
+TEST(EVMCacheImplicitDynPred, DynTargetJumpDest_StitchedIntoSPP) {
+  const std::vector<uint8_t> Code = {
+      OP_CALLDATALOAD, OP_JUMP, OP_JUMPDEST, OP_ADD, OP_POP, OP_STOP,
+  };
+  const EVMBytecodeCache Cache = buildSPPCache(Code);
+
+  ASSERT_EQ(Cache.GasChunkCost.size(), Code.size());
+  ASSERT_EQ(Cache.GasChunkCostSPP.size(), Code.size());
+  // Block at PC 2 = JUMPDEST(1) + ADD(3) + POP(2) + STOP(0) = 6 gas.
+  EXPECT_EQ(Cache.GasChunkCost[2], 6u);
+  // Block has empty Succs (STOP terminates), so `lemma614Update` keeps
+  // its cost unshifted. The metering pass still writes the array entry,
+  // demonstrating the dom/loop analysis included this dyn-target chunk
+  // (without the stitch the block would be unreachable in `Reachable[]`
+  // and not in the dom-tree input, though it would remain in RevTopo).
+  EXPECT_EQ(Cache.GasChunkCostSPP[2], Cache.GasChunkCost[2]);
+  // The dyn-jump source at block 0 has CALLDATALOAD(3) + JUMP(8) = 11
+  // gas and a terminator JUMP, so it carries no shift either.
+  EXPECT_EQ(Cache.GasChunkCost[0], 11u);
+}
+
+// Fixture 3: interpreter-only path (EnableSPP=false) must leave
+// `GasChunkCostSPP` empty so the JIT-consumer fall-through at
+// `evm_compiler.cpp:73` (Cache.GasChunkCostSPP.empty() ? nullptr) keeps
+// the unshifted array as the source.
+TEST(EVMCacheImplicitDynPred, InterpreterOnly_LeavesSPPArrayEmpty) {
+  const std::vector<uint8_t> Code = {OP_PUSH1, 0x05,        OP_JUMP, OP_PUSH1,
+                                     0x00,     OP_JUMPDEST, OP_STOP};
+  const EVMBytecodeCache Cache = buildNoSPPCache(Code);
+
+  // GasChunkCost is always populated.
+  ASSERT_EQ(Cache.GasChunkCost.size(), Code.size());
+  // GasChunkCostSPP must be empty when EnableSPP=false (clear() path in
+  // buildBytecodeCache).
+  EXPECT_TRUE(Cache.GasChunkCostSPP.empty())
+      << "Interpreter-only build must skip SPP allocation (CacheNeedsSPP "
+         "lifecycle invariant).";
+}
+
+// Fixture 4: contract with two dynamic JUMPs targeting one JUMPDEST. The
+// JUMPDEST's `ImplicitDynamicPredCount == 2`, so even if a single static
+// predecessor were added the effective predecessor count (>= 3) blocks
+// any `lemma614Update` shift INTO that JUMPDEST.
+//   PC 0  CALLDATALOAD          block B0
+//   PC 1  JUMP                  (B0 ends, dyn jump #1)
+//   PC 2  JUMPDEST  <-- B1      first JUMPDEST
+//   PC 3  CALLDATALOAD          block continues
+//   PC 4  JUMP                  (dyn jump #2; B1 ends here)
+//   PC 5  JUMPDEST  <-- B2      second JUMPDEST (dyn target of both jumps)
+//   PC 6  POP
+//   PC 7  STOP
+TEST(EVMCacheImplicitDynPred, MultipleDynJumps_BothTargetsCounted) {
+  const std::vector<uint8_t> Code = {
+      OP_CALLDATALOAD, OP_JUMP,     OP_JUMPDEST, OP_CALLDATALOAD,
+      OP_JUMP,         OP_JUMPDEST, OP_POP,      OP_STOP,
+  };
+  const EVMBytecodeCache Cache = buildSPPCache(Code);
+
+  ASSERT_EQ(Cache.GasChunkCost.size(), Code.size());
+  ASSERT_EQ(Cache.GasChunkCostSPP.size(), Code.size());
+  // JumpDestMap recognises both JUMPDESTs.
+  EXPECT_EQ(Cache.JumpDestMap[2], 1u);
+  EXPECT_EQ(Cache.JumpDestMap[5], 1u);
+  // Both JUMPDESTs at PC 2 and PC 5 must have non-zero base cost
+  // (JUMPDEST opcode costs 1 gas, plus whatever follows in the block).
+  EXPECT_GT(Cache.GasChunkCost[2], 0u);
+  EXPECT_GT(Cache.GasChunkCost[5], 0u);
+  // No shift opportunities on either JUMPDEST block (B1 ends with the
+  // second dyn JUMP, B2 ends with STOP). SPP value must match base.
+  EXPECT_EQ(Cache.GasChunkCostSPP[2], Cache.GasChunkCost[2]);
+  EXPECT_EQ(Cache.GasChunkCostSPP[5], Cache.GasChunkCost[5]);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Before this PR, the EVM bytecode cache's SPP gas-metering pipeline used
an all-or-nothing bailout: **any unresolved dynamic jump caused the
entire contract to skip SPP and fall back to per-block gas metering**.
Real-world Solidity contracts always contain dynamic jumps (function
dispatch, return-via-stack), so in practice SPP delivered zero benefit
on the workloads that matter.

This PR removes the bailout by making the cache build a **mixed-precision
CFG** (precise edges for static `PUSH→JUMP`, over-approximated edges for
all other dynamic jumps) and exporting a separate **SPP-shifted gas-cost
array** that the multipass JIT consumes while the interpreter continues
to read the unshifted costs guaranteed by PR #371. The expensive SPP
pipeline is also gated to JIT-consumer modules so interpreter-only paths
never pay for it.

### What this PR delivers

1. **Capability** — SPP gas metering now applies to every contract,
   including ones with unresolvable dynamic jumps. Previously it was
   effectively dead code on real Solidity workloads.
2. **Algorithmic complexity** — `O(D × J²)` → `O(N)` on the cache CFG
   build, where `D` is the dynamic-jump count and `J` is the JUMPDEST
   count. Verified: `loop_full_of_jumpdests` cache-build wall-clock
   drops from 7.3s to 3.3s (local single-machine measurement, not
   CI-tracked).
3. **Architecture** — `GasChunkCost` / `GasChunkCostSPP` parallel arrays
   plus the `CacheNeedsSPP` lifecycle flag cleanly separate the
   interpreter and JIT gas paths, so future work on either side can
   move independently.

Runtime delta on the 27-bench paper subset is within evmone-bench's
inter-binary drift band — see Evaluation below.

### Phase 1 — mixed-CFG gas block construction

- Remove the all-or-nothing `HasDynamicJump` bailout in
  `buildGasChunksSPP`. Contracts with any unresolved dynamic jump used to
  skip the SPP pipeline completely; now they run the pipeline with
  over-approximated edges for the unresolved portion.
- Factor out `buildCFGEdges()` with over-approximation for all unresolved
  dynamic jumps (sound for SPP metering). The CFG is intentionally kept
  over-approximate — using resolved targets to narrow edges would
  under-approximate the CFG when resolution is incomplete, causing
  `lemma614Update` to shift gas along non-existent edges.
- Tighten the SPP shift guard inside `lemma614Update` so a shift never
  crosses an `isGasChunkTerminator` boundary, and set `MinSucc = 0` when
  encountering excluded successors to prevent unsafe shifting.

### Phase 2 — `decodePushAsJumpDest` decode helper

- Factor `decodePushAsJumpDest()` out of `resolveConstantJumpTarget()` as
  a shared decode helper.

### Phase 3 — wire SPP-shifted costs into the multipass JIT

- Add a second parallel cost array `EVMBytecodeCache::GasChunkCostSPP`
  populated from `Metering[]` inside `buildGasChunksSPP`. The existing
  `GasChunkCost` continues to hold unshifted `Blocks[Id].Cost` per the
  interpreter-safety invariant established by PR #371.
- Plumb the pointer through `EVMFrontendContext::setGasChunkInfo` and the
  `EVMMirBuilder` constructor / copy path.
- Swap reads at three JIT sites so they prefer `GasChunkCostSPP` when
  available, falling back to `GasChunkCost`:
  - `EVMMirBuilder::meterOpcode` — primary per-chunk-start charge
  - `EVMMirBuilder::meterOpcodeRange` — JUMPDEST-skip cumulative sum
  - `buildEVMFunction` JUMPDEST-run suffix-sum precompute

### Phase 4 — gate the SPP pipeline on JIT-consumer modules only

- Add `buildBytecodeCache(..., bool EnableSPP = false)`. When false,
  skip the expensive CFG / metering pipeline entirely.
- Track `EVMModule::CacheNeedsSPP`. Flipped to `true` immediately before
  `action::performEVMJITCompile` runs — interpreter-only modules never
  pay the SPP pipeline cost.

### Phase 5 — CFG soundness fix

- Remove the two-pass CFG rebuild that used resolved call-site targets to
  replace over-approximate edges. This created an under-approximate CFG
  when call-site enumeration was incomplete, causing `lemma614Update` to
  shift gas along non-existent edges and produce unsafe metering.
- `buildCFGEdges()` now always over-approximates dynamic jumps
  logically: unresolved dynamic jumps are represented by
  `ImplicitDynamicPredCount` stamped onto JUMPDEST blocks, rather than by
  materializing one Succs/Preds edge per dynamic-jump/JUMPDEST pair.
  Static jumps (PUSH → JUMP) still get precise single-target edges.
- Remove dead call-site enumeration code (`resolveCallSiteTargets` and
  `ResolvedJumpTargets` export) — no downstream consumer exists yet.
  The algorithm can be restored from git history when a consumer
  (e.g. MIR direct-branch optimization) is implemented.

### Phase 6 — review fixes

- Remove dead `GasBlock::Prev2Pc` / `Prev2Opcode` fields and their
  writebacks. They were originally added to support a future
  3-instruction call-site window lookup, but the call-site enumeration
  that would have consumed them was removed in Phase 5. Whole-repo
  grep confirmed zero readers; struct shrinks ~9 bytes.
- Extend the `buildCFGEdges` function comment to make the soundness
  pairing with `lemma614Update` explicit: the implicit dynamic
  predecessor count is folded into `effectivePredCount`, so dynamic
  targets are treated as multi-predecessor blocks without materializing
  D×J CFG edges.
- Document the `EVMModule::CacheNeedsSPP` lifecycle invariant: the flag
  must be set before any `getBytecodeCache()` call, since the
  `EnableSPP` decision is fixed at lazy-build time.

### Phase 7 — drop `O(D × J²)` over-approximation cost

- Replace the explicit add-then-split-critical-edge step that materialised
  one CFG edge per (dynamic-jump-block, JUMPDEST) pair with a per-JUMPDEST
  scalar `ImplicitDynamicPredCount`, folded into `effectivePredCount` so
  the lemma 6.14 update behaves identically without materialising the
  edges. On a contract with `D` dynamic jumps and `J` JUMPDESTs, the
  cache build drops from `O(D × J²)` to `O(N)`.
- To keep dyn-only JUMPDESTs (Solidity function returns, unreachable in
  the static-only CFG) visible to the dominator / loop analyses, seed
  the reachability search from every JUMPDEST after the static reachable
  set is built. Gated on `ImplicitDynamicPredCount > 0` (round-2 review
  fix) so statically-dead JUMPDESTs in dynamic-jump-free contracts
  preserve pre-Phase-7 behavior.
- Compile-time check: end-to-end `evmone-unittests` wall clock for
  `loop_full_of_jumpdests` (24556 JUMPDESTs) drops from **7.3 s** to
  **3.3 s** (local single-machine measurement, not CI-tracked).
- **Intra-PR demo** — same source built on the commit immediately
  before this Phase 7 commit (`99f23a3`) vs current HEAD, on a
  synthetic contract `CALLDATALOAD JUMP <N × JUMPDEST> STOP`:

  | N JUMPDESTs | Pre-Phase-7 (D × J explicit edges) | Phase 7 (O(N) implicit count) | Speedup |
  |------------:|----------------------------------:|------------------------------:|--------:|
  |         100 |   0.07 ms |  0.05 ms | 1.4× |
  |         500 |   0.39 ms |  0.13 ms | 3.0× |
  |       1,000 |   1.01 ms |  0.29 ms | 3.4× |
  |       2,000 |   3.04 ms |  0.67 ms | 4.5× |
  |       5,000 |  19.66 ms |  2.71 ms | 7.2× |
  |      10,000 |  84.76 ms | 10.38 ms | 8.2× |
  |      20,000 | 345.94 ms | 43.68 ms | **7.9×** |

  Pre-Phase-7 grows ~4× per doubling of N (quadratic — the expected
  O(D × J²) shape). Phase 7 grows 2–4× per doubling (sub-quadratic;
  residual super-linearity comes from `computeDominators` /
  `buildLoopsUsingDominance`, which this PR does not touch). Reproduce
  with `cmake --build build --target evmCacheComplexityDemo &&
  bash docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/scaling_demo.sh`.

- New `evmCacheTests` unit test target with 4 smoke/regression cases
  covering the SPP gate, dynamic-target reachability path, interpreter-only
  no-SPP path, and multi-dyn-jump conservative metering.
- Detail: `docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/README.md`
  and `docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/review-fixes-r2.md`.

## Evaluation

### Runtime

After rebasing onto current `upstream/main` (which includes the
intervening upstream perf work — #458 u256 arithmetic, #460
displacement-addressed bytes32, #482 depth-indexed pool, #483 inline
arithmetic delegate), and measuring the 27 paper benches
(`^external/total/(main|micro)/`):

- **27-bench 10-rep geomean: +1.15%** (treatment slower; +0.46% after
  correcting a single 20-rep-confirmed outlier on
  `main/blake2b_shifts/8415nulls`).
- **0 benches above the ±25% CI gate.**
- **Caveat**: this 10-rep number is sequential
  (baseline-all-then-treatment-all), so it conflates real PR delta with
  inter-binary system drift. Focused 20-rep re-measurement on the three
  largest movers indicates the per-bench deltas are dominated by drift,
  not by PR effects:

  | Bench | 10-rep Δ | 20-rep Δ (focused) | Verdict |
  |---|---|---|---|
  | `main/weierstrudel/1` | +3.51% | **+0.55%** (treat CV 2.19%) | drift |
  | `main/blake2b_huff/8415nulls` | -6.30% | **+1.55%** | drift (flipped direction) |
  | `micro/loop_with_many_jumpdests/empty` | -4.84% | **-0.55%** | drift |
  | `main/blake2b_shifts/8415nulls` | +20.34% (CV 21.93%) | **+0.25%** (CV 2.09%) | single-iteration outlier |

  Additionally, three of the four "regression" benches reported above
  the noise band at 10 reps — `micro/memory_grow_mstore/{nogrow,by1}`,
  `micro/memory_grow_mload/nogrow` — contain **zero JUMP / JUMPI /
  JUMPDEST opcodes**, so PR #446's CFG changes cannot affect them by
  construction. Those deltas are pure drift artifacts.

**Reading**: this PR's value is the capability change (Phase 1 — SPP
now applies to contracts with dynamic jumps) and the algorithmic
complexity guarantee (Phase 7 — O(D × J²) → O(N) cache build), not raw
runtime improvement on the existing 27-bench suite. The intervening
upstream perf work absorbed any prior absolute speedup; the remaining
per-bench deltas are at or below evmone-bench's single-machine
inter-binary drift band.

### Interpreter

0 regressions on CI. Local timing confirms the SPP gating bypass:

| test suite | before Phase 4 | after Phase 4 |
|---|---|---|
| `evmone-unittests` interpreter | 3744 ms | **419 ms (−89%)** |

### Correctness

- `tools/format.sh check`: clean
- `evmone-unittests` multipass: **223/223 pass**
- `evmone-unittests` interpreter: **215/215 pass**
- `evmone-statetest --fork Cancun` multipass: **2723/2723 pass**
- `evmone-statetest --fork Cancun` interpreter: **2723/2723 pass**
- New `evmCacheTests` unit tests: **4/4 pass**

## Changed files

- `src/evm/evm_cache.h` — add `GasChunkCostSPP` array;
  `GasBlock::ImplicitDynamicPredCount` field
- `src/evm/evm_cache.cpp` — mixed-CFG, SPP export, `EnableSPP` gating,
  soundness fix (always over-approximate CFG); drop dead
  `Prev2Pc/Prev2Opcode`; clarify CFG over-approx invariant;
  implicit-dyn-pred count + reachability stitch with R2 gate (Phase 7)
- `src/compiler/evm_frontend/evm_mir_compiler.{h,cpp}` — plumb SPP
  pointer; prefer SPP-shifted cost at three chunk-cost read sites
- `src/compiler/evm_compiler.cpp` — pass SPP pointer via `setGasChunkInfo`
- `src/runtime/evm_module.{h,cpp}` — add `CacheNeedsSPP` flag; flip
  before JIT compile; document lifecycle invariant
- `src/tests/evm_cache_tests.cpp` — NEW unit test target
- `src/tests/CMakeLists.txt` — register new test target
- `docs/changes/2026-04-05-gas-check-placement/` — change doc +
  review-fix plan
- `docs/changes/2026-05-11-spp-cfg-implicit-dyn-pred/` — Phase 7
  change doc + round-2 review-fix plan
- `docs/design/evm-gas-mechanism.md` — design doc (interpreter + JIT
  gas mechanism with SPP)

## Test plan

- [x] `tools/format.sh check` clean
- [x] `evmone-unittests` multipass and interpreter: all pass
- [x] `evmone-statetest --fork Cancun` multipass and interpreter: all pass
- [x] New `evmCacheTests` 4 cases pass
- [x] CI perf regression check passes within the ±25% gate
- [x] `loop_full_of_jumpdests` cache build under 4s (compile-time
  complexity verification, local single-machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

