### PR TITLE
docs(other): archive 2026-05-15-fetchcontent-cache

### DIFF
--- a/docs/_archive/2026-05/2026-05-15-fetchcontent-cache/README.md
+++ b/docs/_archive/2026-05/2026-05-15-fetchcontent-cache/README.md
@@ -1,6 +1,6 @@
 # Change: actions/cache for FetchContent on DTVM CI
 
-- **Status**: Proposed
+- **Status**: Implemented
 - **Date**: 2026-05-15
 - **Tier**: Light
 - **Branch**: ci/fetchcontent-cache (continues commit `96707a2`)

--- a/docs/_archive/README.md
+++ b/docs/_archive/README.md
@@ -25,6 +25,7 @@ All entries follow the `YYYY-MM/short-name/` convention, grouped by the month th
 | 2026-02 | add-jit-suitability-checker| JIT suitability checker for EVM      |
 | 2026-03 | add-evm-jit-fallback       | EVM JIT fallback mechanism           |
 | 2026-04 | update-evm-memory-block-precheck | EVM block-local memory precheck optimization |
+| 2026-05 | 2026-05-15-fetchcontent-cache | actions/cache for FetchContent + boost mirror swap |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Archive the change-doc for the `actions/cache` FetchContent work — PR #508 (mergeCommit `7a4d2a5`, merged 2026-05-15).

- Status: `Proposed` → `Implemented`
- Move: `docs/changes/2026-05-15-fetchcontent-cache/` → `docs/_archive/2026-05/2026-05-15-fetchcontent-cache/`
- Add the matching row to `docs/_archive/README.md`

Follows the `archive` skill convention. No code or workflow changes.

## Test plan

- [x] PR #508 merged into main (verified by `gh pr view`)
- [x] All 16 CI checks on #508 were SUCCESS (both cold-cache and warm-cache runs)
- [x] No module specs touched (CI infra change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)