### PR TITLE
fix(evm): block gas limit overflow

### DIFF
--- a/src/tests/evm_interp_tests.cpp
+++ b/src/tests/evm_interp_tests.cpp
@@ -1159,3 +1159,166 @@ TEST(EVMRegressionTest, Issue545_BalanceReflectsUpfrontGasDeduction) {
   EXPECT_EQ(ReturnedBalance, ExpectedBalance)
       << "BALANCE should return sender balance after upfront gas deduction";
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests for Issue #563 / #564:
+//   loadState() must clamp int64_t fields (block_gas_limit, block_number,
+//   block_timestamp) to INT64_MAX when JSON values exceed INT64_MAX, rather
+//   than silently wrapping them to negative values.
+// ---------------------------------------------------------------------------
+
+// Helper: write a minimal state JSON with a specific tx_context field set to
+// the given numeric value. All other tx_context fields use safe defaults.
+static void writeInt64OverflowStateJson(const std::string &FilePath,
+                                        const std::string &FieldName,
+                                        const std::string &NumericValue) {
+  // clang-format off
+  const std::string DefaultJson = R"({
+  "accounts": {
+    "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+      "balance": "000000000000000000000000000000000000000000000000000000ffffffffff",
+      "nonce": 0, "code": "", "codehash": "0000000000000000000000000000000000000000000000000000000000000000", "storage": {}
+    }
+  },
+  "tx_context": {
+    "gas_price": "0000000000000000000000000000000000000000000000000000000000000010",
+    "block_number": 1,
+    "block_timestamp": 1000,
+    "block_coinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+    "block_prev_randao": "0000000000000000000000000000000000000000000000000000000000200000",
+    "block_gas_limit": 30000000,
+    "block_base_fee": "0000000000000000000000000000000000000000000000000000000000000010"
+  }
+})";
+  // clang-format on
+
+  // Map each field name to its default value in the template above.
+  std::string DefaultKeyValue;
+  if (FieldName == "block_gas_limit") {
+    DefaultKeyValue = "\"block_gas_limit\": 30000000";
+  } else if (FieldName == "block_number") {
+    DefaultKeyValue = "\"block_number\": 1";
+  } else if (FieldName == "block_timestamp") {
+    DefaultKeyValue = "\"block_timestamp\": 1000";
+  } else {
+    FAIL() << "Unsupported field name: " << FieldName;
+  }
+
+  std::string Content = DefaultJson;
+  auto Pos = Content.find(DefaultKeyValue);
+  ASSERT_NE(Pos, std::string::npos) << "Could not find default value for "
+                                    << FieldName << " in template JSON";
+  Content.replace(Pos, DefaultKeyValue.size(),
+                  "\"" + FieldName + "\": " + NumericValue);
+
+  std::ofstream OutFile(FilePath);
+  OutFile << Content;
+  OutFile.close();
+}
+
+// block_gas_limit = 2^63  →  clamped to INT64_MAX (no negative wrap)
+TEST(EVMStateSaveLoad, BlockGasLimitOverflowInt64) {
+  const std::string FilePath = "/tmp/dtvm_test_gas_limit_overflow_int64.json";
+  writeInt64OverflowStateJson(FilePath, "block_gas_limit",
+                              "9223372036854775808"); // 2^63
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_gas_limit,
+            std::numeric_limits<int64_t>::max());
+  EXPECT_GT(Host->tx_context.block_gas_limit, 0)
+      << "block_gas_limit must not be negative after clamp";
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_gas_limit = 2^64 - 1  →  clamped to INT64_MAX
+TEST(EVMStateSaveLoad, BlockGasLimitOverflowUint64Max) {
+  const std::string FilePath =
+      "/tmp/dtvm_test_gas_limit_overflow_uint64max.json";
+  writeInt64OverflowStateJson(FilePath, "block_gas_limit",
+                              "18446744073709551615"); // 2^64 - 1
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_gas_limit,
+            std::numeric_limits<int64_t>::max());
+  EXPECT_GT(Host->tx_context.block_gas_limit, 0)
+      << "block_gas_limit must not be negative after clamp";
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_gas_limit = INT64_MAX  →  exact value preserved (boundary)
+TEST(EVMStateSaveLoad, BlockGasLimitAtInt64Max) {
+  const std::string FilePath = "/tmp/dtvm_test_gas_limit_int64max.json";
+  writeInt64OverflowStateJson(FilePath, "block_gas_limit",
+                              "9223372036854775807"); // INT64_MAX
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_gas_limit,
+            std::numeric_limits<int64_t>::max());
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_number = 2^63  →  clamped to INT64_MAX
+TEST(EVMStateSaveLoad, BlockNumberOverflowInt64) {
+  const std::string FilePath =
+      "/tmp/dtvm_test_block_number_overflow_int64.json";
+  writeInt64OverflowStateJson(FilePath, "block_number",
+                              "9223372036854775808"); // 2^63
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_number, std::numeric_limits<int64_t>::max());
+  EXPECT_GT(Host->tx_context.block_number, 0)
+      << "block_number must not be negative after clamp";
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_number = INT64_MAX  →  exact value preserved
+TEST(EVMStateSaveLoad, BlockNumberAtInt64Max) {
+  const std::string FilePath = "/tmp/dtvm_test_block_number_int64max.json";
+  writeInt64OverflowStateJson(FilePath, "block_number",
+                              "9223372036854775807"); // INT64_MAX
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_number, std::numeric_limits<int64_t>::max());
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_timestamp = 2^63  →  clamped to INT64_MAX
+TEST(EVMStateSaveLoad, BlockTimestampOverflowInt64) {
+  const std::string FilePath =
+      "/tmp/dtvm_test_block_timestamp_overflow_int64.json";
+  writeInt64OverflowStateJson(FilePath, "block_timestamp",
+                              "9223372036854775808"); // 2^63
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_timestamp,
+            std::numeric_limits<int64_t>::max());
+  EXPECT_GT(Host->tx_context.block_timestamp, 0)
+      << "block_timestamp must not be negative after clamp";
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_timestamp = INT64_MAX  →  exact value preserved
+TEST(EVMStateSaveLoad, BlockTimestampAtInt64Max) {
+  const std::string FilePath = "/tmp/dtvm_test_block_timestamp_int64max.json";
+  writeInt64OverflowStateJson(FilePath, "block_timestamp",
+                              "9223372036854775807"); // INT64_MAX
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_timestamp,
+            std::numeric_limits<int64_t>::max());
+
+  std::filesystem::remove(FilePath);
+}

--- a/src/tests/evm_interp_tests.cpp
+++ b/src/tests/evm_interp_tests.cpp
@@ -1319,3 +1319,166 @@ TEST(EVMRegressionTest, Issue545_BalanceReflectsUpfrontGasDeduction) {
   EXPECT_EQ(ReturnedBalance, ExpectedBalance)
       << "BALANCE should return sender balance after upfront gas deduction";
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests for Issue #563 / #564:
+//   loadState() must clamp int64_t fields (block_gas_limit, block_number,
+//   block_timestamp) to INT64_MAX when JSON values exceed INT64_MAX, rather
+//   than silently wrapping them to negative values.
+// ---------------------------------------------------------------------------
+
+// Helper: write a minimal state JSON with a specific tx_context field set to
+// the given numeric value. All other tx_context fields use safe defaults.
+static void writeInt64OverflowStateJson(const std::string &FilePath,
+                                        const std::string &FieldName,
+                                        const std::string &NumericValue) {
+  // clang-format off
+  const std::string DefaultJson = R"({
+  "accounts": {
+    "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+      "balance": "000000000000000000000000000000000000000000000000000000ffffffffff",
+      "nonce": 0, "code": "", "codehash": "0000000000000000000000000000000000000000000000000000000000000000", "storage": {}
+    }
+  },
+  "tx_context": {
+    "gas_price": "0000000000000000000000000000000000000000000000000000000000000010",
+    "block_number": 1,
+    "block_timestamp": 1000,
+    "block_coinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+    "block_prev_randao": "0000000000000000000000000000000000000000000000000000000000200000",
+    "block_gas_limit": 30000000,
+    "block_base_fee": "0000000000000000000000000000000000000000000000000000000000000010"
+  }
+})";
+  // clang-format on
+
+  // Map each field name to its default value in the template above.
+  std::string DefaultKeyValue;
+  if (FieldName == "block_gas_limit") {
+    DefaultKeyValue = "\"block_gas_limit\": 30000000";
+  } else if (FieldName == "block_number") {
+    DefaultKeyValue = "\"block_number\": 1";
+  } else if (FieldName == "block_timestamp") {
+    DefaultKeyValue = "\"block_timestamp\": 1000";
+  } else {
+    FAIL() << "Unsupported field name: " << FieldName;
+  }
+
+  std::string Content = DefaultJson;
+  auto Pos = Content.find(DefaultKeyValue);
+  ASSERT_NE(Pos, std::string::npos) << "Could not find default value for "
+                                    << FieldName << " in template JSON";
+  Content.replace(Pos, DefaultKeyValue.size(),
+                  "\"" + FieldName + "\": " + NumericValue);
+
+  std::ofstream OutFile(FilePath);
+  OutFile << Content;
+  OutFile.close();
+}
+
+// block_gas_limit = 2^63  →  clamped to INT64_MAX (no negative wrap)
+TEST(EVMStateSaveLoad, BlockGasLimitOverflowInt64) {
+  const std::string FilePath = "/tmp/dtvm_test_gas_limit_overflow_int64.json";
+  writeInt64OverflowStateJson(FilePath, "block_gas_limit",
+                              "9223372036854775808"); // 2^63
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_gas_limit,
+            std::numeric_limits<int64_t>::max());
+  EXPECT_GT(Host->tx_context.block_gas_limit, 0)
+      << "block_gas_limit must not be negative after clamp";
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_gas_limit = 2^64 - 1  →  clamped to INT64_MAX
+TEST(EVMStateSaveLoad, BlockGasLimitOverflowUint64Max) {
+  const std::string FilePath =
+      "/tmp/dtvm_test_gas_limit_overflow_uint64max.json";
+  writeInt64OverflowStateJson(FilePath, "block_gas_limit",
+                              "18446744073709551615"); // 2^64 - 1
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_gas_limit,
+            std::numeric_limits<int64_t>::max());
+  EXPECT_GT(Host->tx_context.block_gas_limit, 0)
+      << "block_gas_limit must not be negative after clamp";
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_gas_limit = INT64_MAX  →  exact value preserved (boundary)
+TEST(EVMStateSaveLoad, BlockGasLimitAtInt64Max) {
+  const std::string FilePath = "/tmp/dtvm_test_gas_limit_int64max.json";
+  writeInt64OverflowStateJson(FilePath, "block_gas_limit",
+                              "9223372036854775807"); // INT64_MAX
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_gas_limit,
+            std::numeric_limits<int64_t>::max());
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_number = 2^63  →  clamped to INT64_MAX
+TEST(EVMStateSaveLoad, BlockNumberOverflowInt64) {
+  const std::string FilePath =
+      "/tmp/dtvm_test_block_number_overflow_int64.json";
+  writeInt64OverflowStateJson(FilePath, "block_number",
+                              "9223372036854775808"); // 2^63
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_number, std::numeric_limits<int64_t>::max());
+  EXPECT_GT(Host->tx_context.block_number, 0)
+      << "block_number must not be negative after clamp";
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_number = INT64_MAX  →  exact value preserved
+TEST(EVMStateSaveLoad, BlockNumberAtInt64Max) {
+  const std::string FilePath = "/tmp/dtvm_test_block_number_int64max.json";
+  writeInt64OverflowStateJson(FilePath, "block_number",
+                              "9223372036854775807"); // INT64_MAX
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_number, std::numeric_limits<int64_t>::max());
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_timestamp = 2^63  →  clamped to INT64_MAX
+TEST(EVMStateSaveLoad, BlockTimestampOverflowInt64) {
+  const std::string FilePath =
+      "/tmp/dtvm_test_block_timestamp_overflow_int64.json";
+  writeInt64OverflowStateJson(FilePath, "block_timestamp",
+                              "9223372036854775808"); // 2^63
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_timestamp,
+            std::numeric_limits<int64_t>::max());
+  EXPECT_GT(Host->tx_context.block_timestamp, 0)
+      << "block_timestamp must not be negative after clamp";
+
+  std::filesystem::remove(FilePath);
+}
+
+// block_timestamp = INT64_MAX  →  exact value preserved
+TEST(EVMStateSaveLoad, BlockTimestampAtInt64Max) {
+  const std::string FilePath = "/tmp/dtvm_test_block_timestamp_int64max.json";
+  writeInt64OverflowStateJson(FilePath, "block_timestamp",
+                              "9223372036854775807"); // INT64_MAX
+
+  auto Host = std::make_unique<zen::evm::ZenMockedEVMHost>();
+  ASSERT_TRUE(zen::utils::loadState(*Host, FilePath));
+  EXPECT_EQ(Host->tx_context.block_timestamp,
+            std::numeric_limits<int64_t>::max());
+
+  std::filesystem::remove(FilePath);
+}

--- a/src/utils/evm.cpp
+++ b/src/utils/evm.cpp
@@ -9,6 +9,7 @@
 #include "utils/rlp_encoding.h"
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
 
@@ -420,13 +421,20 @@ bool loadState(evmc::MockedHost &Host, const std::string &FilePath) {
 
     if (TxContext.HasMember("block_number") &&
         TxContext["block_number"].IsUint64()) {
-      Host.tx_context.block_number = TxContext["block_number"].GetUint64();
+      auto Val = TxContext["block_number"].GetUint64();
+      if (Val > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+        Val = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+      }
+      Host.tx_context.block_number = static_cast<int64_t>(Val);
     }
 
     if (TxContext.HasMember("block_timestamp") &&
         TxContext["block_timestamp"].IsUint64()) {
-      Host.tx_context.block_timestamp =
-          TxContext["block_timestamp"].GetUint64();
+      auto Val = TxContext["block_timestamp"].GetUint64();
+      if (Val > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+        Val = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+      }
+      Host.tx_context.block_timestamp = static_cast<int64_t>(Val);
     }
 
     if (TxContext.HasMember("block_coinbase") &&
@@ -443,8 +451,11 @@ bool loadState(evmc::MockedHost &Host, const std::string &FilePath) {
 
     if (TxContext.HasMember("block_gas_limit") &&
         TxContext["block_gas_limit"].IsUint64()) {
-      Host.tx_context.block_gas_limit =
-          TxContext["block_gas_limit"].GetUint64();
+      auto Val = TxContext["block_gas_limit"].GetUint64();
+      if (Val > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+        Val = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+      }
+      Host.tx_context.block_gas_limit = static_cast<int64_t>(Val);
     }
 
     if (TxContext.HasMember("block_base_fee") &&


### PR DESCRIPTION
Clamp block_gas_limit, block_number, and block_timestamp to INT64_MAX when their JSON values in loadState() exceed INT64_MAX, instead of silently wrapping to negative int64_t values.

Previously, IsUint64()/GetUint64() accepted values in [2^63, 2^64-1] which silently overflowed when assigned to int64_t fields. Now values exceeding INT64_MAX are clamped to INT64_MAX, ensuring the stored value is always non-negative and within the valid int64_t range.

Closes #563, Closes #564

<!-- Thank you for contributing to DTVM!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.

-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [ ] Y 

fix #563 , re #564 , 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    lib/wasi,
    smart_ir/src/abi
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

```release-note
None
```