### PR TITLE
fix(evm): protectUnsafeValue last ADC in handleAddU64Const carry chain

### DIFF
--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -3116,14 +3116,14 @@ EVMMirBuilder::handleAddU64Const(const Operand &FullOp,
   for (size_t I = 1; I < EVM_ELEMENTS_COUNT; ++I) {
     MInstruction *AdcInst = createInstruction<AdcInstruction>(
         false, MirI64Type, LHS[I], RHSZero, Carry);
-    // Last ADC: carry flag is dead after this point, no subsequent ADC
-    // consumes it. The barrier is only needed for intermediate ADCs to
-    // force immediate execution while CF is live.
-    if (I < EVM_ELEMENTS_COUNT - 1) {
-      Result[I] = protectUnsafeValue(AdcInst, MirI64Type);
-    } else {
-      Result[I] = AdcInst;
-    }
+    // Every ADC must be protected (materialized into a variable) to force
+    // immediate evaluation while CF is live. Even the last ADC — while CF
+    // is dead *within* the carry chain after this instruction, the tree-IR
+    // expression for the last ADC may not be lowered immediately.
+    // Subsequent CMP instructions from comparison consumers (e.g. GT/LT)
+    // can clobber EFLAGS before the ADC expression is evaluated, silently
+    // corrupting the carry chain. (See GitHub issue #541.)
+    Result[I] = protectUnsafeValue(AdcInst, MirI64Type);
   }
   // u64const + value: if the value fits in u64, the sum is < 2^65 (fits u128);
   // for wider operands a carry past bit 127 is possible, so stay conservative.

--- a/src/tests/evm_interp_tests.cpp
+++ b/src/tests/evm_interp_tests.cpp
@@ -688,4 +688,72 @@ TEST(EVMRegressionTest, Issue488_PCAsAddmodAugend_InterpMatchesMultipass) {
   EXPECT_EQ(InterpExec.OutputHex,
             "0000000000000000000000000000000000000000000000000000000000000006");
 }
+
+// Regression test for issue #541 (and #542): multipass JIT carry chain
+// corruption when the last ADC in handleAddU64Const is not
+// protectUnsafeValue'd.
+//
+// When ADD produces a U256 result via the handleAddU64Const fast path
+// (ADD limb[0] + 3×ADC for carry propagation), the last ADC (limb[3]) was
+// intentionally left as an un-materialized tree-IR expression because the
+// carry flag is "dead" within the carry chain after that instruction.
+// However, if the ADD result is later consumed by a CMP instruction (e.g.
+// from GT/LT comparison), the CMP lowers before the last ADC, clobbering
+// x86 EFLAGS (including CF). The ADC then reads the wrong CF from CMP
+// instead of the correct CF from the preceding ADC, corrupting the carry
+// chain.
+//
+// The test uses a minimal EVM program that triggers the bug:
+//   PUSH24 big_val  -- a 192-bit value with non-zero limbs
+//   PUSH1 0xff      -- a small value (U64 range)
+//   RETURNDATASIZE  -- pushes 0 (U64 range)
+//   ADD             -- ADD(0, 0xff) via handleAddU64Const
+//   GT              -- GT(0xff, big_val) should return 0
+//   PUSH0           -- offset for MSTORE
+//   MSTORE          -- store GT result to memory
+//   PUSH1 32        -- size for RETURN
+//   PUSH0           -- offset for RETURN
+//   RETURN
+//
+// Before the fix: CMP from GT clobbered CF before the last ADC was lowered,
+// ADC computed wrong limb[3], GT incorrectly returned 1 instead of 0.
+// For issue #542: the same root cause also caused a crash.
+TEST(EVMRegressionTest, Issue541_AddU64ConstLastAdcCarryChainPreserved) {
+  // Bytecode: PUSH24 big_val, PUSH1 0xff, RETURNDATASIZE, ADD, GT,
+  //           PUSH0, MSTORE, PUSH1 32, PUSH0, RETURN
+  //
+  // big_val = 0x0000_0000_0000_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
+  // (3 non-zero limbs to force CMP in GT to set CF=1)
+  const std::string BytecodeHex =
+      "77000000000000ffffffffffffffffffffffffffffffffffff"
+      "60ff3d01115f5260205ff3";
+
+  auto BytecodeBuf = zen::utils::fromHex(BytecodeHex);
+  ASSERT_TRUE(BytecodeBuf) << "Failed to parse bytecode hex";
+
+  // Run interpreter (reference) and multipass JIT, compare outputs.
+  auto InterpExec = executeEvmBytecode("issue541_interp", *BytecodeBuf,
+                                       common::RunMode::InterpMode);
+  ASSERT_EQ(InterpExec.Status, EVMC_SUCCESS) << "Interpreter execution failed";
+
+  auto MultipassExec = executeEvmBytecode("issue541_multipass", *BytecodeBuf,
+                                          common::RunMode::MultipassMode);
+  ASSERT_EQ(MultipassExec.Status, EVMC_SUCCESS)
+      << "Multipass JIT execution failed (crash = issue #542)";
+
+#ifdef ZEN_ENABLE_JIT
+  EXPECT_TRUE(MultipassExec.JITCompiled)
+      << "Multipass JIT should compile issue541 reproducer";
+#endif
+
+  // GT(0xff, big_val) should return 0. Before the fix, multipass returned 1.
+  EXPECT_EQ(MultipassExec.OutputHex, InterpExec.OutputHex)
+      << "Multipass output diverged from interpreter for issue #541 "
+         "regression";
+
+  // Explicitly verify: GT(0xff, big_val) = 0 (0xff is NOT greater than
+  // a 192-bit value).
+  EXPECT_EQ(InterpExec.OutputHex,
+            "0000000000000000000000000000000000000000000000000000000000000000");
+}
 #endif


### PR DESCRIPTION
In handleAddU64Const, the last ADC (limb[3]) was intentionally left unprotected because the carry flag is 'dead' within the carry chain after that instruction. However, this is wrong when the ADD result's U256Components are later used as operands for CMP instructions in comparison handlers (e.g. handleCompareGT_LT). The CMP clobbers x86 EFLAGS before the last ADC tree-IR expression is evaluated, silently corrupting the carry chain and producing wrong results.

Root cause (GitHub issue #541): GT(0xff, big_val) incorrectly returned 1 in multipass JIT because:
1. ADD produced [0xff, 0, 0, 0] via ADD+3xADC carry chain
2. The last ADC (limb[3]) was not protectUnsafeValue'd
3. CMP instruction from GT comparison clobbered CF before the last ADC was lowered (CMP sets CF=1 because 0xff < 0xFFFFFFFF)
4. The last ADC computed 0+0+wrong_CF=1 instead of 0+0+0=0
5. GT's select chain saw limb[3]=1 (nonzero), returned true

Fix: Always protectUnsafeValue all ADCs in the carry chain, matching the pattern already used in the full ADD handler (handleBinaryArithmetic). This forces immediate evaluation before any flag-clobbering instruction can intervene.

<!-- Thank you for contributing to DTVM!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.

-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    lib/wasi,
    smart_ir/src/abi
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```