### PR TITLE
fix(evm): reject transactions from senders with deployed code (EIP-3607) #486

### DIFF
--- a/src/cli/dtvm.cpp
+++ b/src/cli/dtvm.cpp
@@ -384,6 +384,26 @@ int main(int argc, char *argv[]) {
                                .ContractAddress = ContractAddress};
     evmc_message Msg = createEvmMessage(MockedHost, MsgConfig, Bytecode);
 
+    // EIP-3607 (London+): Reject transactions from senders with deployed code.
+    // A sender with non-empty code is a contract, not an EOA, unless the code
+    // is an EIP-7702 delegation designator (0xef0100...).
+    if (EvmRevision >= EVMC_LONDON) {
+      auto SenderIt = MockedHost.accounts.find(Msg.sender);
+      if (SenderIt != MockedHost.accounts.end() &&
+          !SenderIt->second.code.empty()) {
+        const auto &SenderCode = SenderIt->second.code;
+        constexpr uint8_t DELEGATION_MAGIC[] = {0xef, 0x01, 0x00};
+        bool IsDelegated = SenderCode.size() >= sizeof(DELEGATION_MAGIC) &&
+                           std::memcmp(SenderCode.data(), DELEGATION_MAGIC,
+                                       sizeof(DELEGATION_MAGIC)) == 0;
+        if (!IsDelegated) {
+          ZEN_LOG_ERROR("sender not an EOA: sender account has deployed code "
+                        "(EIP-3607)");
+          return exitMain(EXIT_FAILURE, RT.get());
+        }
+      }
+    }
+
     // Deduct intrinsic gas before EVM execution.
     const int64_t IntrinsicGas = zen::utils::computeIntrinsicGas(
         EvmRevision, MsgKind, Msg.input_data, Msg.input_size);

--- a/src/cli/dtvm.cpp
+++ b/src/cli/dtvm.cpp
@@ -11,6 +11,7 @@
 #include "tests/evm_test_host.hpp"
 #include "utils/evm.h"
 #endif // ZEN_ENABLE_EVM
+#include <cstring>
 #include <unistd.h>
 
 #ifdef ZEN_ENABLE_BUILTIN_WASI
@@ -386,16 +387,21 @@ int main(int argc, char *argv[]) {
 
     // EIP-3607 (London+): Reject transactions from senders with deployed code.
     // A sender with non-empty code is a contract, not an EOA, unless the code
-    // is an EIP-7702 delegation designator (0xef0100...).
+    // is an EIP-7702 delegation designator (0xef0100...) on Prague+.
     if (EvmRevision >= EVMC_LONDON) {
       auto SenderIt = MockedHost.accounts.find(Msg.sender);
       if (SenderIt != MockedHost.accounts.end() &&
           !SenderIt->second.code.empty()) {
-        const auto &SenderCode = SenderIt->second.code;
-        constexpr uint8_t DELEGATION_MAGIC[] = {0xef, 0x01, 0x00};
-        bool IsDelegated = SenderCode.size() >= sizeof(DELEGATION_MAGIC) &&
-                           std::memcmp(SenderCode.data(), DELEGATION_MAGIC,
-                                       sizeof(DELEGATION_MAGIC)) == 0;
+        // EIP-7702 delegation designator exemption is only valid on Prague+,
+        // where delegation is actually supported.
+        bool IsDelegated = false;
+        if (EvmRevision >= EVMC_PRAGUE) {
+          const auto &SenderCode = SenderIt->second.code;
+          constexpr uint8_t DELEGATION_MAGIC[] = {0xef, 0x01, 0x00};
+          IsDelegated = SenderCode.size() >= sizeof(DELEGATION_MAGIC) &&
+                        std::memcmp(SenderCode.data(), DELEGATION_MAGIC,
+                                    sizeof(DELEGATION_MAGIC)) == 0;
+        }
         if (!IsDelegated) {
           ZEN_LOG_ERROR("sender not an EOA: sender account has deployed code "
                         "(EIP-3607)");


### PR DESCRIPTION
Add EIP-3607 check in CLI EVM execution path to reject transactions whose sender account has non-empty code (i.e., is a contract, not an EOA). The check is active for London+ revisions and correctly exempts EIP-7702 delegation designators (0xef0100 prefix).

This aligns DTVM CLI behavior with evmone-t8n and the Ethereum specification, which requires transaction-layer rejection before any EVM execution takes place.

Closes #486

<!-- Thank you for contributing to DTVM!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.

-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    lib/wasi,
    smart_ir/src/abi
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```