### PR TITLE
perf(evm): pre-expand COPY memory in multipass JIT

### DIFF
--- a/src/compiler/evm_frontend/evm_imported.cpp
+++ b/src/compiler/evm_frontend/evm_imported.cpp
@@ -212,6 +212,7 @@ const RuntimeFunctions &getRuntimeFunctionTable() {
       .GetCallDataSize = &evmGetCallDataSize,
       .GetCodeSize = &evmGetCodeSize,
       .SetCodeCopy = &evmSetCodeCopy,
+      .SetCodeCopyNoExpand = &evmSetCodeCopyNoExpand,
       .GetGasPrice = &evmGetGasPrice,
       .GetExtCodeSize = &evmGetExtCodeSize,
       .GetExtCodeHash = &evmGetExtCodeHash,
@@ -234,6 +235,7 @@ const RuntimeFunctions &getRuntimeFunctionTable() {
       .SetTStore = &evmSetTStore,
       .SetCallDataCopy = &evmSetCallDataCopy,
       .TouchExtCodeCopyAccount = &evmTouchExtCodeCopyAccount,
+      .SetCallDataCopyNoExpand = &evmSetCallDataCopyNoExpand,
       .SetExtCodeCopy = &evmSetExtCodeCopy,
       .SetReturnDataCopy = &evmSetReturnDataCopy,
       .ExpandMemoryNoGas = &evmExpandMemoryNoGas,
@@ -669,11 +671,21 @@ void evmSetCallDataCopy(zen::runtime::EVMInstance *Instance,
       return;
     }
   }
+  evmSetCallDataCopyNoExpand(Instance, DestOffset, Offset, Size);
+}
 
+void evmSetCallDataCopyNoExpand(zen::runtime::EVMInstance *Instance,
+                                uint64_t DestOffset, uint64_t Offset,
+                                uint64_t Size) {
+  // JIT no-expand callers must prove memory and charge word-copy gas first.
+  if (Size == 0) {
+    return;
+  }
   const evmc_message *Msg = Instance->getCurrentMessage();
   ZEN_ASSERT(Msg && "No current message set in EVMInstance");
 
   uint8_t *MemoryBase = Instance->getMemoryBase();
+  ZEN_ASSERT(MemoryBase);
 
   // Calculate actual source offset and copy size
   uint64_t ActualOffset =
@@ -1289,13 +1301,23 @@ void evmSetCodeCopy(zen::runtime::EVMInstance *Instance, uint64_t DestOffset,
       return;
     }
   }
+  evmSetCodeCopyNoExpand(Instance, DestOffset, Offset, Size);
+}
 
+void evmSetCodeCopyNoExpand(zen::runtime::EVMInstance *Instance,
+                            uint64_t DestOffset, uint64_t Offset,
+                            uint64_t Size) {
+  // JIT no-expand callers must prove memory and charge word-copy gas first.
+  if (Size == 0) {
+    return;
+  }
   const zen::runtime::EVMModule *Module = Instance->getModule();
   ZEN_ASSERT(Module);
   const zen::common::Byte *Code = Module->Code;
   size_t CodeSize = Module->CodeSize;
 
   uint8_t *MemoryBase = Instance->getMemoryBase();
+  ZEN_ASSERT(MemoryBase);
 
   if (Offset < CodeSize) {
     auto CopySize = std::min(Size, CodeSize - Offset);

--- a/src/compiler/evm_frontend/evm_imported.h
+++ b/src/compiler/evm_frontend/evm_imported.h
@@ -106,6 +106,7 @@ struct RuntimeFunctions {
   SizeFn GetCallDataSize;
   SizeFn GetCodeSize;
   VoidWithUInt64UInt64UInt64Fn SetCodeCopy;
+  VoidWithUInt64UInt64UInt64Fn SetCodeCopyNoExpand;
   U256Fn GetGasPrice;
   SizeWithBytes32Fn GetExtCodeSize;
   U256WithBytes32Fn GetExtCodeHash;
@@ -128,6 +129,7 @@ struct RuntimeFunctions {
   VoidWithU256U256Fn SetTStore;
   VoidWithUInt64UInt64UInt64Fn SetCallDataCopy;
   VoidWithBytes32Fn TouchExtCodeCopyAccount;
+  VoidWithUInt64UInt64UInt64Fn SetCallDataCopyNoExpand;
   VoidWithBytes32UInt64UInt64UInt64Fn SetExtCodeCopy;
   UInt64WithUInt64UInt64UInt64Fn SetReturnDataCopy;
   VoidWithUInt64Fn ExpandMemoryNoGas;
@@ -202,6 +204,9 @@ uint64_t evmGetCallDataSize(zen::runtime::EVMInstance *Instance);
 uint64_t evmGetCodeSize(zen::runtime::EVMInstance *Instance);
 void evmSetCodeCopy(zen::runtime::EVMInstance *Instance, uint64_t DestOffset,
                     uint64_t Offset, uint64_t Size);
+void evmSetCodeCopyNoExpand(zen::runtime::EVMInstance *Instance,
+                            uint64_t DestOffset, uint64_t Offset,
+                            uint64_t Size);
 const intx::uint256 *evmGetGasPrice(zen::runtime::EVMInstance *Instance);
 uint64_t evmGetExtCodeSize(zen::runtime::EVMInstance *Instance,
                            const uint8_t *Address);
@@ -224,6 +229,9 @@ void evmSetCallDataCopy(zen::runtime::EVMInstance *Instance,
                         uint64_t DestOffset, uint64_t Offset, uint64_t Size);
 void evmTouchExtCodeCopyAccount(zen::runtime::EVMInstance *Instance,
                                 const uint8_t *Address);
+void evmSetCallDataCopyNoExpand(zen::runtime::EVMInstance *Instance,
+                                uint64_t DestOffset, uint64_t Offset,
+                                uint64_t Size);
 void evmSetExtCodeCopy(zen::runtime::EVMInstance *Instance,
                        const uint8_t *Address, uint64_t DestOffset,
                        uint64_t Offset, uint64_t Size);

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -4553,19 +4553,14 @@ void EVMMirBuilder::handleCodeCopy(Operand DestOffsetComponents,
                                    Operand OffsetComponents,
                                    Operand SizeComponents) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
-  normalizeOffsetWithSize(DestOffsetComponents, SizeComponents);
+  preExpandCopyMemory(DestOffsetComponents, SizeComponents);
+  MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
+  chargeWordCopyGasIR(Size);
   uint64_t Non64Value = std::numeric_limits<uint64_t>::max();
   normalizeOperandU64(OffsetComponents, &Non64Value);
-#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
-  syncGasToMemory();
-#endif
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t, uint64_t>(
-      RuntimeFunctions.SetCodeCopy, DestOffsetComponents, OffsetComponents,
-      SizeComponents);
-#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
-  reloadGasFromMemory();
-#endif
-  reloadMemorySizeFromInstance();
+      RuntimeFunctions.SetCodeCopyNoExpand, DestOffsetComponents,
+      OffsetComponents, SizeComponents);
 }
 
 typename EVMMirBuilder::Operand
@@ -6371,6 +6366,41 @@ void EVMMirBuilder::preExpandKeccakTwoWordMemory(Operand &OffsetComponents) {
   expandMemoryIR(RequiredSize, Overflow);
 }
 
+void EVMMirBuilder::preExpandCopyMemory(Operand &DestOffsetComponents,
+                                        Operand &SizeComponents) {
+  normalizeOffsetWithSize(DestOffsetComponents, SizeComponents);
+
+  MType *I64Type = &Ctx.I64Type;
+  MInstruction *DestOffset = extractKnownU64LowOperand(DestOffsetComponents);
+  MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
+  MInstruction *RequiredSize = createInstruction<BinaryInstruction>(
+      false, OP_add, I64Type, DestOffset, Size);
+  MInstruction *Overflow = createInstruction<CmpInstruction>(
+      false, CmpInstruction::Predicate::ICMP_ULT, I64Type, RequiredSize,
+      DestOffset);
+  expandMemoryIR(RequiredSize, Overflow);
+}
+
+void EVMMirBuilder::chargeWordCopyGasIR(MInstruction *Size) {
+  MType *I64Type = &Ctx.I64Type;
+  MInstruction *Shift5 = createIntConstInstruction(I64Type, 5);
+  MInstruction *WordMask = createIntConstInstruction(I64Type, 31);
+  MInstruction *Words = createInstruction<BinaryInstruction>(
+      false, OP_ushr, I64Type, Size, Shift5);
+  MInstruction *TrailingBytes = createInstruction<BinaryInstruction>(
+      false, OP_and, I64Type, Size, WordMask);
+  MInstruction *Zero = createIntConstInstruction(I64Type, 0);
+  MInstruction *HasTrailingBytes = createInstruction<CmpInstruction>(
+      false, CmpInstruction::Predicate::ICMP_NE, I64Type, TrailingBytes, Zero);
+  Words = createInstruction<BinaryInstruction>(false, OP_add, I64Type, Words,
+                                               HasTrailingBytes);
+  MInstruction *WordCopyCost =
+      createIntConstInstruction(I64Type, zen::evm::WORD_COPY_COST);
+  MInstruction *CopyGas = createInstruction<BinaryInstruction>(
+      false, OP_mul, I64Type, Words, WordCopyCost);
+  chargeDynamicGasIR(CopyGas);
+}
+
 // Template function for no-argument runtime calls
 template <typename RetType>
 typename EVMMirBuilder::Operand
@@ -6761,19 +6791,13 @@ void EVMMirBuilder::handleCallDataCopy(Operand DestOffsetComponents,
                                        Operand SizeComponents) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   uint64_t Non64Value = std::numeric_limits<uint64_t>::max();
-  normalizeOperandU64(DestOffsetComponents, &Non64Value);
+  preExpandCopyMemory(DestOffsetComponents, SizeComponents);
+  MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
+  chargeWordCopyGasIR(Size);
   normalizeOperandU64(OffsetComponents, &Non64Value);
-  normalizeOperandU64(SizeComponents, &Non64Value);
-#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
-  syncGasToMemory();
-#endif
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t, uint64_t>(
-      RuntimeFunctions.SetCallDataCopy, DestOffsetComponents, OffsetComponents,
-      SizeComponents);
-#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
-  reloadGasFromMemory();
-#endif
-  reloadMemorySizeFromInstance();
+      RuntimeFunctions.SetCallDataCopyNoExpand, DestOffsetComponents,
+      OffsetComponents, SizeComponents);
 }
 
 void EVMMirBuilder::handleExtCodeCopy(Operand AddressComponents,

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -1647,6 +1647,9 @@ private:
   void reloadMemorySizeFromInstance();
   void expandMemoryIR(MInstruction *RequiredSize, MInstruction *Overflow);
   void preExpandKeccakTwoWordMemory(Operand &OffsetComponents);
+  void preExpandCopyMemory(Operand &DestOffsetComponents,
+                           Operand &SizeComponents);
+  void chargeWordCopyGasIR(MInstruction *Size);
   void chargeDynamicGasIR(MInstruction *GasCost);
   void chargeMemoryExpansionGasIR(MInstruction *CurrentSize,
                                   MInstruction *NewSize);

--- a/src/tests/evm_interp_tests.cpp
+++ b/src/tests/evm_interp_tests.cpp
@@ -275,6 +275,14 @@ std::vector<uint8_t> makePaddedAddressWord(const evmc::address &Address) {
   return Word;
 }
 
+std::vector<uint8_t> makeIncrementingBytes(size_t Size) {
+  std::vector<uint8_t> Data(Size);
+  for (size_t I = 0; I < Data.size(); ++I) {
+    Data[I] = static_cast<uint8_t>(I);
+  }
+  return Data;
+}
+
 void expectInterpMatchesMultipass(const std::string &ModuleName,
                                   const std::vector<uint8_t> &Bytecode,
                                   const std::vector<uint8_t> &CallData,
@@ -621,6 +629,74 @@ TEST(EVMMultipassDisplacedBytes32Test,
   EXPECT_TRUE(Exec.JITCompiled);
 #endif
   EXPECT_EQ(Exec.Status, EVMC_OUT_OF_GAS);
+}
+
+TEST(EVMMultipassCopyHelperTest,
+     CallDataCopyMatchesInterpreterAfterMemoryPreExpand) {
+  auto BytecodeBuf = zen::utils::fromHex("6030601060203760406020f3");
+  ASSERT_TRUE(BytecodeBuf) << "Failed to parse calldata-copy bytecode";
+
+  const std::vector<uint8_t> CallData = makeIncrementingBytes(80);
+  std::vector<uint8_t> ExpectedOutput;
+  ExpectedOutput.insert(ExpectedOutput.end(), CallData.begin() + 16,
+                        CallData.begin() + 64);
+  ExpectedOutput.resize(64, 0);
+
+  expectInterpMatchesMultipass(
+      "calldatacopy_preexpand", *BytecodeBuf, CallData, EVMC_SUCCESS,
+      zen::utils::toHex(ExpectedOutput.data(), ExpectedOutput.size()));
+}
+
+TEST(EVMMultipassCopyHelperTest,
+     CallDataCopyZeroSizeWithOversizedDestRemainsNoOp) {
+  auto BytecodeBuf = zen::utils::fromHex(
+      "60006000"
+      "7f0100000000000000000000000000000000000000000000000000000000000000"
+      "3760006000f3");
+  ASSERT_TRUE(BytecodeBuf)
+      << "Failed to parse zero-size calldata-copy bytecode";
+
+  expectInterpMatchesMultipass("calldatacopy_zero_size_oversized_dest",
+                               *BytecodeBuf, {}, EVMC_SUCCESS);
+}
+
+TEST(EVMMultipassCopyHelperTest,
+     CallDataCopyNonZeroSizeWithOversizedDestReturnsOutOfGas) {
+  auto BytecodeBuf = zen::utils::fromHex(
+      "60016000"
+      "7f0100000000000000000000000000000000000000000000000000000000000000"
+      "3700");
+  ASSERT_TRUE(BytecodeBuf)
+      << "Failed to parse oversized calldata-copy bytecode";
+
+  expectInterpMatchesMultipass("calldatacopy_nonzero_size_oversized_dest",
+                               *BytecodeBuf, {}, EVMC_OUT_OF_GAS);
+}
+
+TEST(EVMMultipassCopyHelperTest,
+     CodeCopyMatchesInterpreterAfterMemoryPreExpand) {
+  auto BytecodeBuf = zen::utils::fromHex("6008600060003960206000f3");
+  ASSERT_TRUE(BytecodeBuf) << "Failed to parse code-copy bytecode";
+
+  std::vector<uint8_t> ExpectedOutput = {0x60, 0x08, 0x60, 0x00,
+                                         0x60, 0x00, 0x39, 0x60};
+  ExpectedOutput.resize(32, 0);
+
+  expectInterpMatchesMultipass(
+      "codecopy_preexpand", *BytecodeBuf, {}, EVMC_SUCCESS,
+      zen::utils::toHex(ExpectedOutput.data(), ExpectedOutput.size()));
+}
+
+TEST(EVMMultipassCopyHelperTest,
+     CodeCopyNonZeroSizeWithOversizedDestReturnsOutOfGas) {
+  auto BytecodeBuf = zen::utils::fromHex(
+      "60016000"
+      "7f0100000000000000000000000000000000000000000000000000000000000000"
+      "3900");
+  ASSERT_TRUE(BytecodeBuf) << "Failed to parse oversized code-copy bytecode";
+
+  expectInterpMatchesMultipass("codecopy_nonzero_size_oversized_dest",
+                               *BytecodeBuf, {}, EVMC_OUT_OF_GAS);
 }
 
 TEST(EVMMultipassKeccakHelperTest,


### PR DESCRIPTION
Move CALLDATACOPY and CODECOPY memory expansion plus word-copy gas charging into MIR before calling no-expand runtime helpers.

Keep the runtime-expanding helpers for fallback callers, and add interpreter-vs-multipass tests for normal copies plus zero-size and oversized-destination edge cases.

<!-- Thank you for contributing to DTVM!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.

-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    lib/wasi,
    smart_ir/src/abi
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```