### PR TITLE
fix(evm): fix ZEN_LOG format string mismatch

### DIFF
--- a/src/action/interpreter.cpp
+++ b/src/action/interpreter.cpp
@@ -580,7 +580,7 @@ private:
         break;
       }
       default:
-        ZEN_LOG_ERROR("unimplemented opcode : {%d}", Opcode);
+        ZEN_LOG_ERROR("unimplemented opcode : 0x%x", Opcode);
         ZEN_ASSERT_TODO();
         break;
       }

--- a/src/tests/evm_test_helpers.h
+++ b/src/tests/evm_test_helpers.h
@@ -146,7 +146,7 @@ inline std::string decimalToHex(const std::string &DecimalStr) {
     return "0";
   }
   if (TrimmedStr[0] == '-') {
-    ZEN_LOG_ERROR("Negative values are not supported. Value: {}",
+    ZEN_LOG_ERROR("Negative values are not supported. Value: %s",
                   DecimalStr.c_str());
     return "0";
   }
@@ -162,11 +162,11 @@ inline std::string decimalToHex(const std::string &DecimalStr) {
   try {
     Value = std::stoull(TrimmedStr);
   } catch (const std::out_of_range &E) {
-    ZEN_LOG_ERROR("Value exceeds uint64_t range. Value: {}",
+    ZEN_LOG_ERROR("Value exceeds uint64_t range. Value: %s",
                   DecimalStr.c_str());
     return "0";
   } catch (const std::invalid_argument &E) {
-    ZEN_LOG_ERROR("Invalid decimal string (parsing failed). Value: {}",
+    ZEN_LOG_ERROR("Invalid decimal string (parsing failed). Value: %s",
                   DecimalStr.c_str());
     return "0";
   }

--- a/src/tests/evm_test_helpers.h
+++ b/src/tests/evm_test_helpers.h
@@ -153,7 +153,7 @@ inline std::string decimalToHex(const std::string &DecimalStr) {
   for (char C : TrimmedStr) {
     if (!std::isdigit(C)) {
       ZEN_LOG_ERROR(
-          "Invalid decimal string (contains non-digit characters). Value: {}",
+          "Invalid decimal string (contains non-digit characters). Value: %s",
           DecimalStr.c_str());
       return "0";
     }
@@ -175,7 +175,7 @@ inline std::string decimalToHex(const std::string &DecimalStr) {
   std::string HexStr = S.str();
   if (HexStr.size() > 64) {
     ZEN_LOG_ERROR(
-        "Hex value exceeds 64 characters (uint256 max). Length: {}, Value: {}",
+        "Hex value exceeds 64 characters (uint256 max). Length: %zu, Value: %s",
         HexStr.size(), HexStr.c_str());
     HexStr = HexStr.substr(HexStr.size() - 64);
   }

--- a/src/tests/evm_test_host.hpp
+++ b/src/tests/evm_test_host.hpp
@@ -481,7 +481,7 @@ public:
     if (It == accounts.end() || It->second.code.empty()) {
       // No contract found, return parent result
       ZEN_LOG_DEBUG(
-          "No contract found for code address {}, return parent result",
+          "No contract found for code address %s, return parent result",
           evmc::hex(evmc::bytes_view(CodeAddr.bytes, 20)).c_str());
       if (Msg.kind == EVMC_CALL && !applyCallValueTransfer(Msg)) {
         return ParentResult;
@@ -517,7 +517,7 @@ public:
       auto ModRet =
           RT->loadEVMModule(ModName, ContractCode.data(), ContractCode.size());
       if (!ModRet) {
-        ZEN_LOG_ERROR("Failed to load EVM module: {}", ModName.c_str());
+        ZEN_LOG_ERROR("Failed to load EVM module: %s", ModName.c_str());
         return ParentResult;
       }
 
@@ -526,7 +526,7 @@ public:
       IsolationPtr Iso(nullptr, IsolationDeleter{RT});
       Iso.reset(RT->createManagedIsolation());
       if (!Iso) {
-        ZEN_LOG_ERROR("Failed to create isolation for module: {}",
+        ZEN_LOG_ERROR("Failed to create isolation for module: %s",
                       ModName.c_str());
         return ParentResult;
       }
@@ -534,7 +534,7 @@ public:
       // Create EVM instance
       auto InstRet = Iso->createEVMInstance(*Mod, Msg.gas);
       if (!InstRet) {
-        ZEN_LOG_ERROR("Failed to create EVM instance for module: {}",
+        ZEN_LOG_ERROR("Failed to create EVM instance for module: %s",
                       ModName.c_str());
         return ParentResult;
       }
@@ -573,7 +573,7 @@ public:
           RT->callEVMMain(*Inst, CallMsg, ExecResult);
         }
       } catch (const std::exception &E) {
-        ZEN_LOG_ERROR("Error in recursive call: {}", E.what());
+        ZEN_LOG_ERROR("Error in recursive call: %s", E.what());
         restoreHostState(StateSnapshot);
         return ParentResult;
       }
@@ -599,7 +599,7 @@ public:
 
     } catch (const std::exception &E) {
       // On error, return parent result
-      ZEN_LOG_ERROR("Error in recursive call: {}", E.what());
+      ZEN_LOG_ERROR("Error in recursive call: %s", E.what());
       restoreHostState(StateSnapshot);
       return ParentResult;
     }
@@ -695,7 +695,7 @@ public:
       if (!IsNewAccount) {
         ensureAccountHasCodeHash(It->second);
         if (isCreateCollision(It->second)) {
-          ZEN_LOG_ERROR("Create collision at address {}",
+          ZEN_LOG_ERROR("Create collision at address %s",
                         evmc::hex(NewAddr).c_str());
           auto SenderIt = accounts.find(Msg.sender);
           if (SenderIt != accounts.end() &&
@@ -721,7 +721,7 @@ public:
       auto ModRet = RT->loadEVMModule(ModName, InitcodePtr, InitcodeSize);
       if (!ModRet) {
         restoreHostState(StateSnapshot);
-        ZEN_LOG_ERROR("Failed to load EVM module: {}", ModName.c_str());
+        ZEN_LOG_ERROR("Failed to load EVM module: %s", ModName.c_str());
         return evmc::Result{EVMC_FAILURE, Msg.gas, 0, NewAddr};
       }
       EVMModule *Mod = *ModRet;
@@ -730,7 +730,7 @@ public:
       Iso.reset(RT->createManagedIsolation());
       if (!Iso) {
         restoreHostState(StateSnapshot);
-        ZEN_LOG_ERROR("Failed to create isolation for module: {}",
+        ZEN_LOG_ERROR("Failed to create isolation for module: %s",
                       ModName.c_str());
         return evmc::Result{EVMC_FAILURE, Msg.gas, 0, NewAddr};
       }
@@ -738,7 +738,7 @@ public:
       auto InstRet = Iso->createEVMInstance(*Mod, Msg.gas);
       if (!InstRet) {
         restoreHostState(StateSnapshot);
-        ZEN_LOG_ERROR("Failed to create EVM instance for module: {}",
+        ZEN_LOG_ERROR("Failed to create EVM instance for module: %s",
                       ModName.c_str());
         return evmc::Result{EVMC_FAILURE, Msg.gas, 0, NewAddr};
       }
@@ -761,7 +761,7 @@ public:
           intx::be::load<intx::uint256>(SenderAcc.balance);
       if (SenderBalance < Value) {
         restoreHostState(StateSnapshot);
-        ZEN_LOG_ERROR("Insufficient balance for CREATE: have {}, need {}",
+        ZEN_LOG_ERROR("Insufficient balance for CREATE: have %s, need %s",
                       SenderBalance, Value);
         return evmc::Result{EVMC_INSUFFICIENT_BALANCE, Msg.gas, 0, NewAddr};
       }
@@ -799,7 +799,7 @@ public:
         }
       } catch (const std::exception &E) {
         restoreHostState(StateSnapshot);
-        ZEN_LOG_ERROR("Error in handleCreate execution: {}", E.what());
+        ZEN_LOG_ERROR("Error in handleCreate execution: %s", E.what());
         return evmc::Result{EVMC_FAILURE, Msg.gas, 0, evmc::address{}};
       }
 
@@ -889,7 +889,7 @@ public:
       CreateResult.create_address = NewAddr;
       return CreateResult;
     } catch (const std::exception &E) {
-      ZEN_LOG_ERROR("Error in handleCreate: {}", E.what());
+      ZEN_LOG_ERROR("Error in handleCreate: %s", E.what());
       restoreHostState(StateSnapshot);
       return evmc::Result{EVMC_FAILURE, Msg.gas, 0, evmc::address{}};
     }

--- a/src/tests/evm_test_host.hpp
+++ b/src/tests/evm_test_host.hpp
@@ -504,7 +504,7 @@ public:
       const auto &ContractCode = It->second.code;
       if (ContractCode.empty()) {
         ZEN_LOG_DEBUG(
-            "Contract code is empty for recipient {}",
+            "Contract code is empty for recipient %s",
             evmc::hex(evmc::bytes_view(Msg.recipient.bytes, 20)).c_str());
         return ParentResult;
       }
@@ -761,8 +761,10 @@ public:
           intx::be::load<intx::uint256>(SenderAcc.balance);
       if (SenderBalance < Value) {
         restoreHostState(StateSnapshot);
+        const auto SenderBalanceStr = intx::to_string(SenderBalance);
+        const auto ValueStr = intx::to_string(Value);
         ZEN_LOG_ERROR("Insufficient balance for CREATE: have %s, need %s",
-                      SenderBalance, Value);
+                      SenderBalanceStr.c_str(), ValueStr.c_str());
         return evmc::Result{EVMC_INSUFFICIENT_BALANCE, Msg.gas, 0, NewAddr};
       }
       SenderBalance -= Value;


### PR DESCRIPTION


ZEN_LOG_* macros use snprintf (printf-style %s/%d), but several log calls in evm_test_host.hpp and evm_test_helpers.h used fmt-style {} placeholders. snprintf ignores {}, leaving them in the output string. When spdlog then parses the message as a fmt format string, it triggers 'argument index out of range' error.

Fixed by replacing all {} with %s in ZEN_LOG_* calls. Also fixed a mixed {%d} format in action/interpreter.cpp.

<!-- Thank you for contributing to DTVM!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.

-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 
fix #450
fix #452

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    lib/wasi,
    smart_ir/src/abi
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```