### PR TITLE
perf(evm): pre-expand KECCAK memory in multipass JIT

### DIFF
--- a/src/compiler/evm_frontend/evm_imported.cpp
+++ b/src/compiler/evm_frontend/evm_imported.cpp
@@ -98,6 +98,11 @@ inline uint64_t calculateWordCopyGas(uint64_t Size) {
   return Words * static_cast<uint64_t>(zen::evm::WORD_COPY_COST);
 }
 
+bool chargeKeccakWordGas(zen::runtime::EVMInstance *Instance, uint64_t Length) {
+  const uint64_t ExtraGas = static_cast<uint64_t>(numWords(Length)) * 6;
+  return Instance->chargeGas(ExtraGas);
+}
+
 const uint8_t *cacheKeccak256Result(zen::runtime::EVMInstance *Instance,
                                     const uint8_t *InputData, uint64_t Length) {
   auto &ExecCache = Instance->getMessageCache();
@@ -255,6 +260,7 @@ const RuntimeFunctions &getRuntimeFunctionTable() {
       .HandleUndefined = &evmHandleUndefined,
       .HandleSelfDestruct = &evmHandleSelfDestruct,
       .GetKeccak256 = &evmGetKeccak256,
+      .GetKeccak256NoExpand = &evmGetKeccak256NoExpand,
       .GetKeccak256TwoWord = &evmGetKeccak256TwoWord,
       .GetKeccak256TwoWordNoExpand = &evmGetKeccak256TwoWordNoExpand,
       .GetKeccak256CallDataSlot = &evmGetKeccak256CallDataSlot,
@@ -1312,17 +1318,25 @@ void evmSetCodeCopy(zen::runtime::EVMInstance *Instance, uint64_t DestOffset,
 
 const uint8_t *evmGetKeccak256(zen::runtime::EVMInstance *Instance,
                                uint64_t Offset, uint64_t Length) {
-  const uint8_t *InputData = nullptr;
   if (Length > 0) {
     uint8_t *MemoryBase = nullptr;
     if (!prepareKeccakMemoryRange(Instance, Offset, Length, MemoryBase)) {
       return nullptr;
     }
-    const uint64_t ExtraGas =
-        static_cast<uint64_t>(numWords(static_cast<uint64_t>(Length))) * 6;
-    if (!Instance->chargeGas(ExtraGas)) {
+    if (!chargeKeccakWordGas(Instance, Length)) {
       return nullptr;
     }
+  }
+
+  return evmGetKeccak256NoExpand(Instance, Offset, Length);
+}
+
+const uint8_t *evmGetKeccak256NoExpand(zen::runtime::EVMInstance *Instance,
+                                       uint64_t Offset, uint64_t Length) {
+  const uint8_t *InputData = nullptr;
+  if (Length > 0) {
+    uint8_t *MemoryBase = Instance->getMemoryBase();
+    ZEN_ASSERT(MemoryBase);
     InputData = MemoryBase + Offset;
   }
 

--- a/src/compiler/evm_frontend/evm_imported.h
+++ b/src/compiler/evm_frontend/evm_imported.h
@@ -149,6 +149,7 @@ struct RuntimeFunctions {
   VoidFn HandleUndefined;
   VoidWithBytes32Fn HandleSelfDestruct;
   Bytes32WithUInt64UInt64Fn GetKeccak256;
+  Bytes32WithUInt64UInt64Fn GetKeccak256NoExpand;
   Bytes32WithUInt64U256U256Fn GetKeccak256TwoWord;
   Bytes32WithUInt64U256U256Fn GetKeccak256TwoWordNoExpand;
   Bytes32WithUInt64UInt64U256Fn GetKeccak256CallDataSlot;
@@ -275,6 +276,8 @@ void evmHandleInvalid(zen::runtime::EVMInstance *Instance);
 void evmHandleUndefined(zen::runtime::EVMInstance *Instance);
 const uint8_t *evmGetKeccak256(zen::runtime::EVMInstance *Instance,
                                uint64_t Offset, uint64_t Length);
+const uint8_t *evmGetKeccak256NoExpand(zen::runtime::EVMInstance *Instance,
+                                       uint64_t Offset, uint64_t Length);
 const uint8_t *evmGetKeccak256TwoWord(zen::runtime::EVMInstance *Instance,
                                       uint64_t Offset,
                                       const intx::uint256 &Word0,

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -5493,19 +5493,25 @@ EVMMirBuilder::handleKeccak256(Operand OffsetComponents,
   const bool LengthWasConstU64 = LengthComponents.isConstU64();
   const uint64_t ConstLength =
       LengthWasConstU64 ? LengthComponents.getConstValue()[0] : 0;
-  normalizeOffsetWithSize(OffsetComponents, LengthComponents);
+  if (LengthWasConstU64 && ConstLength == 0) {
+    normalizeOffsetWithSize(OffsetComponents, LengthComponents);
+#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
+    syncGasToMemory();
+#endif
+  } else {
+    preExpandMemoryRange(OffsetComponents, LengthComponents);
+    MInstruction *Length = extractKnownU64LowOperand(LengthComponents);
+    chargeKeccakWordGasIR(Length);
+  }
   noteKeccak256MemoryAccess(OffsetWasConstU64, ConstOffset, LengthWasConstU64,
                             ConstLength);
-#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
-  syncGasToMemory();
-#endif
   auto Result =
       callRuntimeForWithErrorCheck<const uint8_t *, uint64_t, uint64_t>(
-          RuntimeFunctions.GetKeccak256, OffsetComponents, LengthComponents);
+          RuntimeFunctions.GetKeccak256NoExpand, OffsetComponents,
+          LengthComponents);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
   return Result;
 }
 
@@ -6338,6 +6344,20 @@ void EVMMirBuilder::normalizeOffsetWithSize(Operand &Offset, Operand &Size) {
       false, I64Type, IsSizeZero, Zero, OffsetParts[0]);
   U256Inst NewVal = {SelectedLow, Zero, Zero, Zero};
   Offset = Operand(NewVal, EVMType::UINT256);
+}
+
+void EVMMirBuilder::preExpandMemoryRange(Operand &Offset, Operand &Size) {
+  normalizeOffsetWithSize(Offset, Size);
+
+  MType *I64Type = &Ctx.I64Type;
+  MInstruction *OffsetLow = extractKnownU64LowOperand(Offset);
+  MInstruction *SizeLow = extractKnownU64LowOperand(Size);
+  MInstruction *RequiredSize = createInstruction<BinaryInstruction>(
+      false, OP_add, I64Type, OffsetLow, SizeLow);
+  MInstruction *Overflow = createInstruction<CmpInstruction>(
+      false, CmpInstruction::Predicate::ICMP_ULT, I64Type, RequiredSize,
+      OffsetLow);
+  expandMemoryIR(RequiredSize, Overflow);
 }
 
 void EVMMirBuilder::preExpandKeccakTwoWordMemory(Operand &OffsetComponents) {
@@ -8066,6 +8086,21 @@ void EVMMirBuilder::chargeDynamicGasIR(MInstruction *GasCost) {
   createInstruction<BrInstruction>(true, Ctx, MsgSkipBB);
   addSuccessor(MsgSkipBB);
   setInsertBlock(MsgSkipBB);
+}
+
+void EVMMirBuilder::chargeKeccakWordGasIR(MInstruction *Length) {
+  MType *I64Type = &Ctx.I64Type;
+
+  MInstruction *Const31 = createIntConstInstruction(I64Type, 31);
+  MInstruction *Shift5 = createIntConstInstruction(I64Type, 5);
+  MInstruction *LenPlus31 = createInstruction<BinaryInstruction>(
+      false, OP_add, I64Type, Length, Const31);
+  MInstruction *Words = createInstruction<BinaryInstruction>(
+      false, OP_ushr, I64Type, LenPlus31, Shift5);
+  MInstruction *WordGas = createIntConstInstruction(I64Type, 6);
+  MInstruction *KeccakGas = createInstruction<BinaryInstruction>(
+      false, OP_mul, I64Type, Words, WordGas);
+  chargeDynamicGasIR(KeccakGas);
 }
 
 void EVMMirBuilder::chargeMemoryExpansionGasIR(MInstruction *OldSize,

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -1301,6 +1301,7 @@ private:
   MInstruction *anchorDirectMemoryPointer(MInstruction *Ptr);
   MInstruction *extractKnownU64LowOperand(const Operand &Opnd);
   void normalizeOffsetWithSize(Operand &Offset, Operand &Size);
+  void preExpandMemoryRange(Operand &Offset, Operand &Size);
 
   Operand convertSingleInstrToU256Operand(MInstruction *SingleInstr);
   Operand convertU256InstrToU256Operand(MInstruction *U256Instr);
@@ -1648,6 +1649,7 @@ private:
   void expandMemoryIR(MInstruction *RequiredSize, MInstruction *Overflow);
   void preExpandKeccakTwoWordMemory(Operand &OffsetComponents);
   void chargeDynamicGasIR(MInstruction *GasCost);
+  void chargeKeccakWordGasIR(MInstruction *Length);
   void chargeMemoryExpansionGasIR(MInstruction *CurrentSize,
                                   MInstruction *NewSize);
   MInstruction *calculateMemoryGasCostIR(MInstruction *SizeInBytes);

--- a/src/tests/evm_interp_tests.cpp
+++ b/src/tests/evm_interp_tests.cpp
@@ -269,6 +269,11 @@ std::string computeTwoWordKeccakHex(const std::vector<uint8_t> &Word0,
   return zen::utils::toHex(Hash.data(), Hash.size());
 }
 
+std::string computeKeccakHex(const std::vector<uint8_t> &Input) {
+  const auto Hash = zen::host::evm::crypto::keccak256(Input);
+  return zen::utils::toHex(Hash.data(), Hash.size());
+}
+
 std::vector<uint8_t> makePaddedAddressWord(const evmc::address &Address) {
   std::vector<uint8_t> Word(32, 0);
   std::memcpy(Word.data() + 12, Address.bytes, sizeof(Address.bytes));
@@ -686,6 +691,57 @@ TEST(EVMMultipassKeccakHelperTest,
 
   expectInterpMatchesMultipass("keccak_calldata_const_slot_mem_oog",
                                *BytecodeBuf, makeUint256Calldata(0x1234),
+                               EVMC_OUT_OF_GAS);
+}
+
+TEST(EVMMultipassKeccakHelperTest,
+     GenericKeccakPreExpandMatchesInterpreterAndExpectedDigest) {
+  std::vector<uint8_t> Word(32);
+  for (size_t I = 0; I < Word.size(); ++I) {
+    Word[I] = static_cast<uint8_t>(I);
+  }
+
+  std::vector<uint8_t> Bytecode = {0x7f};
+  Bytecode.insert(Bytecode.end(), Word.begin(), Word.end());
+  const std::vector<uint8_t> Suffix = {
+      0x60, 0x00, 0x52,       // MSTORE word at memory offset 0.
+      0x60, 0x30, 0x60, 0x00, // KECCAK256 memory[0:48].
+      0x20, 0x60, 0x00, 0x52, // Store digest at memory offset 0.
+      0x60, 0x20, 0x60, 0x00, 0xf3};
+  Bytecode.insert(Bytecode.end(), Suffix.begin(), Suffix.end());
+
+  std::vector<uint8_t> KeccakInput = Word;
+  KeccakInput.insert(KeccakInput.end(), 16, 0);
+  const std::string ExpectedDigest = computeKeccakHex(KeccakInput);
+
+  expectInterpMatchesMultipass("keccak_generic_preexpand_48", Bytecode, {},
+                               EVMC_SUCCESS, ExpectedDigest);
+}
+
+TEST(EVMMultipassKeccakHelperTest,
+     GenericKeccakZeroLengthAllowsOversizedOffset) {
+  std::vector<uint8_t> Bytecode = {0x60, 0x00, 0x7f, 0x01};
+  Bytecode.insert(Bytecode.end(), 31, 0x00);
+  const std::vector<uint8_t> Suffix = {0x20, 0x60, 0x00, 0x52,
+                                       0x60, 0x20, 0x60, 0x00};
+  Bytecode.insert(Bytecode.end(), Suffix.begin(), Suffix.end());
+  Bytecode.push_back(0xf3);
+
+  const std::vector<uint8_t> EmptyInput;
+  const std::string ExpectedDigest = computeKeccakHex(EmptyInput);
+
+  expectInterpMatchesMultipass("keccak_zero_size_oversized_offset", Bytecode,
+                               {}, EVMC_SUCCESS, ExpectedDigest);
+}
+
+TEST(EVMMultipassKeccakHelperTest,
+     GenericKeccakNonZeroLengthRejectsOversizedOffset) {
+  std::vector<uint8_t> Bytecode = {0x60, 0x01, 0x7f, 0x01};
+  Bytecode.insert(Bytecode.end(), 31, 0x00);
+  Bytecode.push_back(0x20);
+  Bytecode.push_back(0x00);
+
+  expectInterpMatchesMultipass("keccak_nonzero_oversized_offset", Bytecode, {},
                                EVMC_OUT_OF_GAS);
 }
 


### PR DESCRIPTION
Move generic KECCAK memory expansion and per-word hash gas charging into the multipass JIT before calling a no-expand runtime hash helper.

Keep the original runtime helper as a fallback and reuse the no-expand helper for two-word KECCAK helpers to avoid repeating the same memory prepare. Add interpreter-vs-multipass tests for generic hashing and zero/nonzero oversized offset semantics.

<!-- Thank you for contributing to DTVM!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.

-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    lib/wasi,
    smart_ir/src/abi
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```