### PR TITLE
perf(compiler): reduce repeated cold-path scans

### DIFF
--- a/docs/changes/2026-07-24-reduce-compiler-cold-path-scans/README.md
+++ b/docs/changes/2026-07-24-reduce-compiler-cold-path-scans/README.md
@@ -1,0 +1,109 @@
+# Change: Reduce repeated compiler cold-path scans
+
+- **Status**: Accepted
+- **Date**: 2026-07-24
+- **Tier**: Light
+
+## Overview
+
+This change removes two repeated linear scans from cold multipass compilation:
+
+- MIR block membership now uses the block's index and pointer identity instead
+  of scanning every block in the function.
+- CGIR dead-instruction elimination now walks backward across the use suffix of
+  a register chain instead of traversing its definition prefix for each query.
+
+Both changes preserve the existing compiler semantics and data-structure
+contracts.
+
+## Motivation
+
+The following diagnostic measurements were collected on pre-rebase
+implementation head `1edac697773e3f20fe186a6a071a42793ee22b81`, based on
+`57324bda91c945dc4c11c29d9809c2085b74d9d2`. They motivate this change but
+do not measure the rebased integration.
+
+On LabPerf's frozen 4-block, 499-transaction `prefix004` diagnostic corpus
+(`SHA256 7242de6d9331621b27a4422891a05f0f167c49f0183c69c96b321a81fd38cc52`),
+the two original scans dominated cold compilation:
+
+| Flat sampled cycles | Before | After |
+|---|---:|---:|
+| `CgDeadCgInstructionElim::isDead` | 39.53% | 0.28% |
+| `EVMMirBuilder::setInsertBlock` | 12.92% | 0.01% |
+
+For the combined change, first cold block-execution time decreased from
+2,238.890–2,263.209 seconds to 1,083.372 seconds, a diagnostic reduction of
+51.6–52.1% or 2.07–2.09x. The two baseline values are non-identical reference
+runs, not statistical replicates or a confidence interval.
+
+These measurements apply only to `prefix004`. They do not establish a
+32-block, mainnet-wide, production, steady-state runtime, or formal benchmark
+result.
+
+## Implementation
+
+### MIR block membership
+
+`MFunction::appendBlock` assigns each appended block its position in the
+function's block vector. The new membership query accepts a block only when
+its index is in range and the pointer at that index is identical. The pointer
+check prevents a newly created block with the default index from being
+mistaken for the entry block. `EVMMirBuilder::setInsertBlock` uses this
+constant-time query before appending a block.
+
+This relies on the existing append-only, stable-index invariant for live MIR
+blocks.
+
+### CGIR external-use lookup
+
+The CGIR register chain stores definitions as a prefix and uses as a suffix.
+The new lookup starts at the chain tail and walks backward only while operands
+are uses. A use owned by another instruction keeps the definition live; a use
+owned by the definition itself does not. The walk stops at the first
+definition, with an explicit head check for a circular chain containing only
+uses.
+
+This preserves dead-instruction elimination behavior for self-uses, external
+uses, multiple definitions, and fixed-point deletion.
+
+## Impact
+
+The blast radius is limited to the multipass compiler's MIR membership lookup,
+CGIR dead-instruction elimination, and their regression tests. There is no
+public ABI, SONAME, dependency, object-layout, global-state, threading, or
+determinism contract change.
+
+The compiler module specification was reviewed and remains accurate; no
+module-spec update is required. The implementation depends on the existing
+MIR stable-index and CGIR definition-prefix/use-suffix invariants. Future
+changes to either data structure must update the corresponding query and
+tests.
+
+The measured hotspot shift identifies register allocation and liveness as
+subsequent diagnostic targets. It does not show identical generated machine
+code or a runtime-execution improvement.
+
+## Validation
+
+Local validation on implementation head
+`7390935f9fe19d325fb096b787b6d643762262f0`, rebased onto
+`a7e73059ffc46b14978e87d04a3fa6b36d4f6c3a`:
+
+- Format and diff checks: passed
+- Release build: passed
+- Release EVM frontend: 53/53
+- EVM range analyzer: 50/50
+- EVM differential: 65/65
+- ASAN EVM frontend: 53/53, with 0 sanitizer errors
+- `tools/dtvm_local_test.sh --auto`: unit 223/223, EEST state
+  2723/2723, EVM assembly 209/209, and CTest 12/12
+
+GitHub Actions status for the rebased branch is tracked by PR #577.
+
+## Checklist
+
+- [x] Implementation complete
+- [x] Tests added/updated
+- [x] Module specs reviewed; no contract update required
+- [x] Build and tests pass

--- a/src/compiler/cgir/pass/cg_register_info.h
+++ b/src/compiler/cgir/pass/cg_register_info.h
@@ -334,6 +334,24 @@ public:
     return use_nodbg_begin(RegNo) == use_nodbg_end();
   }
 
+  // The use-def list stores definitions as a prefix and uses as a suffix. Walk
+  // backward from the tail through only the uses; MO == Head terminates the
+  // circular Prev chain when the list contains only uses.
+  bool hasUseOutside(Register RegNo, const CgInstruction &MI) const {
+    CgOperand *Head = getRegUseDefListHead(RegNo);
+    if (!Head)
+      return false;
+
+    for (CgOperand *MO = Head->Contents.Reg.Prev; MO->isUse();
+         MO = MO->Contents.Reg.Prev) {
+      if (MO->getParent() != &MI)
+        return true;
+      if (MO == Head)
+        break;
+    }
+    return false;
+  }
+
   /// use_instr_iterator/use_instr_begin/use_instr_end - Walk all uses of the
   /// specified register, stepping by CgInstruction.
   using use_instr_iterator =

--- a/src/compiler/cgir/pass/dead_cg_instruction_elim.cpp
+++ b/src/compiler/cgir/pass/dead_cg_instruction_elim.cpp
@@ -46,12 +46,9 @@ bool CgDeadCgInstructionElim::isDead(const CgInstruction *MI) const {
 #endif
           continue;
         }
-        for (const CgInstruction &Use : MRI->use_nodbg_instructions(Reg)) {
-          if (&Use != MI)
-            // This def has a non-debug use. Don't delete the
-            // instruction!
-            return false;
-        }
+        if (MRI->hasUseOutside(Reg, *MI))
+          // This def has a use in another instruction. Don't delete it!
+          return false;
       }
     }
   }

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -1143,9 +1143,7 @@ private:
 
   void setInsertBlock(MBasicBlock *BB) {
     CurBB = BB;
-    // Check if this basic block is already in the function's BasicBlocks list
-    // to avoid duplicate insertion
-    if (std::find(CurFunc->begin(), CurFunc->end(), BB) == CurFunc->end()) {
+    if (!CurFunc->containsBasicBlock(BB)) {
       CurFunc->appendBlock(BB);
     }
   }

--- a/src/compiler/mir/function.h
+++ b/src/compiler/mir/function.h
@@ -84,6 +84,12 @@ public:
     BasicBlocks.emplace_back(BB);
   }
 
+  bool containsBasicBlock(const MBasicBlock *BB) const {
+    ZEN_ASSERT(BB);
+    uint32_t BBIdx = BB->getIdx();
+    return BBIdx < BasicBlocks.size() && BasicBlocks[BBIdx] == BB;
+  }
+
   MBasicBlock *getBasicBlock(uint32_t BBIdx) const {
     ZEN_ASSERT(BBIdx < BasicBlocks.size());
     return BasicBlocks[BBIdx];

--- a/src/tests/evm_jit_frontend_tests.cpp
+++ b/src/tests/evm_jit_frontend_tests.cpp
@@ -98,68 +98,22 @@ TEST(EVMMirBuilderBasicBlockTest, InitDoesNotReappendEntryBlock) {
   EXPECT_EQ(Harness.Func.getNumBasicBlocks(), 1U);
 }
 
-TEST(CgRegisterInfoTest, FindsOnlyUsesOutsideInstruction) {
-  COMPILER::EVMFrontendContext Ctx;
-  Ctx.initialize();
-  COMPILER::MFunction MFunc(Ctx, 0);
-  COMPILER::CgFunction CgFunc(Ctx, MFunc);
-  COMPILER::CgBasicBlock *BB = CgFunc.createCgBasicBlock();
-  CgFunc.appendCgBasicBlock(BB);
-
-  auto &MRI = CgFunc.getRegInfo();
-  const auto &TII = CgFunc.getTargetInstrInfo();
-  auto AddDef = [&](COMPILER::CgRegister Reg) {
-    llvm::SmallVector<COMPILER::CgOperand, 1> Operands{
-        COMPILER::CgOperand::createRegOperand(Reg, true)};
-    return CgFunc.createCgInstruction(
-        *BB, TII.get(llvm::TargetOpcode::IMPLICIT_DEF), Operands,
-        /*no_implicit=*/true);
-  };
-  auto AddCopy = [&](COMPILER::CgRegister Dst, COMPILER::CgRegister Src) {
-    llvm::SmallVector<COMPILER::CgOperand, 2> Operands{
-        COMPILER::CgOperand::createRegOperand(Dst, true),
-        COMPILER::CgOperand::createRegOperand(Src, false)};
-    return CgFunc.createCgInstruction(*BB, TII.get(llvm::TargetOpcode::COPY),
-                                      Operands,
-                                      /*no_implicit=*/true);
-  };
-
-  COMPILER::CgRegister MultiDefReg = MRI.createIncompleteVirtualRegister();
-  COMPILER::CgInstruction *FirstDef = AddDef(MultiDefReg);
-  COMPILER::CgInstruction *SecondDef = AddDef(MultiDefReg);
-  EXPECT_FALSE(MRI.hasUseOutside(MultiDefReg, *FirstDef));
-  EXPECT_FALSE(MRI.hasUseOutside(MultiDefReg, *SecondDef));
-
-  COMPILER::CgRegister SelfReg = MRI.createIncompleteVirtualRegister();
-  COMPILER::CgInstruction *SelfCopy = AddCopy(SelfReg, SelfReg);
-  EXPECT_FALSE(MRI.hasUseOutside(SelfReg, *SelfCopy));
-
-  COMPILER::CgRegister CopyDst = MRI.createIncompleteVirtualRegister();
-  COMPILER::CgInstruction *ExternalUse = AddCopy(CopyDst, MultiDefReg);
-  EXPECT_TRUE(MRI.hasUseOutside(MultiDefReg, *FirstDef));
-  ExternalUse->eraseFromParent();
-  EXPECT_FALSE(MRI.hasUseOutside(MultiDefReg, *FirstDef));
-
-  COMPILER::CgRegister UseOnlyReg = MRI.createIncompleteVirtualRegister();
-  COMPILER::CgInstruction *FirstUse =
-      AddCopy(MRI.createIncompleteVirtualRegister(), UseOnlyReg);
-  COMPILER::CgInstruction *SecondUse =
-      AddCopy(MRI.createIncompleteVirtualRegister(), UseOnlyReg);
-  EXPECT_TRUE(MRI.hasUseOutside(UseOnlyReg, *SecondUse));
-  FirstUse->eraseFromParent();
-  EXPECT_FALSE(MRI.hasUseOutside(UseOnlyReg, *SecondUse));
-}
-
 TEST(CgDeadInstructionElimTest, PreservesExternalUsesAndDeletesSelfUses) {
   COMPILER::EVMFrontendContext Ctx;
   Ctx.initialize();
   COMPILER::MFunction MFunc(Ctx, 0);
   COMPILER::CgFunction CgFunc(Ctx, MFunc);
-  COMPILER::CgBasicBlock *DefBB = CgFunc.createCgBasicBlock();
+  COMPILER::CgBasicBlock *FirstDefBB = CgFunc.createCgBasicBlock();
+  COMPILER::CgBasicBlock *SecondDefBB = CgFunc.createCgBasicBlock();
+  COMPILER::CgBasicBlock *SelfCopyBB = CgFunc.createCgBasicBlock();
   COMPILER::CgBasicBlock *UseBB = CgFunc.createCgBasicBlock();
-  CgFunc.appendCgBasicBlock(DefBB);
+  CgFunc.appendCgBasicBlock(FirstDefBB);
+  CgFunc.appendCgBasicBlock(SecondDefBB);
+  CgFunc.appendCgBasicBlock(SelfCopyBB);
   CgFunc.appendCgBasicBlock(UseBB);
-  DefBB->addSuccessorWithoutProb(UseBB);
+  FirstDefBB->addSuccessorWithoutProb(SecondDefBB);
+  SecondDefBB->addSuccessorWithoutProb(SelfCopyBB);
+  SelfCopyBB->addSuccessorWithoutProb(UseBB);
 
   auto &MRI = CgFunc.getRegInfo();
   const auto &TII = CgFunc.getTargetInstrInfo();
@@ -171,13 +125,13 @@ TEST(CgDeadInstructionElimTest, PreservesExternalUsesAndDeletesSelfUses) {
       };
 
   COMPILER::CgRegister LiveReg = MRI.createIncompleteVirtualRegister();
-  for (unsigned I = 0; I != 2; ++I) {
-    AddInstruction(*DefBB, llvm::TargetOpcode::IMPLICIT_DEF,
-                   {COMPILER::CgOperand::createRegOperand(LiveReg, true)});
-  }
+  AddInstruction(*FirstDefBB, llvm::TargetOpcode::IMPLICIT_DEF,
+                 {COMPILER::CgOperand::createRegOperand(LiveReg, true)});
+  AddInstruction(*SecondDefBB, llvm::TargetOpcode::IMPLICIT_DEF,
+                 {COMPILER::CgOperand::createRegOperand(LiveReg, true)});
 
   COMPILER::CgRegister SelfReg = MRI.createIncompleteVirtualRegister();
-  AddInstruction(*DefBB, llvm::TargetOpcode::COPY,
+  AddInstruction(*SelfCopyBB, llvm::TargetOpcode::COPY,
                  {COMPILER::CgOperand::createRegOperand(SelfReg, true),
                   COMPILER::CgOperand::createRegOperand(SelfReg, false)});
 
@@ -188,19 +142,16 @@ TEST(CgDeadInstructionElimTest, PreservesExternalUsesAndDeletesSelfUses) {
 
   MRI.freezeReservedRegs(CgFunc);
   (void)COMPILER::CgDeadCgInstructionElim(CgFunc);
-  auto CountOpcode = [](const COMPILER::CgBasicBlock &BB, unsigned Opcode) {
-    return std::count_if(BB.begin(), BB.end(),
-                         [Opcode](const COMPILER::CgInstruction &MI) {
-                           return MI.getOpcode() == Opcode;
-                         });
-  };
-  EXPECT_EQ(CountOpcode(*DefBB, llvm::TargetOpcode::IMPLICIT_DEF), 2);
-  EXPECT_EQ(CountOpcode(*DefBB, llvm::TargetOpcode::COPY), 0);
-  EXPECT_EQ(CountOpcode(*UseBB, llvm::TargetOpcode::INLINEASM), 1);
+  EXPECT_FALSE(FirstDefBB->empty());
+  EXPECT_FALSE(SecondDefBB->empty());
+  EXPECT_TRUE(SelfCopyBB->empty());
+  EXPECT_FALSE(UseBB->empty());
 
   InlineAsm->eraseFromParent();
   (void)COMPILER::CgDeadCgInstructionElim(CgFunc);
-  EXPECT_TRUE(DefBB->empty());
+  EXPECT_TRUE(FirstDefBB->empty());
+  EXPECT_TRUE(SecondDefBB->empty());
+  EXPECT_TRUE(SelfCopyBB->empty());
   EXPECT_TRUE(UseBB->empty());
 }
 

--- a/src/tests/evm_jit_frontend_tests.cpp
+++ b/src/tests/evm_jit_frontend_tests.cpp
@@ -68,6 +68,32 @@ public:
   EVMMirBuilder Builder;
 };
 
+TEST(MFunctionBasicBlockTest, MembershipUsesIndexAndPointerIdentity) {
+  COMPILER::EVMFrontendContext Ctx;
+  COMPILER::MFunction Func(Ctx, 0);
+  COMPILER::MBasicBlock *First = Func.createBasicBlock();
+  COMPILER::MBasicBlock *Second = Func.createBasicBlock();
+
+  EXPECT_FALSE(Func.containsBasicBlock(First));
+  Func.appendBlock(First);
+  EXPECT_TRUE(Func.containsBasicBlock(First));
+
+  EXPECT_EQ(Second->getIdx(), 0U);
+  EXPECT_FALSE(Func.containsBasicBlock(Second));
+  Func.appendBlock(Second);
+  EXPECT_TRUE(Func.containsBasicBlock(Second));
+
+  EXPECT_EQ(Func.getNumBasicBlocks(), 2U);
+  EXPECT_EQ(Func.getBasicBlock(First->getIdx()), First);
+  EXPECT_EQ(Func.getBasicBlock(Second->getIdx()), Second);
+}
+
+TEST(EVMMirBuilderBasicBlockTest, InitDoesNotReappendEntryBlock) {
+  MirBuilderConstFoldHarness Harness;
+
+  EXPECT_EQ(Harness.Func.getNumBasicBlocks(), 1U);
+}
+
 void expectPCList(const std::vector<uint64_t> &Actual,
                   std::initializer_list<uint64_t> Expected) {
   ASSERT_EQ(Actual.size(), Expected.size());

--- a/src/tests/evm_jit_frontend_tests.cpp
+++ b/src/tests/evm_jit_frontend_tests.cpp
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "action/evm_bytecode_visitor.h"
+#include "compiler/cgir/cg_function.h"
+#include "compiler/cgir/pass/dead_cg_instruction_elim.h"
 #include "compiler/evm_frontend/evm_analyzer.h"
 #include "compiler/evm_frontend/evm_mir_compiler.h"
 
 #include <gtest/gtest.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/CodeGen/TargetOpcodes.h>
 
 #include <algorithm>
 #include <array>
@@ -92,6 +96,112 @@ TEST(EVMMirBuilderBasicBlockTest, InitDoesNotReappendEntryBlock) {
   MirBuilderConstFoldHarness Harness;
 
   EXPECT_EQ(Harness.Func.getNumBasicBlocks(), 1U);
+}
+
+TEST(CgRegisterInfoTest, FindsOnlyUsesOutsideInstruction) {
+  COMPILER::EVMFrontendContext Ctx;
+  Ctx.initialize();
+  COMPILER::MFunction MFunc(Ctx, 0);
+  COMPILER::CgFunction CgFunc(Ctx, MFunc);
+  COMPILER::CgBasicBlock *BB = CgFunc.createCgBasicBlock();
+  CgFunc.appendCgBasicBlock(BB);
+
+  auto &MRI = CgFunc.getRegInfo();
+  const auto &TII = CgFunc.getTargetInstrInfo();
+  auto AddDef = [&](COMPILER::CgRegister Reg) {
+    llvm::SmallVector<COMPILER::CgOperand, 1> Operands{
+        COMPILER::CgOperand::createRegOperand(Reg, true)};
+    return CgFunc.createCgInstruction(
+        *BB, TII.get(llvm::TargetOpcode::IMPLICIT_DEF), Operands,
+        /*no_implicit=*/true);
+  };
+  auto AddCopy = [&](COMPILER::CgRegister Dst, COMPILER::CgRegister Src) {
+    llvm::SmallVector<COMPILER::CgOperand, 2> Operands{
+        COMPILER::CgOperand::createRegOperand(Dst, true),
+        COMPILER::CgOperand::createRegOperand(Src, false)};
+    return CgFunc.createCgInstruction(*BB, TII.get(llvm::TargetOpcode::COPY),
+                                      Operands,
+                                      /*no_implicit=*/true);
+  };
+
+  COMPILER::CgRegister MultiDefReg = MRI.createIncompleteVirtualRegister();
+  COMPILER::CgInstruction *FirstDef = AddDef(MultiDefReg);
+  COMPILER::CgInstruction *SecondDef = AddDef(MultiDefReg);
+  EXPECT_FALSE(MRI.hasUseOutside(MultiDefReg, *FirstDef));
+  EXPECT_FALSE(MRI.hasUseOutside(MultiDefReg, *SecondDef));
+
+  COMPILER::CgRegister SelfReg = MRI.createIncompleteVirtualRegister();
+  COMPILER::CgInstruction *SelfCopy = AddCopy(SelfReg, SelfReg);
+  EXPECT_FALSE(MRI.hasUseOutside(SelfReg, *SelfCopy));
+
+  COMPILER::CgRegister CopyDst = MRI.createIncompleteVirtualRegister();
+  COMPILER::CgInstruction *ExternalUse = AddCopy(CopyDst, MultiDefReg);
+  EXPECT_TRUE(MRI.hasUseOutside(MultiDefReg, *FirstDef));
+  ExternalUse->eraseFromParent();
+  EXPECT_FALSE(MRI.hasUseOutside(MultiDefReg, *FirstDef));
+
+  COMPILER::CgRegister UseOnlyReg = MRI.createIncompleteVirtualRegister();
+  COMPILER::CgInstruction *FirstUse =
+      AddCopy(MRI.createIncompleteVirtualRegister(), UseOnlyReg);
+  COMPILER::CgInstruction *SecondUse =
+      AddCopy(MRI.createIncompleteVirtualRegister(), UseOnlyReg);
+  EXPECT_TRUE(MRI.hasUseOutside(UseOnlyReg, *SecondUse));
+  FirstUse->eraseFromParent();
+  EXPECT_FALSE(MRI.hasUseOutside(UseOnlyReg, *SecondUse));
+}
+
+TEST(CgDeadInstructionElimTest, PreservesExternalUsesAndDeletesSelfUses) {
+  COMPILER::EVMFrontendContext Ctx;
+  Ctx.initialize();
+  COMPILER::MFunction MFunc(Ctx, 0);
+  COMPILER::CgFunction CgFunc(Ctx, MFunc);
+  COMPILER::CgBasicBlock *DefBB = CgFunc.createCgBasicBlock();
+  COMPILER::CgBasicBlock *UseBB = CgFunc.createCgBasicBlock();
+  CgFunc.appendCgBasicBlock(DefBB);
+  CgFunc.appendCgBasicBlock(UseBB);
+  DefBB->addSuccessorWithoutProb(UseBB);
+
+  auto &MRI = CgFunc.getRegInfo();
+  const auto &TII = CgFunc.getTargetInstrInfo();
+  auto AddInstruction =
+      [&](COMPILER::CgBasicBlock &BB, unsigned Opcode,
+          llvm::SmallVector<COMPILER::CgOperand, 2> Operands) {
+        return CgFunc.createCgInstruction(BB, TII.get(Opcode), Operands,
+                                          /*no_implicit=*/true);
+      };
+
+  COMPILER::CgRegister LiveReg = MRI.createIncompleteVirtualRegister();
+  for (unsigned I = 0; I != 2; ++I) {
+    AddInstruction(*DefBB, llvm::TargetOpcode::IMPLICIT_DEF,
+                   {COMPILER::CgOperand::createRegOperand(LiveReg, true)});
+  }
+
+  COMPILER::CgRegister SelfReg = MRI.createIncompleteVirtualRegister();
+  AddInstruction(*DefBB, llvm::TargetOpcode::COPY,
+                 {COMPILER::CgOperand::createRegOperand(SelfReg, true),
+                  COMPILER::CgOperand::createRegOperand(SelfReg, false)});
+
+  COMPILER::CgInstruction *InlineAsm = AddInstruction(
+      *UseBB, llvm::TargetOpcode::INLINEASM,
+      {COMPILER::CgOperand::createRegOperand(LiveReg, false,
+                                             /*IsImplicit=*/true)});
+
+  MRI.freezeReservedRegs(CgFunc);
+  (void)COMPILER::CgDeadCgInstructionElim(CgFunc);
+  auto CountOpcode = [](const COMPILER::CgBasicBlock &BB, unsigned Opcode) {
+    return std::count_if(BB.begin(), BB.end(),
+                         [Opcode](const COMPILER::CgInstruction &MI) {
+                           return MI.getOpcode() == Opcode;
+                         });
+  };
+  EXPECT_EQ(CountOpcode(*DefBB, llvm::TargetOpcode::IMPLICIT_DEF), 2);
+  EXPECT_EQ(CountOpcode(*DefBB, llvm::TargetOpcode::COPY), 0);
+  EXPECT_EQ(CountOpcode(*UseBB, llvm::TargetOpcode::INLINEASM), 1);
+
+  InlineAsm->eraseFromParent();
+  (void)COMPILER::CgDeadCgInstructionElim(CgFunc);
+  EXPECT_TRUE(DefBB->empty());
+  EXPECT_TRUE(UseBB->empty());
 }
 
 void expectPCList(const std::vector<uint64_t> &Actual,


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y

#### 2. What is the scope of this PR (e.g. component or file name):

- multipass compiler MIR block membership
- CGIR dead-instruction elimination
- EVM frontend regression tests

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [x] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

This PR removes two repeated linear scans observed in cold multipass compilation:

1. `EVMMirBuilder::setInsertBlock` now checks membership through the block's
   stable `MFunction` index and pointer identity instead of scanning every
   block in the function.
2. CGIR dead-instruction elimination now starts at the def-use chain tail and
   scans only the use suffix, avoiding repeated traversal of the definition
   prefix while preserving self-use behavior.

The MIR lookup relies on the existing live-block, append-only/stable-index
contract. The CGIR lookup relies on the existing definition-prefix/use-suffix
operand-chain layout. Focused tests cover unappended MIR blocks with default
indices, pointer-identity membership after append, entry-block reuse,
preservation of external uses, deletion of self-uses, multiple definitions,
and fixed-point deletion after an external use is removed.

The branch is rebased onto upstream `main` at `a7e73059`, which includes the
merged PR #560 and PR #561 fixes.

Pre-rebase LabPerf diagnostic evidence, collected on implementation head
`1edac697` based on `57324bd`: on the frozen 4-block/499-transaction
`prefix004` corpus, the combined candidate reduced first cold block-execution
time from 2,238.890–2,263.209 seconds to 1,083.372 seconds (51.6–52.1%,
2.07–2.09x). In cold `cycles:u` profiles,
`CgDeadCgInstructionElim::isDead` moved from 39.53% to 0.28% flat sampled
cycles and `EVMMirBuilder::setInsertBlock` from 12.92% to 0.01%. This is
workload-specific diagnostic evidence, not a full-mainnet, 32-block,
production, runtime, or statistically formal benchmark claim. It motivates
the change but does not measure the rebased integration.

No public export, SONAME, dependency, object layout, global state, threading,
or determinism change was found.

Change document: [`docs/changes/2026-07-24-reduce-compiler-cold-path-scans/README.md`](https://github.com/abmcar/DTVM/blob/56729ee377635bbfd869b686713bbd44ab7ac606/docs/changes/2026-07-24-reduce-compiler-cold-path-scans/README.md)

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [x] Unit test
- [x] Integration test
- [x] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

Validated on implementation head `7390935` rebased onto `a7e73059`. The
subsequent change-document commit `56729ee` does not modify source or tests:

- `cmake -S . -B build && cmake --build build -j56`
- `tools/format.sh check`
- `git diff --check upstream/main..HEAD`
- focused new regressions: 3/3
- Release EVM frontend suite: 53/53
- Release EVM range analyzer suite: 50/50
- Release EVM differential suite: 65/65
- ASAN EVM frontend suite: 53/53, with 0 sanitizer errors
- `tools/dtvm_local_test.sh --auto --base upstream/main --jobs 1`:
  unit 223/223, EEST state 2723/2723, EVM assembly 209/209, and CTest 12/12
- GitHub Actions triggered by the rebased push: 17/17 checks completed
  successfully on PR head `56729ee`
- current-main performance checks: interpreter 194/194 and multipass 194/194,
  with 0 regressions in each mode

#### 6. Release note

```release-note
Improve multipass cold compilation by avoiding repeated MIR block-membership and CGIR definition-prefix scans.
```
