### PR TITLE
feat(compiler): add EVM arithmetic fast-path hit counters

### DIFF
--- a/docs/changes/2026-05-29-evm-arith-fastpath-counters/README.md
+++ b/docs/changes/2026-05-29-evm-arith-fastpath-counters/README.md
@@ -1,0 +1,61 @@
+# Change: Arithmetic fast-path hit counters for the EVM MIR builder
+
+- **Status**: Implemented
+- **Date**: 2026-05-29
+- **Tier**: Light
+
+## Overview
+
+Add compile-time hit counters for the u256 arithmetic fast paths (ADD, SUB,
+MUL, DIV, MOD), so the value-range / u64-fast-path effort becomes measurable.
+Each opcode gets a `{FastRangeU64, FastConstU64, Full}` counter triple,
+incremented at the corresponding lowering return site and emitted as an
+`[EVM-ARITH-SUMMARY]` line, mirroring the existing `[EVM-MEM-SUMMARY]`
+memory-stats mechanism.
+
+## Motivation
+
+The u256 fast-path audit (2026-05-29) found that **no** arithmetic fast-path hit
+is instrumented today: `MemoryCompileStats` is entirely memory-domain, and the
+similarly-named `LinearU64*FastPathCount` fields are MLOAD/MSTORE address fast
+paths — a naming trap, not arithmetic. With neither a numerator (sites that hit
+the narrow path) nor a denominator (total sites lowered), every claim about
+which arithmetic paths "fire often" is currently a guess. Instrumentation is the
+prerequisite for prioritizing and defending the result-range narrowing (DIV/MOD
+u64, ADDMOD, MUL) and U128-consumer work.
+
+## Impact
+
+- Module: `src/compiler/evm_frontend` — `MemoryCompileStats` (counter fields),
+  `handleBinaryArithmetic` (ADD/SUB, header), `handleMul`/`handleDiv`/`handleMod`
+  (`.cpp`), `hasMemoryCompileStats`, `dumpMemoryCompileStats`.
+- Counter triples: ADD/MUL/DIV/MOD get `FastRangeU64` (non-const `bothFitU64`
+  path), `FastConstU64` (`isConstU64` path), `Full` (multi-limb fallback); SUB
+  gets `FastConstU64` + `Full` (no range path exists for SUB).
+- All increments are wrapped in `#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING`, so
+  the default and CI builds compile them out — **zero runtime/codegen impact**.
+  No change to lowering or results in any build.
+- Measurement requires a `-DZEN_ENABLE_JIT_LOGGING=ON` build; the
+  summary is logged via `ZEN_LOG_DEBUG`.
+
+## Checklist
+
+- [x] Implementation complete (14 counters; 17 `#ifdef`-gated increment sites;
+      `[EVM-ARITH-SUMMARY]` dump; `hasMemoryCompileStats` extended)
+- [x] Tests added/updated — covered by regression; no new unit test (counters
+      are macro-gated diagnostics with no codegen/behavior change)
+- [x] Module specs in `docs/modules/` updated (if affected) — none affected
+- [x] Build and tests pass — default (logging OFF) build: multipass
+      `evmone-unittests` 223/223, `evmone-statetest -k fork_Cancun` 2723/2723.
+      Logging build (`build-arithlog/`, `-DZEN_ENABLE_JIT_LOGGING=ON`) emits
+      `[EVM-ARITH-SUMMARY] ... add_fast_const_u64=1 ... mul_fast_const_u64=1
+      ... div_fast_const_u64=1 ... mod_fast_const_u64=1 ...` (non-zero).
+
+## Notes
+
+- The CMake option that defines the `ZEN_ENABLE_MULTIPASS_JIT_LOGGING` macro is
+  `ZEN_ENABLE_JIT_LOGGING` (`src/CMakeLists.txt:119`). `ZEN_LOG_DEBUG` is
+  surfaced via the `dtvm` CLI `--log-level debug`; the evmone EVMC path installs
+  no logger.
+- `build-arithlog/` (Ninja, logging ON) is retained for measurement reuse by the
+  result-range narrowing and U128 tasks.

--- a/docs/changes/2026-05-29-evm-arith-fastpath-counters/README.md
+++ b/docs/changes/2026-05-29-evm-arith-fastpath-counters/README.md
@@ -28,20 +28,25 @@ u64, ADDMOD, MUL) and U128-consumer work.
 
 - Module: `src/compiler/evm_frontend` — `MemoryCompileStats` (counter fields),
   `handleBinaryArithmetic` (ADD/SUB, header), `handleMul`/`handleDiv`/`handleMod`
-  (`.cpp`), `hasMemoryCompileStats`, `dumpMemoryCompileStats`.
+  (`.cpp`), `hasArithCompileStats` (new, arith-domain gate), `dumpMemoryCompileStats`.
 - Counter triples: ADD/MUL/DIV/MOD get `FastRangeU64` (non-const `bothFitU64`
   path), `FastConstU64` (`isConstU64` path), `Full` (multi-limb fallback); SUB
   gets `FastConstU64` + `Full` (no range path exists for SUB).
 - All increments are wrapped in `#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING`, so
-  the default and CI builds compile them out — **zero runtime/codegen impact**.
-  No change to lowering or results in any build.
+  the default and CI builds compile them out — **no change to lowering,
+  generated code, or execution results in any build**. The counter fields
+  themselves are always present in the transient per-compile
+  `MemoryCompileStats`, so the only unconditional cost is a small fixed
+  increase in that diagnostic struct's size (no effect on generated code,
+  runtime EVM state, or any public ABI).
 - Measurement requires a `-DZEN_ENABLE_JIT_LOGGING=ON` build; the
   summary is logged via `ZEN_LOG_DEBUG`.
 
 ## Checklist
 
 - [x] Implementation complete (14 counters; 17 `#ifdef`-gated increment sites;
-      `[EVM-ARITH-SUMMARY]` dump; `hasMemoryCompileStats` extended)
+      `[EVM-ARITH-SUMMARY]` dump gated by a dedicated `hasArithCompileStats`,
+      keeping `hasMemoryCompileStats` memory-domain-only)
 - [x] Tests added/updated — covered by regression; no new unit test (counters
       are macro-gated diagnostics with no codegen/behavior change)
 - [x] Module specs in `docs/modules/` updated (if affected) — none affected

--- a/docs/changes/2026-05-29-u256-u128-consumer-fastpath/README.md
+++ b/docs/changes/2026-05-29-u256-u128-consumer-fastpath/README.md
@@ -1,0 +1,62 @@
+# Change: U128 consumer fast-path — measurement and decision (de-scoped)
+
+- **Status**: Implemented (measurement + decision; no consumer fast path added)
+- **Date**: 2026-05-29
+- **Tier**: Light
+
+## Overview
+
+The audit recommended adding U128 half-width consumer fast paths (e.g. 128×128→256
+MUL, 128/64 DIV) only after counters prove that analyzer-proven `U128` operands
+actually reach those consumers at hot sites. This change adds the measurement
+instrumentation, runs it, and records the data-driven decision: **do not add the
+U128 consumer fast paths now** — the opportunity essentially never occurs.
+
+## Motivation
+
+The u256 fast-path audit (2026-05-29) found the `U128` lattice tier "nearly
+inert — only AND consumes a proven-U128 operand". A U128 half-width MUL/DIV/MOD
+path is a larger change with real multi-limb half-width correctness surface, so
+the audit's priority ranking placed it last, gated on empirical confirmation.
+
+## Instrumentation added
+
+`MemoryCompileStats` gains `MulU128OpportunityCount` / `DivU128OpportunityCount`
+/ `ModU128OpportunityCount` (`evm_mir_compiler.h:1290-1292`), incremented at the
+full-limb fallback of `handleMul` / `handleDiv` / `handleMod`
+(`evm_mir_compiler.cpp:1984 / 2149 / 2280`) when one operand has proven range
+`U128` and the other is `<= U128` — i.e. a half-width path could have applied.
+All `#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING`-gated (zero default-build impact);
+reported in `[EVM-ARITH-SUMMARY]`.
+
+## Measurement (logging build, `build-arithlog/`)
+
+| Workload | mul_u128_opp | div_u128_opp | mod_u128_opp |
+|---|---|---|---|
+| snailtracer | 0 | 0 | 0 |
+| blake2b_shifts | 0 | 0 | 0 |
+| weierstrudel | 0 | 0 | 0 |
+| swap_math | 0 | 0 | 0 |
+| sha1_divs | 1 | 0 | 0 |
+| 10 micro benchmarks (incl. narrow_compare_u128 / _u64) | 0 | 0 | 0 |
+
+Totals across 15 workloads: **mul = 1, div = 0, mod = 0.** Even
+`narrow_compare_u128`, which explicitly produces U128 ranges, shows 0 — those
+U128 values feed comparisons, not arithmetic.
+
+## Decision: de-scope
+
+A proven-`U128` operand reaches a MUL/DIV/MOD full-limb fallback exactly once
+across all workloads; DIV/MOD never. A U128 half-width consumer fast path would
+not pay off, confirming the audit's static finding (only AND consumes a
+proven-U128 operand today). The instrumentation is retained so the decision can
+be revisited if future workloads change the picture.
+
+## Checklist
+
+- [x] Implementation complete (measurement instrumentation; no consumer path)
+- [x] Tests added/updated — covered by regression; counters are macro-gated
+- [x] Module specs in `docs/modules/` updated (if affected) — none affected
+- [x] Build and tests pass — default (logging OFF) multipass `evmone-unittests`
+      223/223, `evmone-statetest -k fork_Cancun` 2723/2723; logging build emits
+      the `*_u128_opportunity` counts above.

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -1894,6 +1894,9 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleMul(Operand MultiplicandOp,
     MInstruction *MulLo = createEvmUmul128(A[0], B[0]);
     MInstruction *MulHi = createEvmUmul128Hi(MulLo);
     U256Inst Result = {MulLo, MulHi, Zero, Zero};
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+    ++MemStats.MulFastRangeU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
     return Operand(Result, EVMType::UINT256, ValueRange::U128);
   }
 
@@ -1965,10 +1968,23 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleMul(Operand MultiplicandOp,
     R3 = addTermNoCarry(R3, C2);
 
     U256Inst Result = {R0, R1, R2, R3};
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+    ++MemStats.MulFastConstU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
     return Operand(Result, EVMType::UINT256);
   }
 
   // General case: use EvmU256MulInstruction for full 4x4 multiplication
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+  {
+    ValueRange RA = MultiplicandOp.getRange();
+    ValueRange RB = MultiplierOp.getRange();
+    if ((RA == ValueRange::U128 && RB <= ValueRange::U128) ||
+        (RB == ValueRange::U128 && RA <= ValueRange::U128)) {
+      ++MemStats.MulU128OpportunityCount;
+    }
+  }
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
   U256Inst A = extractU256Operand(MultiplicandOp);
   U256Inst B = extractU256Operand(MultiplierOp);
   MType *I64Type = &Ctx.I64Type;
@@ -1982,6 +1998,9 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleMul(Operand MultiplicandOp,
                          false, I64Type, MulInst, 2),
                      createInstruction<EvmU256MulResultInstruction>(
                          false, I64Type, MulInst, 3)};
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+  ++MemStats.MulFullCount;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
   return Operand(Result, EVMType::UINT256);
 }
 
@@ -2032,6 +2051,9 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleDiv(Operand DividendOp,
         false, I64Type, IsZero, Zero, Quotient);
 
     U256Inst Result = {DivResult, Zero, Zero, Zero};
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+    ++MemStats.DivFastRangeU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
     return Operand(Result, EVMType::UINT256, ValueRange::U64);
   }
 
@@ -2096,8 +2118,14 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleDiv(Operand DividendOp,
         addSuccessor(AfterBB);
 
         setInsertBlock(AfterBB);
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+        ++MemStats.DivFastConstU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
         return Operand(loadResult(), EVMType::UINT256);
       }
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+      ++MemStats.DivFastConstU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
       return handleDivU64Divisor(DividendOp, D);
     }
   }
@@ -2105,9 +2133,23 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleDiv(Operand DividendOp,
   // u64 dividend: OR-fold + select
   if (DividendOp.isConstU64()) {
     uint64_t A = DividendOp.getConstValue()[0];
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+    ++MemStats.DivFastConstU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
     return handleDivU64Dividend(A, DivisorOp);
   }
 
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+  ++MemStats.DivFullCount;
+  {
+    ValueRange RA = DividendOp.getRange();
+    ValueRange RB = DivisorOp.getRange();
+    if ((RA == ValueRange::U128 && RB <= ValueRange::U128) ||
+        (RB == ValueRange::U128 && RA <= ValueRange::U128)) {
+      ++MemStats.DivU128OpportunityCount;
+    }
+  }
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
   return handleDivModGeneral(DividendOp, DivisorOp, /*WantQuotient=*/true);
 }
 
@@ -2202,22 +2244,43 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleMod(Operand DividendOp,
         false, I64Type, IsZero, Zero, Remainder);
 
     U256Inst Result = {ModResult, Zero, Zero, Zero};
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+    ++MemStats.ModFastRangeU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
     return Operand(Result, EVMType::UINT256, ValueRange::U64);
   }
 
   // u64 divisor: inline cascading 128/64 mod
   if (DivisorOp.isConstU64()) {
     uint64_t D = DivisorOp.getConstValue()[0];
-    if (D != 0)
+    if (D != 0) {
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+      ++MemStats.ModFastConstU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
       return handleModU64Divisor(DividendOp, D);
+    }
   }
 
   // u64 dividend: OR-fold + select
   if (DividendOp.isConstU64()) {
     uint64_t A = DividendOp.getConstValue()[0];
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+    ++MemStats.ModFastConstU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
     return handleModU64Dividend(A, DivisorOp);
   }
 
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+  ++MemStats.ModFullCount;
+  {
+    ValueRange RA = DividendOp.getRange();
+    ValueRange RB = DivisorOp.getRange();
+    if ((RA == ValueRange::U128 && RB <= ValueRange::U128) ||
+        (RB == ValueRange::U128 && RA <= ValueRange::U128)) {
+      ++MemStats.ModU128OpportunityCount;
+    }
+  }
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
   return handleDivModGeneral(DividendOp, DivisorOp, /*WantQuotient=*/false);
 }
 
@@ -6158,7 +6221,19 @@ bool EVMMirBuilder::hasMemoryCompileStats() const {
          MemStats.HashPrepLiftSimCandidateRegionCount != 0 ||
          MemStats.HashPrepMarkerCandidateRegionCount != 0 ||
          MemStats.HashPrepMarkerMarkedRegionCount != 0 ||
-         MemStats.HashPrepMarkerRejectedRegionCount != 0;
+         MemStats.HashPrepMarkerRejectedRegionCount != 0 ||
+         MemStats.AddFastRangeU64Count != 0 ||
+         MemStats.AddFastConstU64Count != 0 || MemStats.AddFullCount != 0 ||
+         MemStats.SubFastConstU64Count != 0 || MemStats.SubFullCount != 0 ||
+         MemStats.MulFastRangeU64Count != 0 ||
+         MemStats.MulFastConstU64Count != 0 || MemStats.MulFullCount != 0 ||
+         MemStats.DivFastRangeU64Count != 0 ||
+         MemStats.DivFastConstU64Count != 0 || MemStats.DivFullCount != 0 ||
+         MemStats.ModFastRangeU64Count != 0 ||
+         MemStats.ModFastConstU64Count != 0 || MemStats.ModFullCount != 0 ||
+         MemStats.MulU128OpportunityCount != 0 ||
+         MemStats.DivU128OpportunityCount != 0 ||
+         MemStats.ModU128OpportunityCount != 0;
 }
 
 void EVMMirBuilder::noteBlockMemoryEventPC(uint64_t PC) {
@@ -6580,6 +6655,32 @@ void EVMMirBuilder::dumpMemoryCompileStats() const {
           MemStats.HashPrepMarkerRejectedPointerInstability),
       static_cast<unsigned long long>(
           MemStats.HashPrepMarkerRejectedUnknownHelper));
+
+  ZEN_LOG_DEBUG(
+      "[EVM-ARITH-SUMMARY] add_fast_range_u64=%llu add_fast_const_u64=%llu "
+      "add_full=%llu sub_fast_const_u64=%llu sub_full=%llu "
+      "mul_fast_range_u64=%llu mul_fast_const_u64=%llu mul_full=%llu "
+      "div_fast_range_u64=%llu div_fast_const_u64=%llu div_full=%llu "
+      "mod_fast_range_u64=%llu mod_fast_const_u64=%llu mod_full=%llu "
+      "mul_u128_opportunity=%llu div_u128_opportunity=%llu "
+      "mod_u128_opportunity=%llu",
+      static_cast<unsigned long long>(MemStats.AddFastRangeU64Count),
+      static_cast<unsigned long long>(MemStats.AddFastConstU64Count),
+      static_cast<unsigned long long>(MemStats.AddFullCount),
+      static_cast<unsigned long long>(MemStats.SubFastConstU64Count),
+      static_cast<unsigned long long>(MemStats.SubFullCount),
+      static_cast<unsigned long long>(MemStats.MulFastRangeU64Count),
+      static_cast<unsigned long long>(MemStats.MulFastConstU64Count),
+      static_cast<unsigned long long>(MemStats.MulFullCount),
+      static_cast<unsigned long long>(MemStats.DivFastRangeU64Count),
+      static_cast<unsigned long long>(MemStats.DivFastConstU64Count),
+      static_cast<unsigned long long>(MemStats.DivFullCount),
+      static_cast<unsigned long long>(MemStats.ModFastRangeU64Count),
+      static_cast<unsigned long long>(MemStats.ModFastConstU64Count),
+      static_cast<unsigned long long>(MemStats.ModFullCount),
+      static_cast<unsigned long long>(MemStats.MulU128OpportunityCount),
+      static_cast<unsigned long long>(MemStats.DivU128OpportunityCount),
+      static_cast<unsigned long long>(MemStats.ModU128OpportunityCount));
 #endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
 }
 

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -6221,8 +6221,11 @@ bool EVMMirBuilder::hasMemoryCompileStats() const {
          MemStats.HashPrepLiftSimCandidateRegionCount != 0 ||
          MemStats.HashPrepMarkerCandidateRegionCount != 0 ||
          MemStats.HashPrepMarkerMarkedRegionCount != 0 ||
-         MemStats.HashPrepMarkerRejectedRegionCount != 0 ||
-         MemStats.AddFastRangeU64Count != 0 ||
+         MemStats.HashPrepMarkerRejectedRegionCount != 0;
+}
+
+bool EVMMirBuilder::hasArithCompileStats() const {
+  return MemStats.AddFastRangeU64Count != 0 ||
          MemStats.AddFastConstU64Count != 0 || MemStats.AddFullCount != 0 ||
          MemStats.SubFastConstU64Count != 0 || MemStats.SubFullCount != 0 ||
          MemStats.MulFastRangeU64Count != 0 ||
@@ -6464,7 +6467,7 @@ void EVMMirBuilder::noteKeccak256MemoryAccess(bool OffsetWasConstU64,
 }
 
 void EVMMirBuilder::dumpMemoryCompileStats() const {
-  if (!hasMemoryCompileStats()) {
+  if (!hasMemoryCompileStats() && !hasArithCompileStats()) {
     return;
   }
 
@@ -6656,31 +6659,33 @@ void EVMMirBuilder::dumpMemoryCompileStats() const {
       static_cast<unsigned long long>(
           MemStats.HashPrepMarkerRejectedUnknownHelper));
 
-  ZEN_LOG_DEBUG(
-      "[EVM-ARITH-SUMMARY] add_fast_range_u64=%llu add_fast_const_u64=%llu "
-      "add_full=%llu sub_fast_const_u64=%llu sub_full=%llu "
-      "mul_fast_range_u64=%llu mul_fast_const_u64=%llu mul_full=%llu "
-      "div_fast_range_u64=%llu div_fast_const_u64=%llu div_full=%llu "
-      "mod_fast_range_u64=%llu mod_fast_const_u64=%llu mod_full=%llu "
-      "mul_u128_opportunity=%llu div_u128_opportunity=%llu "
-      "mod_u128_opportunity=%llu",
-      static_cast<unsigned long long>(MemStats.AddFastRangeU64Count),
-      static_cast<unsigned long long>(MemStats.AddFastConstU64Count),
-      static_cast<unsigned long long>(MemStats.AddFullCount),
-      static_cast<unsigned long long>(MemStats.SubFastConstU64Count),
-      static_cast<unsigned long long>(MemStats.SubFullCount),
-      static_cast<unsigned long long>(MemStats.MulFastRangeU64Count),
-      static_cast<unsigned long long>(MemStats.MulFastConstU64Count),
-      static_cast<unsigned long long>(MemStats.MulFullCount),
-      static_cast<unsigned long long>(MemStats.DivFastRangeU64Count),
-      static_cast<unsigned long long>(MemStats.DivFastConstU64Count),
-      static_cast<unsigned long long>(MemStats.DivFullCount),
-      static_cast<unsigned long long>(MemStats.ModFastRangeU64Count),
-      static_cast<unsigned long long>(MemStats.ModFastConstU64Count),
-      static_cast<unsigned long long>(MemStats.ModFullCount),
-      static_cast<unsigned long long>(MemStats.MulU128OpportunityCount),
-      static_cast<unsigned long long>(MemStats.DivU128OpportunityCount),
-      static_cast<unsigned long long>(MemStats.ModU128OpportunityCount));
+  if (hasArithCompileStats()) {
+    ZEN_LOG_DEBUG(
+        "[EVM-ARITH-SUMMARY] add_fast_range_u64=%llu add_fast_const_u64=%llu "
+        "add_full=%llu sub_fast_const_u64=%llu sub_full=%llu "
+        "mul_fast_range_u64=%llu mul_fast_const_u64=%llu mul_full=%llu "
+        "div_fast_range_u64=%llu div_fast_const_u64=%llu div_full=%llu "
+        "mod_fast_range_u64=%llu mod_fast_const_u64=%llu mod_full=%llu "
+        "mul_u128_opportunity=%llu div_u128_opportunity=%llu "
+        "mod_u128_opportunity=%llu",
+        static_cast<unsigned long long>(MemStats.AddFastRangeU64Count),
+        static_cast<unsigned long long>(MemStats.AddFastConstU64Count),
+        static_cast<unsigned long long>(MemStats.AddFullCount),
+        static_cast<unsigned long long>(MemStats.SubFastConstU64Count),
+        static_cast<unsigned long long>(MemStats.SubFullCount),
+        static_cast<unsigned long long>(MemStats.MulFastRangeU64Count),
+        static_cast<unsigned long long>(MemStats.MulFastConstU64Count),
+        static_cast<unsigned long long>(MemStats.MulFullCount),
+        static_cast<unsigned long long>(MemStats.DivFastRangeU64Count),
+        static_cast<unsigned long long>(MemStats.DivFastConstU64Count),
+        static_cast<unsigned long long>(MemStats.DivFullCount),
+        static_cast<unsigned long long>(MemStats.ModFastRangeU64Count),
+        static_cast<unsigned long long>(MemStats.ModFastConstU64Count),
+        static_cast<unsigned long long>(MemStats.ModFullCount),
+        static_cast<unsigned long long>(MemStats.MulU128OpportunityCount),
+        static_cast<unsigned long long>(MemStats.DivU128OpportunityCount),
+        static_cast<unsigned long long>(MemStats.ModU128OpportunityCount));
+  }
 #endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
 }
 

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -390,6 +390,9 @@ public:
             false, CmpInstruction::ICMP_ULT, MirI64Type, Sum, LHS[0]);
         MInstruction *CarryExt = zeroExtendToI64(CarryCmp);
         U256Inst Result = {Sum, CarryExt, Zero, Zero};
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+        ++MemStats.AddFastRangeU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
         return Operand(Result, EVMType::UINT256, ValueRange::U128);
       }
     }
@@ -402,6 +405,9 @@ public:
         // ADD is commutative: normalize so the u64 const is on the RHS
         const Operand &FullOp = LHSIsU64 ? RHSOp : LHSOp;
         const Operand &U64Op = LHSIsU64 ? LHSOp : RHSOp;
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+        ++MemStats.AddFastConstU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
         return handleAddU64Const(FullOp, U64Op);
       }
     }
@@ -409,6 +415,9 @@ public:
     // Phase 2: u64 fast path for SUB (only when RHS is u64 const)
     if constexpr (Operator == BinaryOperator::BO_SUB) {
       if (RHSOp.isConstU64()) {
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+        ++MemStats.SubFastConstU64Count;
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
         return handleSubU64Const(LHSOp, RHSOp);
       }
     }
@@ -473,6 +482,13 @@ public:
     } else {
       ZEN_ASSERT_TODO();
     }
+#ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
+    if constexpr (Operator == BinaryOperator::BO_ADD) {
+      ++MemStats.AddFullCount;
+    } else if constexpr (Operator == BinaryOperator::BO_SUB) {
+      ++MemStats.SubFullCount;
+    }
+#endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
     return Operand(Result, EVMType::UINT256);
   }
 
@@ -1250,6 +1266,30 @@ private:
     uint64_t HashPrepMarkerRejectedGasMemorySemantics = 0;
     uint64_t HashPrepMarkerRejectedPointerInstability = 0;
     uint64_t HashPrepMarkerRejectedUnknownHelper = 0;
+
+    // Arithmetic fast-path tier hit counters. Increments are gated by
+    // ZEN_ENABLE_MULTIPASS_JIT_LOGGING; the fields always exist.
+    uint64_t AddFastRangeU64Count = 0;
+    uint64_t AddFastConstU64Count = 0;
+    uint64_t AddFullCount = 0;
+    uint64_t SubFastConstU64Count = 0;
+    uint64_t SubFullCount = 0;
+    uint64_t MulFastRangeU64Count = 0;
+    uint64_t MulFastConstU64Count = 0;
+    uint64_t MulFullCount = 0;
+    uint64_t DivFastRangeU64Count = 0;
+    uint64_t DivFastConstU64Count = 0;
+    uint64_t DivFullCount = 0;
+    uint64_t ModFastRangeU64Count = 0;
+    uint64_t ModFastConstU64Count = 0;
+    uint64_t ModFullCount = 0;
+
+    // U128-consumer opportunity counters: incremented on the genuine
+    // full-limb fallback when one operand has proven range U128 and the
+    // other is <= U128, i.e. a 128-bit half-width path could have applied.
+    uint64_t MulU128OpportunityCount = 0;
+    uint64_t DivU128OpportunityCount = 0;
+    uint64_t ModU128OpportunityCount = 0;
   };
   bool hasMemoryCompileStats() const;
   MemoryCompileStats MemStats;

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -1292,6 +1292,7 @@ private:
     uint64_t ModU128OpportunityCount = 0;
   };
   bool hasMemoryCompileStats() const;
+  bool hasArithCompileStats() const;
   MemoryCompileStats MemStats;
 
   struct MemoryBlockCompileStats {


### PR DESCRIPTION
## What

Instrument the u256 arithmetic lowering tiers so fast-path hit rates become
measurable. `ADD`/`SUB`/`MUL`/`DIV`/`MOD` each get a
`{FastRangeU64, FastConstU64, Full}` counter triple (`SUB` has no range tier),
plus `MUL`/`DIV`/`MOD` U128-consumer-opportunity counters that fire on the
full-limb fallback when a proven-`U128` operand meets a `<= U128` operand — i.e.
where a 128-bit half-width path could have applied. Counters are emitted as an
`[EVM-ARITH-SUMMARY]` line mirroring the existing `[EVM-MEM-SUMMARY]` mechanism.

## Zero default-build impact

All increments and the dump are gated by `ZEN_ENABLE_MULTIPASS_JIT_LOGGING`
(enabled by the `-DZEN_ENABLE_JIT_LOGGING=ON` CMake option). The struct fields
always exist; the default and CI builds compile the instrumentation to a no-op.

## Result

The U128-opportunity measurement found the half-width consumer path occurs
almost never (mul=1, div=0, mod=0 across 15 workloads), so it is deliberately
not added — recorded as a data-driven decision.

## Testing (local, this branch)

Builds in both the default config and `-DZEN_ENABLE_JIT_LOGGING=ON`;
`tools/format.sh check` clean. Pure diagnostics — no behavior change, no new
runtime tests.

See `docs/changes/2026-05-29-evm-arith-fastpath-counters/` and
`docs/changes/2026-05-29-u256-u128-consumer-fastpath/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
