### PR TITLE
fix(compiler): materialize ADDMOD operand limbs before fast/slow branch

### DIFF
--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -2444,6 +2444,18 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleAddMod(Operand AugendOp,
   U256Inst Addend = extractU256Operand(AddendOp);
   U256Inst Modulus = extractU256Operand(ModulusOp);
 
+  // Materialize all operand limbs before the fast/slow BrIf below. The raw
+  // tree IR for these limbs is referenced from both FastBB and SlowBB (two
+  // non-dominating successors); without materialization the CgIR lowering can
+  // place a shared computation into only one branch, leaving the sibling path
+  // with undefined virtual-register uses -- the same cross-block hazard
+  // handleDivModGeneral guards against by materializing its dividend limbs.
+  for (size_t I = 0; I < EVM_ELEMENTS_COUNT; ++I) {
+    Augend[I] = protectUnsafeValue(Augend[I], I64Type);
+    Addend[I] = protectUnsafeValue(Addend[I], I64Type);
+    Modulus[I] = protectUnsafeValue(Modulus[I], I64Type);
+  }
+
   // Fast-path eligibility: mod[3] != 0 && x[3] <= mod[3] && y[3] <= mod[3].
   // Invariant established: x < 2*mod and y < 2*mod, so a single conditional
   // subtraction is sufficient to normalize each operand into [0, mod).


### PR DESCRIPTION
ADDMOD miscompiles in multipass when an operand is a raw fast/slow tree; this materializes the operand limbs before the branch so each limb is defined in the dominating block.

### Problem

`handleAddMod` extracts the raw tree IR of its Augend/Addend/Modulus limbs and then branches into `FastBB`/`SlowBB`. The low limbs are first referenced inside those two non-dominating successor blocks. The CgIR lowering memoizes each tree node's virtual register in a function-global map that is never cleared between blocks, so a shared limb lowered in the first-walked branch leaves the sibling path reading a virtual register defined in a block that does not dominate it — undefined on that execution path. The result is a silent multipass miscompile (wrong ADDMOD result, occasionally a crash).

This is the same cross-block materialization hazard fixed for `handleDivModGeneral` in #540. `handleAddMod` has the same structure but never received the #540 fix on the ADDMOD path.

### Trigger

The hazard surfaces when an ADDMOD operand is the raw tree of a preceding inline fast/slow op (e.g. a MOD result). Minimal reproducer:

```
ORIGIN DUP1 DUP1 PUSH0 MOD ADDMOD
```

The interpreter returns 0; multipass returns an incorrect result before this fix.

### Fix

Materialize all operand limbs with `protectUnsafeValue` before the branch, matching the #540 pattern. This forces immediate evaluation so each limb's virtual register is defined in the dominating block.

### Tests

Adds `EVMRegressionTest.AddModCrossBlockMaterialization`, a differential interpreter-vs-multipass regression test over MOD-fed and DIV-fed ADDMOD inputs.

Validated locally: the new regression test passes; multipass `evmone-unittests` (223) and `evmone-statetest -k fork_Cancun` (2723) pass with the fix; `tools/format.sh check` clean.