### PR TITLE
fix(evm): enforce EIP-211 bounds in Rust RETURNDATACOPY

### DIFF
--- a/rust_crate/src/evm/host_functions/control.rs
+++ b/rust_crate/src/evm/host_functions/control.rs
@@ -147,6 +147,34 @@ where
     return_data_size
 }
 
+fn validate_returndata_copy_bounds(
+    return_data_len: usize,
+    data_offset: u32,
+    length: u32,
+) -> HostFunctionResult<(usize, usize)> {
+    let data_offset_usize = data_offset as usize;
+    let length_usize = length as usize;
+    let data_end = data_offset_usize.checked_add(length_usize).ok_or_else(|| {
+        crate::evm::error::out_of_bounds_error_with_function(
+            data_offset,
+            length,
+            "return_data_copy: return data offset overflow",
+            "return_data_copy",
+        )
+    })?;
+
+    if data_end > return_data_len {
+        return Err(crate::evm::error::out_of_bounds_error_with_function(
+            data_offset,
+            length,
+            "return_data_copy: return data out of bounds",
+            "return_data_copy",
+        ));
+    }
+
+    Ok((data_offset_usize, data_end))
+}
+
 /// Copy return data from the last call to memory
 /// Copies the return data from the last external call to the specified memory location
 ///
@@ -184,26 +212,57 @@ where
 
     // Get the return data from the evmhost
     let return_data = evmhost.return_data_copy();
-    let data_offset_usize = data_offset as usize;
-
-    // Prepare buffer for copying
-    let mut buffer = vec![0u8; length_u32 as usize];
-
-    // Copy from return data with bounds checking
-    let available_bytes = if data_offset_usize < return_data.len() {
-        return_data.len() - data_offset_usize
-    } else {
-        0
-    };
-
-    let copy_len = std::cmp::min(available_bytes, length_u32 as usize);
-    if copy_len > 0 {
-        buffer[..copy_len]
-            .copy_from_slice(&return_data[data_offset_usize..data_offset_usize + copy_len]);
-    }
+    let data_offset_u32 = data_offset as u32;
+    let (data_offset_usize, data_end) =
+        validate_returndata_copy_bounds(return_data.len(), data_offset_u32, length_u32)?;
 
     // Write the buffer to memory
-    memory.write_bytes(result_offset_u32, &buffer)?;
+    memory.write_bytes(result_offset_u32, &return_data[data_offset_usize..data_end])?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_returndata_copy_bounds;
+
+    #[test]
+    fn test_validate_returndata_copy_bounds_exact_end_ok() {
+        let (start, end) =
+            validate_returndata_copy_bounds(4, 2, 2).expect("bounds should be valid");
+        assert_eq!((start, end), (2, 4));
+    }
+
+    #[test]
+    fn test_validate_returndata_copy_bounds_oob_rejected() {
+        let err = validate_returndata_copy_bounds(4, 3, 2).expect_err("must fail");
+        assert_eq!(err.category(), "memory");
+        assert!(
+            err.message().contains("out of bounds"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_returndata_copy_bounds_overflow_rejected() {
+        let err = validate_returndata_copy_bounds(4, u32::MAX, 2).expect_err("must fail");
+        assert_eq!(err.category(), "memory");
+        assert!(
+            err.message().contains("offset overflow"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_validate_returndata_copy_bounds_zero_length_past_end_rejected() {
+        let err = validate_returndata_copy_bounds(4, 5, 0).expect_err("must fail");
+        assert_eq!(err.category(), "memory");
+        assert!(
+            err.message().contains("out of bounds"),
+            "unexpected error: {}",
+            err
+        );
+    }
 }

--- a/tests/evm_asm/returndatacopy_oob.easm
+++ b/tests/evm_asm/returndatacopy_oob.easm
@@ -1,0 +1,28 @@
+// RETURNDATACOPY out-of-bounds must fail per EIP-211.
+// Build a 1-byte return buffer via identity precompile (0x04),
+// then request offset=1, size=1 (1 + 1 > 1) to trigger failure.
+
+// input[0] = 0x42
+PUSH1 0x42
+PUSH1 0x00
+MSTORE8
+
+// CALL identity precompile with 1-byte input and 32-byte output area.
+// Stack order for CALL: gas, addr, value, argsOffset, argsSize, retOffset, retSize
+PUSH1 0x20
+PUSH1 0x80
+PUSH1 0x01
+PUSH1 0x00
+PUSH1 0x00
+PUSH1 0x04
+PUSH4 0x100000
+CALL
+POP
+
+// RETURNDATACOPY(dst=0, offset=1, size=1) -> out-of-bounds
+PUSH1 0x01
+PUSH1 0x01
+PUSH1 0x00
+RETURNDATACOPY
+
+STOP

--- a/tests/evm_asm/returndatacopy_oob.expected
+++ b/tests/evm_asm/returndatacopy_oob.expected
@@ -1,0 +1,8 @@
+status: invalid memory access
+error_code: 9
+stack: []
+memory: ''
+storage: {}
+transient_storage: {}
+return: ''
+events: []


### PR DESCRIPTION
Reject RETURNDATACOPY when offset+size exceeds return-data length (or overflows) to match interpreter semantics, and add an OOB regression case for invalid memory access.

Made-with: Cursor

<!-- Thank you for contributing to DTVM!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.

-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    lib/wasi,
    smart_ir/src/abi
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```