### PR TITLE
fix(evm): preserve return data after successful CREATE/CREATE2

### DIFF
--- a/src/evm/opcode_handlers.cpp
+++ b/src/evm/opcode_handlers.cpp
@@ -1239,13 +1239,13 @@ void CreateHandler::doExecute() {
   }
   Context->getInstance()->addGasRefund(Result.gas_refund);
 
+  // Always set return data from the host result, matching CALL handler
+  // behavior and EVM spec (EIP-211: RETURNDATA should reflect last sub-call).
+  Context->setReturnData(std::vector<uint8_t>(
+      Result.output_data, Result.output_data + Result.output_size));
   if (Result.status_code == EVMC_SUCCESS) {
-    Context->setReturnData(std::vector<uint8_t>());
     Frame->pop(); // pop the assume value
     Frame->push(intx::be::load<intx::uint256>(Result.create_address));
-  } else {
-    Context->setReturnData(std::vector<uint8_t>(
-        Result.output_data, Result.output_data + Result.output_size));
   }
   Context->setStatus(EVMC_SUCCESS);
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `CreateHandler::doExecute()` in `src/evm/opcode_handlers.cpp` cleared the return data buffer on CREATE success (`setReturnData({})`), violating EIP-211 which requires `RETURNDATA` to always reflect the output of the most recent external call
- The `CallHandler` already preserved return data unconditionally; this aligns CREATE/CREATE2 with the same pattern
- Without this fix, `RETURNDATASIZE` / `RETURNDATACOPY` after a successful CREATE observes an empty buffer, causing cascading mismatches against evmone

## Changes

**`src/evm/opcode_handlers.cpp`** (4 lines changed):
- Move `setReturnData(Result.output_data, ...)` **before** the status-code check so it executes unconditionally (matching the CALL handler)
- Remove the now-dead `else` branch that only set return data on failure

```diff
+  // Always set return data from the host result, matching CALL handler
+  // behavior and EVM spec (EIP-211: RETURNDATA should reflect last sub-call).
+  Context->setReturnData(std::vector<uint8_t>(
+      Result.output_data, Result.output_data + Result.output_size));
   if (Result.status_code == EVMC_SUCCESS) {
-    Context->setReturnData(std::vector<uint8_t>());
     Frame->pop();
     Frame->push(intx::be::load<intx::uint256>(Result.create_address));
-  } else {
-    Context->setReturnData(std::vector<uint8_t>(
-        Result.output_data, Result.output_data + Result.output_size));
   }
```

## Test plan

- [x] Reproduced all 31 fuzz crashes (`evmone-fuzzer` interpreter mode) before fix
- [x] Verified all 31 crashes pass (exit 0) after fix, covering 7 assertion types:
  - `gas_left` mismatch (14)
  - `status` mismatch (3) — RETURNDATACOPY OOB on empty buffer → EVMC_FAILURE
  - `uint256 value` mismatch (7) — cascading stack divergence
  - `create2_salt` mismatch (3) — cascading stack divergence
  - `m1.gas` mismatch (2)
  - `recorded_calls.size()` mismatch (1)
  - `recorded_logs` mismatch (1)
- [ ] Existing evmone unit tests (`EVMOneInterpreterUnitTestsRunList.txt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)