### PR TITLE
test(evm): add value-range lowering differential harness

### DIFF
--- a/docs/changes/2026-06-09-evm-range-narrowing-differential-harness/README.md
+++ b/docs/changes/2026-06-09-evm-range-narrowing-differential-harness/README.md
@@ -7,14 +7,27 @@ that runs EVM opcodes through both the interpreter and the multipass JIT on an
 adversarial operand matrix and asserts the multipass result is bit-identical to
 the interpreter (the full-width reference).
 
-Three tests, split by which lowering path the operands actually drive:
+Four tests, split by which lowering path the operands actually drive:
 
-- `BinaryOpsMatchInterpreterOnAdversarialOperands` — 18 binary opcodes (ADD,
-  MUL, SUB, DIV, SDIV, MOD, SMOD, LT, GT, SLT, SGT, EQ, AND, OR, XOR, SHL, SHR,
-  SAR) over all pairs of an 11-value operand set. Both operands are dynamic
-  `CALLDATALOAD` values (U256-range), so they do **not** enter the
-  bothFitU64 / AND-narrow fast paths: this test gates the **full-width 4-limb
-  lowering** — the #487-class high-limb-corruption surface.
+- `BinaryOpsMatchInterpreterOnAdversarialOperands` — 20 binary opcodes (ADD,
+  MUL, SUB, DIV, SDIV, MOD, SMOD, SIGNEXTEND, LT, GT, SLT, SGT, EQ, AND, OR,
+  XOR, BYTE, SHL, SHR, SAR) over all pairs of an 11-value operand set. Both
+  operands are dynamic `CALLDATALOAD` values (U256-range), so they do **not**
+  enter the bothFitU64 / AND-narrow fast paths: this test gates the
+  **full-width 4-limb lowering** — the #487-class high-limb-corruption surface.
+  `EXP` is excluded because its gas cost scales with the exponent byte length,
+  so the high-limb operands in this matrix (2^192, 2^255, 2^256-1) would charge
+  enormous dynamic gas and trip out-of-gas before a value-range divergence
+  could show.
+- `ShiftAmountsMatchInterpreterOnLimbBoundaries` — SHL, SHR, SAR swept with
+  shift amounts {2, 7, 8, 31, 63, 64, 65, 127, 128, 129, 136, 191, 192, 200,
+  255} crossed with the 11-value matrix as the shifted value, both fed through
+  `CALLDATALOAD` so the full-width dynamic shift path fires. The 11-value
+  matrix, when used as a shift **amount**, only realizes {0, 1, >=2^64}, so the
+  amounts 2..255 — where the dynamic-shift lowering moves bits across 64-bit
+  limb boundaries (64/128/192) and within a limb (the rest) — are unreachable
+  from the binary-op sweep. This test exercises that cross-limb carry/offset
+  logic directly.
 - `AndU64MaskMatchesInterpreter` — `AND` with a u64 constant (the CONST_U64
   fast path, which tags the result U64 and zeros limbs[1..3]) returned
   **directly**, over the adversarial set. Returning the masked value unconsumed
@@ -24,7 +37,7 @@ Three tests, split by which lowering path the operands actually drive:
   narrow-result **consumer**.
 
 The two `AndU64Mask*` tests gate the actual narrowing fast paths; the binary-op
-sweep gates the full-width path.
+and shift-amount sweeps gate the full-width path.
 
 ## Why
 
@@ -73,10 +86,9 @@ the mutation.
 CI-faithful flags (`ZEN_ENABLE_JIT_PRECOMPILE_FALLBACK=ON`), `SPEC_TEST=ON` for
 the test executables:
 
-- `evmInterpTests --gtest_filter=EVMRangeDifferential.*`: **3 / 3 pass** on the
+- `evmInterpTests --gtest_filter=EVMRangeDifferential.*`: **4 / 4 pass** on the
   current tree (multipass agrees with the interpreter on every adversarial
-  pair).
-- Full `evmInterpTests`: 171 / 171 pass.
+  pair, including all swept shift amounts).
 - Negative control: the deliberate too-narrow AND mutation is caught by the
   direct-return test, then reverted.
 - `tools/format.sh check`: pass.

--- a/docs/changes/2026-06-09-evm-range-narrowing-differential-harness/README.md
+++ b/docs/changes/2026-06-09-evm-range-narrowing-differential-harness/README.md
@@ -1,0 +1,88 @@
+# Value-range lowering differential harness
+
+## What
+
+A C++ gtest suite (`EVMRangeDifferential` in `src/tests/evm_interp_tests.cpp`)
+that runs EVM opcodes through both the interpreter and the multipass JIT on an
+adversarial operand matrix and asserts the multipass result is bit-identical to
+the interpreter (the full-width reference).
+
+Three tests, split by which lowering path the operands actually drive:
+
+- `BinaryOpsMatchInterpreterOnAdversarialOperands` — 18 binary opcodes (ADD,
+  MUL, SUB, DIV, SDIV, MOD, SMOD, LT, GT, SLT, SGT, EQ, AND, OR, XOR, SHL, SHR,
+  SAR) over all pairs of an 11-value operand set. Both operands are dynamic
+  `CALLDATALOAD` values (U256-range), so they do **not** enter the
+  bothFitU64 / AND-narrow fast paths: this test gates the **full-width 4-limb
+  lowering** — the #487-class high-limb-corruption surface.
+- `AndU64MaskMatchesInterpreter` — `AND` with a u64 constant (the CONST_U64
+  fast path, which tags the result U64 and zeros limbs[1..3]) returned
+  **directly**, over the adversarial set. Returning the masked value unconsumed
+  is what makes a dropped/kept high limb observable.
+- `AndU64MaskThenNarrowAddMatchesInterpreter` — the same u64-masked value fed
+  through a self-`ADD` (the bothFitU64 narrow path), exercising a
+  narrow-result **consumer**.
+
+The two `AndU64Mask*` tests gate the actual narrowing fast paths; the binary-op
+sweep gates the full-width path.
+
+## Why
+
+A multipass value-range fast path emits a single- or double-limb result that
+must equal the full 4-limb path for every input the range tag claims to cover.
+A **too-narrow** tag silently miscompiles only on operands with non-zero high
+limbs — exactly what ordinary corpora (evmone-statetest, real-load replay)
+almost never carry. So a too-narrow narrowing can pass the entire existing
+suite and still be wrong.
+
+The interpreter is the full-width reference. Feeding high-sparse operands
+(`{0,x,0,0}`, `{0,0,0,x}`, `2^192+5`, `2^255`) through both engines turns a
+dropped or kept high limb into an observable interp-vs-multipass divergence.
+
+To keep the differential from being vacuous, `rangeDiffRun` forces synchronous
+multipass compilation (`DisableMultipassMultithread`) — the default async
+config can fall back to the interpreter for a single call — and `rangeDiffAgree`
+asserts `JITCompiled` so the multipass side really executes JIT code.
+
+## Adversarial operand set
+
+`0`, `1`, `2^64-1`, `2^64`, `2^128-1`, `2^128`, `2^192`, `2^192+5`,
+`{0,x,0,0}`, `2^255`, `2^256-1` — every value-range boundary plus the
+high-sparse class that a too-narrow tag would corrupt.
+
+## Negative control
+
+To prove the harness catches a too-narrow narrowing rather than passing
+vacuously, the AND-u64 fast path was temporarily mutated to keep the high limbs
+(`Result[I] = Other[I]` instead of `Zero`). Rebuilt,
+`AndU64MaskMatchesInterpreter` — the test that returns the masked value directly
+— **failed** on the high-sparse inputs with an output divergence; reverting
+restored green. (The consumer test `AndU64MaskThenNarrowAddMatchesInterpreter`
+does **not** catch this mutation: its trailing bothFitU64 ADD reads only
+limb[0] and re-zeros the high limbs, masking the bug — which is exactly why the
+direct-return test exists.) The committed tree contains only the harness, not
+the mutation.
+
+## Testing
+
+CI-faithful flags (`ZEN_ENABLE_JIT_PRECOMPILE_FALLBACK=ON`), `SPEC_TEST=ON` for
+the test executables:
+
+- `evmInterpTests --gtest_filter=EVMRangeDifferential.*`: **3 / 3 pass** on the
+  current tree (multipass agrees with the interpreter on every adversarial
+  pair).
+- Full `evmInterpTests`: 171 / 171 pass.
+- Negative control: the deliberate too-narrow AND mutation is caught by the
+  direct-return test, then reverted.
+- `tools/format.sh check`: pass.
+
+Test-only change — no runtime / codegen impact on `libdtvmapi`.
+
+## Scope and limits
+
+This harness covers the **in-block** lowering: operands constructed and consumed
+within one basic block (full-width via CALLDATALOAD; narrow via AND-mask /
+bothFitU64). It does not yet drive a context-size producer
+(CALLDATASIZE/GAS/...) into a narrow consumer, nor the **cross-block**
+`EntryStackRanges` re-import path; both would extend the suite with dedicated
+fixtures.

--- a/docs/changes/2026-06-09-evm-range-narrowing-differential-harness/README.md
+++ b/docs/changes/2026-06-09-evm-range-narrowing-differential-harness/README.md
@@ -42,7 +42,12 @@ dropped or kept high limb into an observable interp-vs-multipass divergence.
 To keep the differential from being vacuous, `rangeDiffRun` forces synchronous
 multipass compilation (`DisableMultipassMultithread`) — the default async
 config can fall back to the interpreter for a single call — and `rangeDiffAgree`
-asserts `JITCompiled` so the multipass side really executes JIT code.
+asserts `JITCompiled` so the multipass side really executes JIT code. That
+assertion is compiled under `#ifdef ZEN_ENABLE_JIT`; the whole suite is already
+gated on `ZEN_ENABLE_MULTIPASS_JIT`, so in the builds where these tests run the
+multipass side is JIT-backed. In a hypothetical no-JIT build the assertion is
+absent and the comparison would reduce to interpreter-vs-interpreter (still
+correct, but not exercising the JIT).
 
 ## Adversarial operand set
 

--- a/src/tests/evm_interp_tests.cpp
+++ b/src/tests/evm_interp_tests.cpp
@@ -704,7 +704,16 @@ TEST(EVMRegressionTest, Issue488_PCAsAddmodAugend_InterpMatchesMultipass) {
 //   - BinaryOpsMatchInterpreterOnAdversarialOperands feeds two CALLDATALOAD
 //     operands, which are dynamic and U256-range, so they do NOT enter the
 //     bothFitU64 / AND-narrow fast paths: this test gates the FULL-width
-//     4-limb lowering (the #487-class high-limb-corruption surface).
+//     4-limb lowering (the #487-class high-limb-corruption surface). It sweeps
+//     20 binary opcodes (arithmetic, comparison, bitwise, BYTE, SIGNEXTEND,
+//     and the three shifts). EXP is excluded because its gas cost scales with
+//     the exponent byte length, so high-limb operands would trip out-of-gas
+//     instead of exposing a value-range divergence.
+//   - ShiftAmountsMatchInterpreterOnLimbBoundaries sweeps SHL/SHR/SAR with
+//     shift amounts in the limb-crossing region 2..255. The 11-value operand
+//     matrix, used as a shift amount, only realizes {0, 1, >=2^64}, so the
+//     dynamic-shift cross-limb carry/offset logic is unreachable from the
+//     binary-op sweep above; this test covers it.
 //   - The AndU64Mask* tests construct a provably-U64 operand (AND with a u64
 //     constant) and feed it directly / through a bothFitU64 ADD, so they gate
 //     the actual narrowing fast paths.
@@ -866,6 +875,13 @@ static std::vector<uint8_t> rangeDiffBinOp(uint8_t Op) {
 // On the first divergent (op, operand) pair the whole test returns, so a single
 // regression reports one op and skips the rest — intentional output-flood
 // control, not full per-op isolation.
+//
+// EXP (0x0a) is intentionally excluded: its gas cost scales with the byte
+// length of the exponent, so the high-limb operands in this matrix (2^192,
+// 2^255, 2^256-1) would charge enormous dynamic gas and obscure a pure
+// value-range divergence behind out-of-gas noise. Shift amounts, which need
+// the limb-crossing region 2..255, are swept separately by
+// ShiftAmountsMatchInterpreterOnLimbBoundaries below.
 TEST(EVMRangeDifferential, BinaryOpsMatchInterpreterOnAdversarialOperands) {
   struct OpCase {
     uint8_t Op;
@@ -873,10 +889,10 @@ TEST(EVMRangeDifferential, BinaryOpsMatchInterpreterOnAdversarialOperands) {
   };
   const OpCase Cases[] = {
       {0x01, "ADD"},  {0x02, "MUL"}, {0x03, "SUB"},  {0x04, "DIV"},
-      {0x05, "SDIV"}, {0x06, "MOD"}, {0x07, "SMOD"}, {0x10, "LT"},
-      {0x11, "GT"},   {0x12, "SLT"}, {0x13, "SGT"},  {0x14, "EQ"},
-      {0x16, "AND"},  {0x17, "OR"},  {0x18, "XOR"},  {0x1b, "SHL"},
-      {0x1c, "SHR"},  {0x1d, "SAR"},
+      {0x05, "SDIV"}, {0x06, "MOD"}, {0x07, "SMOD"}, {0x0b, "SIGNEXTEND"},
+      {0x10, "LT"},   {0x11, "GT"},  {0x12, "SLT"},  {0x13, "SGT"},
+      {0x14, "EQ"},   {0x16, "AND"}, {0x17, "OR"},   {0x18, "XOR"},
+      {0x1a, "BYTE"}, {0x1b, "SHL"}, {0x1c, "SHR"},  {0x1d, "SAR"},
   };
   const auto Operands = rangeDiffOperands();
   for (const auto &C : Cases) {
@@ -884,6 +900,46 @@ TEST(EVMRangeDifferential, BinaryOpsMatchInterpreterOnAdversarialOperands) {
     for (const auto &A : Operands) {
       for (const auto &B : Operands) {
         if (!rangeDiffAgree(C.Name, Bytecode, rangeDiffCalldata(A, B))) {
+          return; // one divergence is enough; avoid output flood
+        }
+      }
+    }
+  }
+}
+
+// Sweep SHL/SHR/SAR with shift amounts that land inside the limb-crossing
+// region 2..255. The 11-value operand matrix, when fed as a shift amount, only
+// realizes {0, 1, >=2^64}; it never produces an amount in 2..255, so the
+// dynamic-shift lowering's cross-limb carry/offset logic (which moves bits
+// across 64-bit limb boundaries at amounts 64/128/192 and within a limb at the
+// rest) is never exercised by BinaryOpsMatchInterpreterOnAdversarialOperands.
+//
+// rangeDiffBinOp puts the shift amount in slot b (calldata[32:64], the stack
+// top SHL/SHR/SAR pops first) and the shifted value in slot a
+// (calldata[0:32]). Both are CALLDATALOAD, so the full-width dynamic shift path
+// fires. The shifted value sweeps the full adversarial matrix; the amount
+// sweeps the boundary set below, covering both the on-limb-boundary amounts
+// (64, 128, 192) and the in-limb amounts (2, 7, 31, 63, 65, 127, ...).
+TEST(EVMRangeDifferential, ShiftAmountsMatchInterpreterOnLimbBoundaries) {
+  struct OpCase {
+    uint8_t Op;
+    const char *Name;
+  };
+  const OpCase Cases[] = {
+      {0x1b, "SHL"},
+      {0x1c, "SHR"},
+      {0x1d, "SAR"},
+  };
+  const uint64_t Amounts[] = {2,   7,   8,   31,  63,  64,  65, 127,
+                              128, 129, 136, 191, 192, 200, 255};
+  const auto Values = rangeDiffOperands();
+  for (const auto &C : Cases) {
+    const auto Bytecode = rangeDiffBinOp(C.Op);
+    for (const auto &Value : Values) {
+      for (uint64_t Amount : Amounts) {
+        const auto AmountWord = rangeDiffLimb(0, Amount);
+        if (!rangeDiffAgree(C.Name, Bytecode,
+                            rangeDiffCalldata(Value, AmountWord))) {
           return; // one divergence is enough; avoid output flood
         }
       }

--- a/src/tests/evm_interp_tests.cpp
+++ b/src/tests/evm_interp_tests.cpp
@@ -688,4 +688,248 @@ TEST(EVMRegressionTest, Issue488_PCAsAddmodAugend_InterpMatchesMultipass) {
   EXPECT_EQ(InterpExec.OutputHex,
             "0000000000000000000000000000000000000000000000000000000000000006");
 }
+
+// ===========================================================================
+// Value-range lowering differential harness.
+//
+// A multipass value-range fast path that emits a single- or double-limb result
+// MUST be bit-identical to the full 4-limb path for every input the range tag
+// claims to cover. A too-narrow tag silently miscompiles only on operands with
+// non-zero high limbs, which ordinary corpora rarely carry. Each test drives an
+// opcode with an adversarial operand matrix (value-range boundaries +
+// high-sparse {0,x,0,0}/{0,0,0,x}) and asserts the multipass JIT agrees
+// bit-for-bit with the interpreter (the full-width reference).
+//
+// Coverage split (the operands decide which lowering path fires):
+//   - BinaryOpsMatchInterpreterOnAdversarialOperands feeds two CALLDATALOAD
+//     operands, which are dynamic and U256-range, so they do NOT enter the
+//     bothFitU64 / AND-narrow fast paths: this test gates the FULL-width
+//     4-limb lowering (the #487-class high-limb-corruption surface).
+//   - The AndU64Mask* tests construct a provably-U64 operand (AND with a u64
+//     constant) and feed it directly / through a bothFitU64 ADD, so they gate
+//     the actual narrowing fast paths.
+// ===========================================================================
+
+// Build a big-endian 32-byte word holding `Val` in 64-bit limb `Limb`
+// (limb 0 = least significant). OR several together for multi-limb operands.
+static std::vector<uint8_t> rangeDiffLimb(int Limb, uint64_t Val) {
+  std::vector<uint8_t> W(32, 0);
+  const int Base = 24 - Limb * 8; // limb 0 -> bytes [24..31]
+  for (int I = 0; I < 8; ++I) {
+    W[Base + 7 - I] = static_cast<uint8_t>((Val >> (8 * I)) & 0xff);
+  }
+  return W;
+}
+
+static std::vector<uint8_t> rangeDiffOr(std::vector<uint8_t> A,
+                                        const std::vector<uint8_t> &B) {
+  for (size_t I = 0; I < A.size(); ++I) {
+    A[I] |= B[I];
+  }
+  return A;
+}
+
+// Adversarial operand matrix: each entry is a 32-byte big-endian u256.
+static std::vector<std::vector<uint8_t>> rangeDiffOperands() {
+  const uint64_t Max = 0xFFFFFFFFFFFFFFFFull;
+  std::vector<std::vector<uint8_t>> Ops;
+  Ops.push_back(rangeDiffLimb(0, 0));   // 0
+  Ops.push_back(rangeDiffLimb(0, 1));   // 1
+  Ops.push_back(rangeDiffLimb(0, Max)); // 2^64 - 1 (U64 boundary)
+  Ops.push_back(rangeDiffLimb(1, 1));   // 2^64
+  Ops.push_back(
+      rangeDiffOr(rangeDiffLimb(0, Max), rangeDiffLimb(1, Max))); // U128-1
+  Ops.push_back(rangeDiffLimb(2, 1)); // 2^128 (U128 boundary)
+  Ops.push_back(rangeDiffLimb(3, 1)); // 2^192 (high-sparse {0,0,0,x})
+  Ops.push_back(
+      rangeDiffOr(rangeDiffLimb(3, 1), rangeDiffLimb(0, 5))); // 2^192+5
+  Ops.push_back(rangeDiffLimb(1, 5)); // high-sparse {0,x,0,0}
+  Ops.push_back(rangeDiffLimb(3, 0x8000000000000000ull)); // 2^255 (sign bit)
+  Ops.push_back(rangeDiffOr(
+      rangeDiffOr(rangeDiffLimb(0, Max), rangeDiffLimb(1, Max)),
+      rangeDiffOr(rangeDiffLimb(2, Max), rangeDiffLimb(3, Max)))); // 2^256-1
+  return Ops;
+}
+
+static std::vector<uint8_t> rangeDiffCalldata(const std::vector<uint8_t> &A,
+                                              const std::vector<uint8_t> &B) {
+  std::vector<uint8_t> CD;
+  CD.insert(CD.end(), A.begin(), A.end());
+  CD.insert(CD.end(), B.begin(), B.end());
+  return CD;
+}
+
+// Execute `Bytecode` in `Mode`, forcing synchronous multipass compilation so
+// the multipass run actually executes JIT code (the default async/multithread
+// config can fall back to the interpreter for a single call, making a
+// differential test vacuous).
+static EVMExecutionResult rangeDiffRun(const std::string &Label,
+                                       const std::vector<uint8_t> &Bytecode,
+                                       common::RunMode Mode,
+                                       const std::vector<uint8_t> &CallData) {
+  EVMExecutionResult Empty;
+  RuntimeConfig Config;
+  Config.Mode = Mode;
+  Config.DisableMultipassMultithread = true; // compile before run -> JIT used
+
+  auto MockedHost = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  MockedHost->tx_context.tx_origin = zen::evm::DEFAULT_DEPLOYER_ADDRESS;
+  auto RT = Runtime::newEVMRuntime(Config, MockedHost.get());
+  if (!RT) {
+    ADD_FAILURE() << "runtime create failed: " << Label;
+    return Empty;
+  }
+  MockedHost->setRuntime(RT.get());
+
+  auto ModRet = RT->loadEVMModule(Label, Bytecode.data(), Bytecode.size());
+  if (!ModRet) {
+    ADD_FAILURE() << "module load failed: " << Label;
+    return Empty;
+  }
+  EVMModule *Mod = *ModRet;
+
+  Isolation *Iso = RT->createManagedIsolation();
+  if (!Iso) {
+    ADD_FAILURE() << "isolation create failed: " << Label;
+    return Empty;
+  }
+  const uint64_t GasLimit = 0xFFFF'FFFF'FFFF - zen::evm::BASIC_EXECUTION_COST;
+  auto InstRet = Iso->createEVMInstance(*Mod, GasLimit);
+  if (!InstRet) {
+    ADD_FAILURE() << "instance create failed: " << Label;
+    return Empty;
+  }
+  EVMInstance *Inst = *InstRet;
+  Inst->setRevision(evmc_revision::EVMC_OSAKA);
+
+  evmc_message Msg = {
+      .kind = EVMC_CALL,
+      .flags = 0u,
+      .depth = 0,
+      .gas = static_cast<int64_t>(GasLimit),
+      .recipient = {},
+      .sender = zen::evm::DEFAULT_DEPLOYER_ADDRESS,
+      .input_data = CallData.empty() ? nullptr : CallData.data(),
+      .input_size = CallData.size(),
+      .value = {},
+      .create2_salt = {},
+      .code_address = {},
+      .code = reinterpret_cast<const uint8_t *>(Mod->Code),
+      .code_size = Mod->CodeSize,
+  };
+  evmc::Result RawResult;
+  EVMExecutionResult Exec;
+#ifdef ZEN_ENABLE_JIT
+  Exec.JITCompiled = Mod->getJITCode() != nullptr && Mod->getJITCodeSize() > 0;
+#endif
+  EXPECT_NO_THROW({ RT->callEVMMain(*Inst, Msg, RawResult); });
+  Exec.Status = RawResult.status_code;
+  Exec.OutputHex =
+      zen::utils::toHex(RawResult.output_data, RawResult.output_size);
+  return Exec;
+}
+
+// Run `Bytecode` with `CallData` through interpreter and multipass, assert the
+// multipass JIT compiled (non-vacuous) and that status + 32-byte output agree.
+// Returns false on divergence so callers can stop flooding output.
+static bool rangeDiffAgree(const std::string &Label,
+                           const std::vector<uint8_t> &Bytecode,
+                           const std::vector<uint8_t> &CallData) {
+  auto Interp = rangeDiffRun(Label + "_interp", Bytecode,
+                             common::RunMode::InterpMode, CallData);
+  auto Multi = rangeDiffRun(Label + "_multipass", Bytecode,
+                            common::RunMode::MultipassMode, CallData);
+#ifdef ZEN_ENABLE_JIT
+  EXPECT_TRUE(Multi.JITCompiled) << "multipass did not JIT-compile: " << Label;
+#endif
+  EXPECT_EQ(Multi.Status, Interp.Status) << "status diverged: " << Label;
+  EXPECT_EQ(Multi.OutputHex, Interp.OutputHex) << "output diverged: " << Label;
+  return Multi.Status == Interp.Status && Multi.OutputHex == Interp.OutputHex;
+}
+
+// "a = calldata[0:32]; b = calldata[32:64]; OP". After the two pushes, b is on
+// top of the stack, so EVM evaluates `b OP a` (e.g. SUB = b - a; for shifts the
+// shift amount is b). The exact convention is irrelevant to a differential test
+// — both engines run identical bytecode — and the nested A*B sweep feeds every
+// matrix value into both slots regardless.
+static std::vector<uint8_t> rangeDiffBinOp(uint8_t Op) {
+  return {0x60, 0x00, 0x35,              // PUSH1 0    CALLDATALOAD -> a
+          0x60, 0x20, 0x35,              // PUSH1 0x20 CALLDATALOAD -> b
+          Op,                            // b OP a
+          0x60, 0x00, 0x52,              // PUSH1 0 MSTORE
+          0x60, 0x20, 0x60, 0x00, 0xf3}; // RETURN(0, 32)
+}
+
+// Differential over every binary opcode whose lowering touches limbs. Operands
+// are dynamic CALLDATALOAD (U256-range), so this gates the FULL-width 4-limb
+// path, not the narrow fast paths (those are gated by the AndU64Mask* tests).
+// On the first divergent (op, operand) pair the whole test returns, so a single
+// regression reports one op and skips the rest — intentional output-flood
+// control, not full per-op isolation.
+TEST(EVMRangeDifferential, BinaryOpsMatchInterpreterOnAdversarialOperands) {
+  struct OpCase {
+    uint8_t Op;
+    const char *Name;
+  };
+  const OpCase Cases[] = {
+      {0x01, "ADD"},  {0x02, "MUL"}, {0x03, "SUB"},  {0x04, "DIV"},
+      {0x05, "SDIV"}, {0x06, "MOD"}, {0x07, "SMOD"}, {0x10, "LT"},
+      {0x11, "GT"},   {0x12, "SLT"}, {0x13, "SGT"},  {0x14, "EQ"},
+      {0x16, "AND"},  {0x17, "OR"},  {0x18, "XOR"},  {0x1b, "SHL"},
+      {0x1c, "SHR"},  {0x1d, "SAR"},
+  };
+  const auto Operands = rangeDiffOperands();
+  for (const auto &C : Cases) {
+    const auto Bytecode = rangeDiffBinOp(C.Op);
+    for (const auto &A : Operands) {
+      for (const auto &B : Operands) {
+        if (!rangeDiffAgree(C.Name, Bytecode, rangeDiffCalldata(A, B))) {
+          return; // one divergence is enough; avoid output flood
+        }
+      }
+    }
+  }
+}
+
+// Directly exercise the AND-with-u64-constant fast path (CONST_U64): it tags
+// the result U64 and MUST zero limbs[1..3]. Returning the result directly (not
+// through a later narrow op that would discard the high limbs) is what makes a
+// too-narrow / too-wide limb bug observable. Feeding high-sparse calldata, the
+// masked result must equal the interpreter's.
+//   a = calldata[0:32]; MSTORE(0, a AND 0xFFFFFFFFFFFFFFFF); RETURN 32.
+TEST(EVMRangeDifferential, AndU64MaskMatchesInterpreter) {
+  const std::vector<uint8_t> Bytecode = {
+      0x60, 0x00, 0x35,                                     // CALLDATALOAD a
+      0x67, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // PUSH8 u64 mask
+      0x16,                                                 // AND -> m (U64)
+      0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3};      // RETURN(0,32)
+  const auto Operands = rangeDiffOperands();
+  for (const auto &A : Operands) {
+    if (!rangeDiffAgree("and_u64_mask", Bytecode, rangeDiffCalldata(A, A))) {
+      return;
+    }
+  }
+}
+
+// Exercise a narrow-result CONSUMER: AND with a u64 constant produces a U64
+// value that feeds a self-ADD on the bothFitU64 narrow path. The summed result
+// is returned; for any high-sparse input the narrowed two-limb sum must match
+// the interpreter's full-width sum.
+//   a = calldata[0:32]; m = a AND 0xFFFFFFFFFFFFFFFF; MSTORE(0, m + m); RETURN.
+TEST(EVMRangeDifferential, AndU64MaskThenNarrowAddMatchesInterpreter) {
+  const std::vector<uint8_t> Bytecode = {
+      0x60, 0x00, 0x35,                                     // CALLDATALOAD a
+      0x67, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // PUSH8 u64 mask
+      0x16,                                                 // AND -> m (U64)
+      0x80,                                                 // DUP1
+      0x01,                                            // ADD m + m (narrow)
+      0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3}; // RETURN(0,32)
+  const auto Operands = rangeDiffOperands();
+  for (const auto &A : Operands) {
+    if (!rangeDiffAgree("and_u64_mask_then_add", Bytecode,
+                        rangeDiffCalldata(A, A))) {
+      return;
+    }
+  }
+}
 #endif


### PR DESCRIPTION
## What

A C++ gtest suite (`EVMRangeDifferential` in `src/tests/evm_interp_tests.cpp`)
that runs EVM opcodes through both the interpreter and the multipass JIT on an
adversarial operand matrix and asserts the multipass result is bit-identical to
the interpreter (the full-width reference). Test-only; no `libdtvmapi` impact.

Three tests, split by which lowering path the operands actually drive:

- `BinaryOpsMatchInterpreterOnAdversarialOperands` — 18 binary opcodes over all
  pairs of an 11-value operand set. Both operands are dynamic `CALLDATALOAD`
  (U256-range), so they gate the **full-width 4-limb lowering** (the #487-class
  high-limb-corruption surface), not the narrow fast paths.
- `AndU64MaskMatchesInterpreter` — `AND` with a u64 constant (CONST_U64 fast
  path) returned **directly**, so a dropped/kept high limb is observable.
- `AndU64MaskThenNarrowAddMatchesInterpreter` — the masked value fed through a
  bothFitU64 `ADD` (narrow-result consumer).

## Why

A value-range fast path that emits a single/double-limb result must equal the
full 4-limb path for every input the tag covers. A too-narrow tag miscompiles
only on operands with non-zero high limbs — which ordinary corpora
(evmone-statetest, real-load replay) almost never carry, so such a bug can pass
the whole suite and still be wrong. Feeding high-sparse operands
(`{0,x,0,0}`, `{0,0,0,x}`, `2^192+5`, `2^255`) turns a dropped high limb into an
observable interp-vs-multipass divergence.

`rangeDiffRun` forces synchronous multipass compilation
(`DisableMultipassMultithread`) and asserts `JITCompiled`, so the multipass side
actually executes JIT code (the default async config can fall back to the
interpreter and make the differential vacuous).

## Negative control

Temporarily mutating the AND-u64 path to keep the high limbs
(`Result[I] = Other[I]` instead of `Zero`) made `AndU64MaskMatchesInterpreter`
fail with an output divergence on the high-sparse inputs; reverting restored
green. (The consumer test does not catch it — its trailing ADD reads only
limb[0] — which is why the direct-return test exists.)

## Testing

- `evmInterpTests --gtest_filter=EVMRangeDifferential.*`: 3/3 pass.
- Full `evmInterpTests`: 171/171 pass.
- `tools/format.sh check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
