### PR TITLE
perf(evm): precheck linear MSTORE8 memory writes

### DIFF
--- a/src/action/evm_bytecode_visitor.h
+++ b/src/action/evm_bytecode_visitor.h
@@ -1356,8 +1356,7 @@ private:
       uint64_t MotifPC = ScanPC;
       if (!consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC, OP_DUP1) ||
           !consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC, OP_DUP1) ||
-          !consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC,
-                                 OP_MSTORE8) ||
+          !consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC, OP_MSTORE8) ||
           !consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC, OP_DUP2) ||
           !consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC, OP_ADD)) {
         return {};

--- a/src/action/evm_bytecode_visitor.h
+++ b/src/action/evm_bytecode_visitor.h
@@ -601,6 +601,7 @@ private:
 
         case OP_MSTORE8: {
           Builder.noteMemoryOpcodeInBlock(Opcode, PC);
+          maybePrepareLinearBlockMemoryPrecheck(Opcode);
           Operand Addr = pop();
           Operand Value = pop();
           Builder.handleMStore8(Addr, Value);
@@ -1337,6 +1338,48 @@ private:
     return Plan;
   }
 
+  BlockLinearPrecheckPlan analyzeLinearMstore8DirectMemoryBlockPrecheck(
+      const Byte *Bytecode, size_t BytecodeSize, uint64_t EntryPC) {
+    uint64_t ScanPC = 0;
+    if (!consumeLinearRecurrencePrefix(Bytecode, BytecodeSize, EntryPC,
+                                       ScanPC)) {
+      return {};
+    }
+
+    uint64_t CoveredDirectOps = 0;
+    while (ScanPC < BytecodeSize) {
+      evmc_opcode Opcode = static_cast<evmc_opcode>(Bytecode[ScanPC]);
+      if (Opcode == OP_JUMPDEST || isBlockTerminatorOpcode(Opcode)) {
+        break;
+      }
+
+      uint64_t MotifPC = ScanPC;
+      if (!consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC, OP_DUP1) ||
+          !consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC, OP_DUP1) ||
+          !consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC,
+                                 OP_MSTORE8) ||
+          !consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC, OP_DUP2) ||
+          !consumeExpectedOpcode(Bytecode, BytecodeSize, MotifPC, OP_ADD)) {
+        return {};
+      }
+
+      ++CoveredDirectOps;
+      ScanPC = MotifPC;
+    }
+
+    if (CoveredDirectOps < 2) {
+      return {};
+    }
+
+    BlockLinearPrecheckPlan Plan;
+    Plan.Eligible = true;
+    Plan.CoveredOpcode = OP_MSTORE8;
+    Plan.AccessWidth = 1;
+    Plan.CoveredDirectOps = CoveredDirectOps;
+    Plan.StrideStackIndex = 3;
+    return Plan;
+  }
+
   BlockLinearPrecheckPlan analyzeLinearDirectMemoryBlockPrecheck(
       const Byte *Bytecode, size_t BytecodeSize, uint64_t EntryPC) {
     BlockLinearPrecheckPlan Plan = analyzeLinearMloadDirectMemoryBlockPrecheck(
@@ -1344,8 +1387,13 @@ private:
     if (Plan.Eligible) {
       return Plan;
     }
-    return analyzeLinearMstoreDirectMemoryBlockPrecheck(Bytecode, BytecodeSize,
+    Plan = analyzeLinearMstoreDirectMemoryBlockPrecheck(Bytecode, BytecodeSize,
                                                         EntryPC);
+    if (Plan.Eligible) {
+      return Plan;
+    }
+    return analyzeLinearMstore8DirectMemoryBlockPrecheck(Bytecode, BytecodeSize,
+                                                         EntryPC);
   }
 
   void maybePrepareLinearBlockMemoryPrecheck(evmc_opcode Opcode) {

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -4967,18 +4967,29 @@ void EVMMirBuilder::handleMStore8(Operand AddrComponents,
   const bool OffsetWasConst = AddrComponents.isConstU64();
   const uint64_t OriginalConstOffset =
       OffsetWasConst ? AddrComponents.getConstValue()[0] : 0;
-  const bool OffsetKnownU64 = OffsetWasConst;
+  bool OffsetKnownU64 = OffsetWasConst;
   const bool CanUseConstBaseDispPath =
       OffsetWasConst &&
       (ConstAddr = OriginalConstOffset) <= static_cast<uint64_t>(INT32_MAX);
-  normalizeOperandU64(AddrComponents);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemory();
 #endif
   MType *I64Type = &Ctx.I64Type;
 
-  U256Inst AddrParts = extractU256Operand(AddrComponents);
-  MInstruction *Offset = AddrParts[0];
+  const bool CanUseLinearU64AddrFastPath =
+      CurBlockLinearPrecheckPlan.Active &&
+      CurBlockLinearPrecheckPlan.CoveredDirectOpsRemaining != 0;
+  MInstruction *Offset = nullptr;
+  bool UsedLinearPrecheck = false;
+  if (CanUseLinearU64AddrFastPath) {
+    Offset = extractKnownU64LowOperand(AddrComponents);
+    UsedLinearPrecheck = tryConsumeLinearBlockMemoryPrecheck(Offset, nullptr);
+    OffsetKnownU64 = OffsetKnownU64 || UsedLinearPrecheck;
+  }
+  if (!UsedLinearPrecheck) {
+    normalizeOperandU64(AddrComponents);
+    Offset = extractKnownU64LowOperand(AddrComponents);
+  }
   U256Inst ValueParts = extractU256Operand(ValueComponents);
 
   MInstruction *SizeConst = createIntConstInstruction(I64Type, 1);
@@ -4993,7 +5004,8 @@ void EVMMirBuilder::handleMStore8(Operand AddrComponents,
   MInstruction *Overflow = createInstruction<CmpInstruction>(
       false, CmpInstruction::Predicate::ICMP_ULT, I64Type, RequiredSize,
       Offset);
-  bool UsedSharedPrecheck = tryConsumeConstBlockMemoryPrecheck();
+  bool UsedSharedPrecheck =
+      UsedLinearPrecheck || tryConsumeConstBlockMemoryPrecheck();
   noteSmallFrameMemoryOp(SmallFrameMemoryOp::MStore8, OffsetWasConst,
                          OriginalConstOffset, OffsetKnownU64, 1,
                          UsedSharedPrecheck);

--- a/src/tests/evm_jit_frontend_tests.cpp
+++ b/src/tests/evm_jit_frontend_tests.cpp
@@ -386,8 +386,17 @@ public:
 
   void beginMemoryCompileBlock(uint64_t) {}
   void setMemoryCompileBlockConstPrecheckPlan(uint64_t, uint64_t) {}
-  void setMemoryCompileBlockLinearPrecheckPlan(uint64_t, uint64_t, bool) {}
-  void prepareLinearBlockMemoryPrecheck(Operand) {}
+  void setMemoryCompileBlockLinearPrecheckPlan(uint64_t AccessWidth,
+                                               uint64_t CoveredDirectOps,
+                                               bool ValueEqualsFirstAddr) {
+    LinearPrecheckPlanCount++;
+    LastLinearPrecheckAccessWidth = AccessWidth;
+    LastLinearPrecheckCoveredDirectOps = CoveredDirectOps;
+    LastLinearPrecheckValueEqualsFirstAddr = ValueEqualsFirstAddr;
+  }
+  void prepareLinearBlockMemoryPrecheck(Operand) {
+    LinearPrecheckPrepareCount++;
+  }
   void noteMemoryOpcodeInBlock(evmc_opcode, uint64_t) {}
   void noteHelperOpcodeInBlock(evmc_opcode, uint64_t) {}
   void endMemoryCompileBlock() {}
@@ -455,6 +464,24 @@ public:
     return RuntimeStack.back().resolvedValue();
   }
 
+  uint32_t linearPrecheckPlanCount() const { return LinearPrecheckPlanCount; }
+
+  uint64_t lastLinearPrecheckAccessWidth() const {
+    return LastLinearPrecheckAccessWidth;
+  }
+
+  uint64_t lastLinearPrecheckCoveredDirectOps() const {
+    return LastLinearPrecheckCoveredDirectOps;
+  }
+
+  bool lastLinearPrecheckValueEqualsFirstAddr() const {
+    return LastLinearPrecheckValueEqualsFirstAddr;
+  }
+
+  uint32_t linearPrecheckPrepareCount() const {
+    return LinearPrecheckPrepareCount;
+  }
+
   bool Trapped = false;
   bool Undefined = false;
 
@@ -478,6 +505,11 @@ private:
   std::vector<Operand> RuntimeStack;
   MockOperand::U256Value LastPushValue = {0, 0, 0, 0};
   bool HasLastPushValue = false;
+  uint32_t LinearPrecheckPlanCount = 0;
+  uint64_t LastLinearPrecheckAccessWidth = 0;
+  uint64_t LastLinearPrecheckCoveredDirectOps = 0;
+  bool LastLinearPrecheckValueEqualsFirstAddr = false;
+  uint32_t LinearPrecheckPrepareCount = 0;
 
 #undef MOCK_OPERAND_STUB
 #undef MOCK_VOID_STUB
@@ -1138,6 +1170,44 @@ TEST(EVMJITFrontendVisitorTest, FusesLinearMStoreNextMotifIntoMeteredRange) {
   EXPECT_EQ(Builder.lastMStore().Value[0], 0x40U);
   EXPECT_EQ(Builder.runtimeStackDepth(), 2U);
   EXPECT_EQ(Builder.topStackValue()[0], 0x60U);
+}
+
+TEST(EVMJITFrontendVisitorTest, PlansLinearMStore8NextMotifMemoryPrecheck) {
+  const std::vector<uint8_t> Bytecode = {
+      0x5f, // PUSH0 calldata offset for stride
+      0x35, // CALLDATALOAD
+      0x5f, // PUSH0 current
+      0x80, // DUP1
+      0x80, // DUP1
+      0x53, // MSTORE8
+      0x81, // DUP2
+      0x01, // ADD
+      0x80, // DUP1
+      0x80, // DUP1
+      0x53, // MSTORE8
+      0x81, // DUP2
+      0x01, // ADD
+      0x00  // STOP
+  };
+
+  COMPILER::EVMFrontendContext Ctx;
+  Ctx.setRevision(EVMC_CANCUN);
+  Ctx.setBytecode(reinterpret_cast<const zen::common::Byte *>(Bytecode.data()),
+                  Bytecode.size());
+
+  MockEVMBuilder Builder;
+  COMPILER::EVMByteCodeVisitor<MockEVMBuilder> Visitor(Builder, &Ctx);
+  EXPECT_TRUE(Visitor.compile());
+  EXPECT_FALSE(Builder.Trapped);
+  EXPECT_FALSE(Builder.Undefined);
+
+  EXPECT_EQ(Builder.linearPrecheckPlanCount(), 1U);
+  EXPECT_EQ(Builder.lastLinearPrecheckAccessWidth(), 1U);
+  EXPECT_EQ(Builder.lastLinearPrecheckCoveredDirectOps(), 2U);
+  EXPECT_FALSE(Builder.lastLinearPrecheckValueEqualsFirstAddr());
+  EXPECT_EQ(Builder.linearPrecheckPrepareCount(), 2U);
+  EXPECT_EQ(Builder.meteredOpcodeCount(OP_MSTORE8), 2U);
+  EXPECT_EQ(Builder.runtimeStackDepth(), 2U);
 }
 
 TEST(EVMJITFrontendVisitorTest, FusesCallerSlotKeccakIntoMeteredRange) {


### PR DESCRIPTION
Extend the EVM JIT linear memory precheck planner to cover repeated MSTORE8 write motifs. Reuse the existing block precheck plan with AccessWidth=1 so byte writes can share one memory proof across the block.

Previously, dynamic MSTORE8 recurrences still normalized and prechecked memory per opcode while MLOAD and MSTORE could consume a shared linear block precheck.

<!-- Thank you for contributing to DTVM!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.

-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    lib/wasi,
    smart_ir/src/abi
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```