### PR TITLE
feat(evm): model effect-aware memory proof lifetime

### DIFF
--- a/docs/changes/2026-08-05-effect-aware-memory-proof-lifetime/README.md
+++ b/docs/changes/2026-08-05-effect-aware-memory-proof-lifetime/README.md
@@ -1,0 +1,60 @@
+# Change: Model effect-aware memory proof lifetime
+
+- **Status**: Proposed
+- **Date**: 2026-08-05
+- **Tier**: Full
+
+## Overview
+
+This change defines typed memory-proof requirements for EVM runtime helpers and
+tracks when a recovered proof remains valid across control-flow edges. Unknown
+effects, incomplete control flow, dynamic dispatch, and unsupported paths fail
+closed.
+
+The proof only establishes the memory facts represented by its typed token. It
+does not authorize moving gas charges, expansion checks, traps, termination, or
+other protocol-observable behavior.
+
+## Motivation
+
+Existing prepared-memory helpers can reuse facts recovered by the multipass
+frontend, but cross-block reuse needs one shared definition of which operations
+preserve or invalidate those facts. Encoding the contract centrally prevents
+individual lowering sites from making ad hoc assumptions about proof lifetime.
+
+## Design
+
+Opcode and runtime-helper effects are summarized with explicit flags for memory
+reads and writes, logical-size observation, dynamic gas, external calls,
+externalization, ordering, and termination. Runtime helper contracts state the
+exact proof obligations that a caller must satisfy.
+
+The proof-lifetime query follows only complete, statically known control flow.
+It rejects joins, cycles, dynamic dispatch, unknown effects, and paths whose
+observable behavior cannot be proven safe. `LOG` is classified as an observable
+memory reader but is not introduced as a typed cross-block consumer here.
+
+## Impact
+
+The change is limited to EVM multipass analysis and its internal helper
+contracts. It does not change a public ABI, runtime helper implementation,
+protocol-visible ordering, or the interpreter. Conservative rejection may
+reduce optimization opportunities but preserves the existing generic path.
+
+This proposal is the foundation for budgeted proof recovery and prepared-helper
+contract enforcement. It has no dependency on experiment policies, telemetry,
+certificate publication, or witness serialization.
+
+## Validation
+
+Focused frontend tests cover opcode effects, helper requirements, logical-size
+preservation, unique-predecessor reuse, and fail-closed behavior for calls,
+termination, incomplete CFGs, dynamic dispatch, and unknown effects.
+Differential tests continue to compare interpreter and multipass behavior.
+
+## Checklist
+
+- [x] Production implementation and focused tests prepared
+- [x] Compiler module specification updated
+- [x] Unknown or incomplete cases fail closed
+- [x] Experiment and paper-only surfaces excluded

--- a/docs/modules/compiler/spec.md
+++ b/docs/modules/compiler/spec.md
@@ -162,8 +162,26 @@ Block prechecks select one maximal safe window with at least two proven direct
 memory operations. The plan records explicit operation IDs, is emitted at the
 first covered operation, and may cover gaps or overlapping intervals because
 expansion grouping does not transform memory values. Per-operation guaranteed
-bytes include proven earlier expansion in the same block, but stop learning
-new guarantees after a hard barrier.
+bytes include proven earlier expansion in the same block.
+
+`MemoryProofLifetimeAnalysis` separates two questions that are distinct under
+EVM semantics. A successful memory operation may establish a logical minimum
+extent that remains true after an opcode such as `GAS` or `MSIZE`; this permits
+a later consumer to reuse the extent proof. It does not permit the compiler to
+move a later expansion, gas charge, trap, log, return, or external call across
+that opcode. The placement query therefore remains fail closed across
+observable-order, trapping, externalization, termination, unknown-effect, and
+unsafe CFG boundaries even when the logical-size proof survives.
+
+Proof propagation uses the analyzer's complete predecessor relation. The
+invocation entry starts with a zero-byte guarantee even when it has a backedge,
+and blocks with incomplete dynamic-dispatch predecessors receive no cross-block
+guarantee. Revision-undefined opcodes are terminating barriers. Prepared-memory
+runtime helpers declare typed proof requirements and normal-success memory
+effects; a helper contract is satisfied only when every required proof
+component has been established. Cached host-base and memory-content proof
+domains are deliberately not propagated until a lowering consumer requires
+them.
 
 The framework may eliminate only the write of an exact, fully overwritten
 `MSTORE` or `MSTORE8`, and may forward an exact 32-byte `MSTORE` value to a

--- a/src/action/evm_bytecode_visitor.h
+++ b/src/action/evm_bytecode_visitor.h
@@ -143,8 +143,11 @@ private:
   void buildMemoryFacts(const EVMAnalyzer &Analyzer, const uint8_t *Bytecode,
                         size_t BytecodeSize) {
     MemoryFacts.reset();
+    MemoryFacts.setRevision(Analyzer.getRevision());
     MemoryEntryAddressAnalysis EntryAddresses(Analyzer, Bytecode, BytecodeSize);
     const auto &BlockInfos = Analyzer.getBlockInfos();
+    const std::vector<uint64_t> DynamicDispatchSources =
+        Analyzer.getDynamicJumpDispatchSourceBlocks();
 
     for (const auto &[EntryPC, BlockInfo] : BlockInfos) {
       const bool HasReliableEntryStack =
@@ -155,9 +158,17 @@ private:
           HasReliableEntryStack ? BlockInfo.ResolvedEntryStackDepth : 0;
       std::vector<MemoryEntryValue> EntryValues = EntryAddresses.getEntryValues(
           EntryPC, static_cast<uint32_t>(EntryDepth));
+      const std::vector<uint64_t> PotentialPredecessors =
+          Analyzer.getPotentialEntryPredecessorsForBlock(EntryPC);
+      const bool PredecessorsAreStatic =
+          Analyzer.getDynamicJumpSourceBlocksForBlock(EntryPC).empty();
+      const bool PredecessorsComplete =
+          Analyzer.dynamicJumpTargetPredecessorsAreComplete(
+              EntryPC, DynamicDispatchSources);
       MemoryFacts.beginBlock(
           EntryPC, BlockInfo.BodyStartPC, BlockInfo.BodyEndPC, EntryValues,
-          BlockInfo.Successors, BlockInfo.Predecessors, HasReliableEntryStack);
+          BlockInfo.Successors, PotentialPredecessors, HasReliableEntryStack,
+          PredecessorsComplete, PredecessorsAreStatic);
 
       // Memory facts model stack-relative addresses.  An unresolved,
       // inconsistent, or dynamic-dispatch-derived entry depth cannot reliably

--- a/src/compiler/evm_frontend/evm_analyzer.h
+++ b/src/compiler/evm_frontend/evm_analyzer.h
@@ -361,6 +361,17 @@ public:
     return PredBlockPCs;
   }
 
+  std::vector<uint64_t> getDynamicJumpDispatchSourceBlocks() const {
+    return collectAllDynamicJumpDispatchSourceBlocks();
+  }
+
+  bool dynamicJumpTargetPredecessorsAreComplete(
+      uint64_t BlockPC,
+      const std::vector<uint64_t> &DispatchSourceBlocks) const {
+    return dynamicJumpTargetPredecessorsCoverCodegenEdges(BlockPC,
+                                                          DispatchSourceBlocks);
+  }
+
   std::vector<uint64_t>
   getCompatibleDynamicJumpTargetBlocksForSourceBlock(uint64_t BlockPC) const {
     auto It = BlockInfos.find(BlockPC);

--- a/src/compiler/evm_frontend/evm_memory_analysis.h
+++ b/src/compiler/evm_frontend/evm_memory_analysis.h
@@ -842,26 +842,6 @@ public:
   }
 
 private:
-  static bool isHardBarrier(const MemoryOp &Op) {
-    switch (Op.Kind) {
-    case MemoryOpKind::Log:
-    case MemoryOpKind::Call:
-    case MemoryOpKind::Create:
-    case MemoryOpKind::Return:
-    case MemoryOpKind::Revert:
-    case MemoryOpKind::MSize:
-    case MemoryOpKind::Gas:
-      return true;
-    default:
-      break;
-    }
-
-    return Op.Effect == MemoryEffect::Escape ||
-           Op.Effect == MemoryEffect::MemorySizeObserver ||
-           Op.Effect == MemoryEffect::GasSensitive ||
-           Op.Effect == MemoryEffect::Unknown;
-  }
-
   static bool getIntervalEnd(const MemoryInterval &Interval, uint64_t &End) {
     if (Interval.Space != AddressSpace::Memory || Interval.Empty ||
         !Interval.Addr.isKnown() ||
@@ -877,54 +857,51 @@ private:
     return true;
   }
 
-  static bool getDirectRequiredBytes(const MemoryOp &Op, uint64_t &End) {
-    switch (Op.Kind) {
-    case MemoryOpKind::MLoad:
-      return Op.Reads.size() == 1 && getIntervalEnd(Op.Reads[0], End);
-    case MemoryOpKind::Keccak:
-      return Op.Reads.size() == 1 && getIntervalEnd(Op.Reads[0], End);
-    case MemoryOpKind::MStore:
-    case MemoryOpKind::MStore8:
-      return Op.Writes.size() == 1 && getIntervalEnd(Op.Writes[0], End);
-    case MemoryOpKind::CallDataCopy:
-    case MemoryOpKind::CodeCopy:
-      return Op.Writes.size() == 1 && getIntervalEnd(Op.Writes[0], End);
-    case MemoryOpKind::MCopy: {
-      if (Op.Reads.size() != 1 || Op.Writes.size() != 1) {
-        return false;
+  static bool getGuaranteedRequiredBytes(const MemoryOp &Op, uint64_t &End) {
+    bool Found = false;
+    End = 0;
+    auto Accumulate = [&Found, &End](const MemoryInterval &Interval) {
+      uint64_t IntervalEnd = 0;
+      if (getIntervalEnd(Interval, IntervalEnd)) {
+        End = std::max(End, IntervalEnd);
+        Found = true;
       }
-      uint64_t ReadEnd = 0;
-      uint64_t WriteEnd = 0;
-      if (!getIntervalEnd(Op.Reads[0], ReadEnd) ||
-          !getIntervalEnd(Op.Writes[0], WriteEnd)) {
-        return false;
-      }
-      End = std::max(ReadEnd, WriteEnd);
-      return true;
+    };
+    for (const MemoryInterval &Read : Op.Reads) {
+      Accumulate(Read);
     }
-    default:
-      return false;
+    for (const MemoryInterval &Write : Op.Writes) {
+      Accumulate(Write);
     }
+    return Found;
   }
 
-  uint64_t transfer(const MemoryBlockFacts &Block,
-                    uint64_t EntryBytesValue) const {
+  struct TransferResult {
+    uint64_t Bytes = 0;
+    bool HasNormalExit = true;
+  };
+
+  TransferResult transfer(const MemoryBlockFacts &Block,
+                          uint64_t EntryBytesValue) const {
     if (!Block.HasCompleteOpcodeFacts) {
-      return 0;
+      return {.Bytes = 0};
     }
     uint64_t Current = EntryBytesValue;
     for (size_t I = Block.OpsBegin; I < Block.OpsEnd && I < Facts.Ops.size();
          ++I) {
       const MemoryOp &Op = Facts.Ops[I];
-      if (isHardBarrier(Op)) {
-        return Current;
+      if (!Op.ObservableEffects.preservesLogicalSizeProof()) {
+        Current = 0;
       }
       uint64_t RequiredBytes = 0;
-      if (getDirectRequiredBytes(Op, RequiredBytes)) {
+      if (getGuaranteedRequiredBytes(Op, RequiredBytes)) {
         Current = std::max(Current, RequiredBytes);
       }
+      if (Op.ObservableEffects.terminatesFrame()) {
+        return {.Bytes = 0, .HasNormalExit = false};
+      }
     }
-    return Current;
+    return {.Bytes = Current};
   }
 
   void recordBeforeOpBytes(const MemoryBlockFacts &Block,
@@ -933,34 +910,35 @@ private:
       return;
     }
     uint64_t Current = EntryBytesValue;
-    bool SeenBarrier = false;
     for (size_t I = Block.OpsBegin; I < Block.OpsEnd && I < Facts.Ops.size();
          ++I) {
       const MemoryOp &Op = Facts.Ops[I];
       BeforeOpBytes[Op.Id] = Current;
-      if (isHardBarrier(Op)) {
-        SeenBarrier = true;
-        continue;
-      }
-      if (SeenBarrier) {
-        continue;
+      if (!Op.ObservableEffects.preservesLogicalSizeProof()) {
+        Current = 0;
       }
       uint64_t RequiredBytes = 0;
-      if (getDirectRequiredBytes(Op, RequiredBytes)) {
+      if (getGuaranteedRequiredBytes(Op, RequiredBytes)) {
         Current = std::max(Current, RequiredBytes);
+      }
+      if (Op.ObservableEffects.terminatesFrame()) {
+        return;
       }
     }
   }
 
   uint64_t computeEntryFromPredecessors(const MemoryBlockFacts &Block) const {
-    if (!Block.HasCompleteOpcodeFacts) {
-      return 0;
-    }
-    if (Block.Predecessors.empty()) {
+    if (!Block.HasCompleteOpcodeFacts || Block.EntryPC == 0 ||
+        !Block.PredecessorsComplete || !Block.PredecessorsAreStatic ||
+        Block.Predecessors.empty()) {
       return 0;
     }
     uint64_t Result = std::numeric_limits<uint64_t>::max();
     for (uint64_t PredPC : Block.Predecessors) {
+      auto PredValidIt = ExitAvailable.find(PredPC);
+      if (PredValidIt == ExitAvailable.end() || !PredValidIt->second) {
+        return 0;
+      }
       auto PredExitIt = ExitBytes.find(PredPC);
       const uint64_t PredExit =
           PredExitIt == ExitBytes.end() ? 0 : PredExitIt->second;
@@ -973,11 +951,22 @@ private:
     std::queue<uint64_t> WorkList;
     std::map<uint64_t, bool> InQueue;
     for (const auto &[EntryPC, Block] : Facts.Blocks) {
-      (void)Block;
       EntryBytes[EntryPC] = 0;
       ExitBytes[EntryPC] = 0;
+      ExitAvailable[EntryPC] = false;
       WorkList.push(EntryPC);
       InQueue[EntryPC] = true;
+      for (uint64_t PredPC : Block.Predecessors) {
+        Dependents[PredPC].push_back(EntryPC);
+      }
+      for (uint64_t SuccPC : Block.Successors) {
+        Dependents[EntryPC].push_back(SuccPC);
+      }
+    }
+    for (auto &[EntryPC, Targets] : Dependents) {
+      (void)EntryPC;
+      std::sort(Targets.begin(), Targets.end());
+      Targets.erase(std::unique(Targets.begin(), Targets.end()), Targets.end());
     }
 
     while (!WorkList.empty()) {
@@ -992,13 +981,19 @@ private:
       const MemoryBlockFacts &Block = BlockIt->second;
       const uint64_t NewEntry = computeEntryFromPredecessors(Block);
       EntryBytes[EntryPC] = NewEntry;
-      const uint64_t NewExit = transfer(Block, NewEntry);
-      if (NewExit == ExitBytes[EntryPC]) {
+      const TransferResult NewExit = transfer(Block, NewEntry);
+      if (!NewExit.HasNormalExit) {
+        ExitAvailable[EntryPC] = false;
+        ExitBytes[EntryPC] = 0;
         continue;
       }
-      ExitBytes[EntryPC] = NewExit;
+      if (ExitAvailable[EntryPC] && NewExit.Bytes == ExitBytes[EntryPC]) {
+        continue;
+      }
+      ExitAvailable[EntryPC] = true;
+      ExitBytes[EntryPC] = NewExit.Bytes;
 
-      for (uint64_t SuccPC : Block.Successors) {
+      for (uint64_t SuccPC : Dependents[EntryPC]) {
         if (Facts.Blocks.find(SuccPC) == Facts.Blocks.end()) {
           continue;
         }
@@ -1017,7 +1012,110 @@ private:
   const MemoryFacts &Facts;
   std::map<uint64_t, uint64_t> EntryBytes;
   std::map<uint64_t, uint64_t> ExitBytes;
+  std::map<uint64_t, bool> ExitAvailable;
+  std::map<uint64_t, std::vector<uint64_t>> Dependents;
   std::map<uint32_t, uint64_t> BeforeOpBytes;
+};
+
+struct MemoryProofAvailability {
+  uint64_t GuaranteedMinBytes = 0;
+  bool HasLogicalSize = false;
+  bool HasAccessRange = false;
+
+  bool canReuseWithoutExpansion() const {
+    return HasLogicalSize && HasAccessRange;
+  }
+};
+
+// Proof availability and placement legality are separate queries. Logical
+// extent survives observers such as GAS and MSIZE, but an expansion may not be
+// moved across their protocol-visible ordering points.
+class MemoryProofLifetimeAnalysis {
+public:
+  explicit MemoryProofLifetimeAnalysis(const MemoryFacts &Facts)
+      : Facts(Facts), GuaranteedBytes(Facts) {}
+
+  MemoryProofAvailability
+  queryBeforeOp(uint32_t OpId, const MemoryInterval &RequiredRange,
+                uint64_t AdditionalGuaranteedBytes = 0) const {
+    if (Facts.getOp(OpId) == nullptr) {
+      return {};
+    }
+
+    MemoryProofAvailability Result;
+    Result.GuaranteedMinBytes =
+        std::max(AdditionalGuaranteedBytes,
+                 GuaranteedBytes.getGuaranteedMinBytesBeforeOp(OpId));
+    Result.HasLogicalSize = true;
+
+    if (RequiredRange.Empty) {
+      Result.HasAccessRange = true;
+      return Result;
+    }
+
+    uint64_t RequiredEnd = 0;
+    Result.HasAccessRange = getExactMemoryEnd(RequiredRange, RequiredEnd) &&
+                            RequiredEnd <= Result.GuaranteedMinBytes;
+    return Result;
+  }
+
+  bool canMoveExpansionBetween(uint32_t ProducerOpId,
+                               uint32_t ConsumerOpId) const {
+    size_t ProducerIndex = 0;
+    size_t ConsumerIndex = 0;
+    if (!findOpIndex(ProducerOpId, ProducerIndex) ||
+        !findOpIndex(ConsumerOpId, ConsumerIndex) ||
+        ProducerIndex >= ConsumerIndex) {
+      return false;
+    }
+
+    const MemoryOp &Producer = Facts.Ops[ProducerIndex];
+    const MemoryOp &Consumer = Facts.Ops[ConsumerIndex];
+    if (Producer.BlockEntryPC != Consumer.BlockEntryPC) {
+      return false;
+    }
+
+    for (size_t I = ProducerIndex + 1; I < ConsumerIndex; ++I) {
+      const MemoryOp &Op = Facts.Ops[I];
+      const MemoryEffectSummary &Effects = Op.ObservableEffects;
+      if (Effects.requiresOrderToken() || Effects.mayTrapOrHalt() ||
+          Effects.externalizesMemory() || Effects.terminatesFrame() ||
+          Op.Effect == MemoryEffect::Escape ||
+          Op.Effect == MemoryEffect::Unknown) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+private:
+  static bool getExactMemoryEnd(const MemoryInterval &Interval, uint64_t &End) {
+    if (Interval.Space != AddressSpace::Memory || Interval.Empty ||
+        !Interval.Addr.isKnown() ||
+        Interval.Addr.Kind != AddressBaseKind::Const || !Interval.Size.Known ||
+        Interval.Addr.Offset < 0) {
+      return false;
+    }
+    const uint64_t Begin = static_cast<uint64_t>(Interval.Addr.Offset);
+    if (Interval.Size.Value > std::numeric_limits<uint64_t>::max() - Begin) {
+      return false;
+    }
+    End = Begin + Interval.Size.Value;
+    return true;
+  }
+
+  bool findOpIndex(uint32_t OpId, size_t &Index) const {
+    for (size_t I = 0; I < Facts.Ops.size(); ++I) {
+      if (Facts.Ops[I].Id == OpId) {
+        Index = I;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  const MemoryFacts &Facts;
+  MemoryGuaranteedMinBytesAnalysis GuaranteedBytes;
 };
 
 } // namespace COMPILER

--- a/src/compiler/evm_frontend/evm_memory_facts.h
+++ b/src/compiler/evm_frontend/evm_memory_facts.h
@@ -140,6 +140,81 @@ enum class MemoryEffect : uint8_t {
   Unknown
 };
 
+enum class MemoryEffectFlag : uint16_t {
+  ReadsMemory = 1U << 0,
+  WritesMemory = 1U << 1,
+  ObservesMemorySize = 1U << 2,
+  ObservesGas = 1U << 3,
+  MayGrowMemory = 1U << 4,
+  MayRebaseMemory = 1U << 5,
+  MayTrapOrHalt = 1U << 6,
+  ExternalizesMemory = 1U << 7,
+  RequiresOrderToken = 1U << 8,
+  TerminatesFrame = 1U << 9,
+  ResetsLogicalMemory = 1U << 10,
+  ChargesDynamicGas = 1U << 11,
+  MayExhaustGas = 1U << 12
+};
+
+// Orthogonal EVM-observable effects. Placement barriers, logical memory-size
+// proofs, and cached host pointers deliberately query different dimensions.
+struct MemoryEffectSummary {
+  uint8_t StackPop = 0;
+  uint8_t StackPush = 0;
+  uint16_t Flags = 0;
+
+  void add(MemoryEffectFlag Flag) { Flags |= static_cast<uint16_t>(Flag); }
+
+  bool has(MemoryEffectFlag Flag) const {
+    return (Flags & static_cast<uint16_t>(Flag)) != 0;
+  }
+
+  bool readsOrWritesMemory() const {
+    return has(MemoryEffectFlag::ReadsMemory) ||
+           has(MemoryEffectFlag::WritesMemory);
+  }
+
+  bool observesMemorySize() const {
+    return has(MemoryEffectFlag::ObservesMemorySize);
+  }
+
+  bool observesGas() const { return has(MemoryEffectFlag::ObservesGas); }
+
+  bool chargesDynamicGas() const {
+    return has(MemoryEffectFlag::ChargesDynamicGas);
+  }
+
+  bool mayExhaustGas() const { return has(MemoryEffectFlag::MayExhaustGas); }
+
+  bool mayGrowMemory() const { return has(MemoryEffectFlag::MayGrowMemory); }
+
+  bool mayRebaseMemory() const {
+    return has(MemoryEffectFlag::MayRebaseMemory);
+  }
+
+  bool mayTrapOrHalt() const { return has(MemoryEffectFlag::MayTrapOrHalt); }
+
+  bool externalizesMemory() const {
+    return has(MemoryEffectFlag::ExternalizesMemory);
+  }
+
+  bool requiresOrderToken() const {
+    return has(MemoryEffectFlag::RequiresOrderToken);
+  }
+
+  bool terminatesFrame() const {
+    return has(MemoryEffectFlag::TerminatesFrame);
+  }
+
+  bool preservesLogicalSizeProof() const {
+    return !has(MemoryEffectFlag::ResetsLogicalMemory);
+  }
+
+  bool preservesCachedMemoryBase() const {
+    return !has(MemoryEffectFlag::MayRebaseMemory);
+  }
+};
+
 enum class MemoryOpKind : uint8_t {
   MLoad,
   MStore,
@@ -188,6 +263,7 @@ struct MemoryOp {
   std::vector<MemoryInterval> Reads;
   std::vector<MemoryInterval> Writes;
   MemoryEffect Effect = MemoryEffect::None;
+  MemoryEffectSummary ObservableEffects;
   bool IsTerminator = false;
 };
 
@@ -203,6 +279,8 @@ struct MemoryBlockFacts {
   evmc_opcode FirstHardBarrierOpcode = OP_STOP;
   uint64_t FirstHardBarrierPC = 0;
   uint64_t MaxConstRequiredSize = 0;
+  bool PredecessorsComplete = true;
+  bool PredecessorsAreStatic = true;
   std::vector<uint64_t> Successors;
   std::vector<uint64_t> Predecessors;
 
@@ -222,6 +300,17 @@ struct MemoryFacts {
   bool empty() const { return Ops.empty(); }
   size_t size() const { return Ops.size(); }
 
+  const MemoryOp *getOp(uint32_t OpId) const {
+    if (OpId >= Ops.size() || Ops[OpId].Id != OpId) {
+      return nullptr;
+    }
+    return &Ops[OpId];
+  }
+
+  size_t getOpIndex(uint32_t OpId) const {
+    return getOp(OpId) == nullptr ? Ops.size() : static_cast<size_t>(OpId);
+  }
+
   const MemoryBlockFacts *getBlock(uint64_t EntryPC) const {
     auto It = Blocks.find(EntryPC);
     return It == Blocks.end() ? nullptr : &It->second;
@@ -232,7 +321,11 @@ struct MemoryFacts {
 // dependency on MIR builder, analysis, or optimization consumers.
 class MemoryFactsBuilder {
 public:
-  MemoryFactsBuilder() = default;
+  explicit MemoryFactsBuilder(evmc_revision Revision = EVMC_CANCUN)
+      : Revision(Revision) {}
+
+  void setRevision(evmc_revision NewRevision) { Revision = NewRevision; }
+  evmc_revision getRevision() const { return Revision; }
 
   void reset() {
     endBlock();
@@ -253,7 +346,9 @@ public:
                   const std::vector<MemoryEntryValue> &EntryValues,
                   const std::vector<uint64_t> &Successors = {},
                   const std::vector<uint64_t> &Predecessors = {},
-                  bool HasCompleteOpcodeFacts = true) {
+                  bool HasCompleteOpcodeFacts = true,
+                  bool PredecessorsComplete = true,
+                  bool PredecessorsAreStatic = true) {
     endBlock();
     HasCurrentBlock = true;
     CurrentBlockEntryPC = EntryPC;
@@ -265,6 +360,8 @@ public:
     Block.OpsBegin = Facts.Ops.size();
     Block.OpsEnd = Facts.Ops.size();
     Block.HasCompleteOpcodeFacts = HasCompleteOpcodeFacts;
+    Block.PredecessorsComplete = PredecessorsComplete;
+    Block.PredecessorsAreStatic = PredecessorsAreStatic;
     Block.Successors = Successors;
     Block.Predecessors = Predecessors;
     Facts.Blocks[EntryPC] = std::move(Block);
@@ -298,6 +395,18 @@ public:
         return;
       }
     }
+    const auto *InstructionNames = evmc_get_instruction_names_table(Revision);
+    if (InstructionNames == nullptr ||
+        InstructionNames[static_cast<uint8_t>(Opcode)] == nullptr) {
+      MemoryOp &Op =
+          addOp(Pc, Opcode, MemoryOpKind::Other, MemoryEffect::Unknown);
+      Op.ObservableEffects.add(MemoryEffectFlag::RequiresOrderToken);
+      Op.ObservableEffects.add(MemoryEffectFlag::MayTrapOrHalt);
+      Op.ObservableEffects.add(MemoryEffectFlag::TerminatesFrame);
+      noteBlockFact(Op);
+      return;
+    }
+
     if (Opcode >= OP_PUSH0 && Opcode <= OP_PUSH32) {
       observePush(Opcode, Pc, Bytecode, BytecodeSize);
       return;
@@ -412,22 +521,10 @@ private:
 
   MemoryFacts Facts;
   std::vector<StackValue> Stack;
+  evmc_revision Revision = EVMC_CANCUN;
   uint32_t NextValueId = 1;
   uint64_t CurrentBlockEntryPC = 0;
   bool HasCurrentBlock = false;
-
-  static bool isHardBarrierEffect(MemoryEffect Effect, MemoryOpKind Kind) {
-    if (Kind == MemoryOpKind::Log || Kind == MemoryOpKind::Call ||
-        Kind == MemoryOpKind::Create || Kind == MemoryOpKind::Return ||
-        Kind == MemoryOpKind::Revert || Kind == MemoryOpKind::MSize ||
-        Kind == MemoryOpKind::Gas) {
-      return true;
-    }
-    return Effect == MemoryEffect::Escape ||
-           Effect == MemoryEffect::MemorySizeObserver ||
-           Effect == MemoryEffect::GasSensitive ||
-           Effect == MemoryEffect::Unknown;
-  }
 
   static MemoryHardBarrierKind getHardBarrierKind(const MemoryOp &Op) {
     switch (Op.Kind) {
@@ -479,10 +576,18 @@ private:
     return MemoryHardBarrierKind::None;
   }
 
-  static bool isUnknownEffectBarrierOpcode(evmc_opcode Opcode) {
+  static bool requiresEffectOnlyRecord(evmc_opcode Opcode) {
     switch (Opcode) {
+    case OP_EXP:
+    case OP_BALANCE:
+    case OP_EXTCODESIZE:
+    case OP_EXTCODEHASH:
+    case OP_SLOAD:
     case OP_SSTORE:
     case OP_TSTORE:
+      // Dynamic gas or host-state access must remain ordered with respect to
+      // memory expansion even though it does not access EVM linear memory.
+      return true;
     case OP_SELFDESTRUCT:
     case OP_INVALID:
       return true;
@@ -533,7 +638,7 @@ private:
     }
     MemoryBlockFacts &Block = It->second;
     Block.OpsEnd = Facts.Ops.size();
-    if (isHardBarrierEffect(Op.Effect, Op.Kind)) {
+    if (Op.ObservableEffects.requiresOrderToken()) {
       Block.HasBarrier = true;
       if (Block.FirstHardBarrierKind == MemoryHardBarrierKind::None) {
         Block.FirstHardBarrierKind = getHardBarrierKind(Op);
@@ -669,8 +774,128 @@ private:
     Op.Opcode = Opcode;
     Op.Kind = Kind;
     Op.Effect = Effect;
+    Op.ObservableEffects = summarizeEffects(Opcode, Kind);
     Facts.Ops.push_back(std::move(Op));
     return Facts.Ops.back();
+  }
+
+  MemoryEffectSummary summarizeEffects(evmc_opcode Opcode,
+                                       MemoryOpKind Kind) const {
+    MemoryEffectSummary Summary;
+    const auto &Metrics = evmc_get_instruction_metrics_table(Revision);
+    const auto &Metric = Metrics[static_cast<uint8_t>(Opcode)];
+    const int PopCount =
+        std::max(0, static_cast<int>(Metric.stack_height_required));
+    const int PushCount = std::max(0, PopCount + Metric.stack_height_change);
+    Summary.StackPop = static_cast<uint8_t>(PopCount);
+    Summary.StackPush = static_cast<uint8_t>(PushCount);
+
+    auto AddMemoryAccessEffects = [&Summary]() {
+      Summary.add(MemoryEffectFlag::MayGrowMemory);
+      Summary.add(MemoryEffectFlag::MayRebaseMemory);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      Summary.add(MemoryEffectFlag::ChargesDynamicGas);
+      Summary.add(MemoryEffectFlag::MayExhaustGas);
+    };
+
+    switch (Kind) {
+    case MemoryOpKind::MLoad:
+    case MemoryOpKind::Keccak:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::MStore:
+    case MemoryOpKind::MStore8:
+    case MemoryOpKind::CallDataCopy:
+    case MemoryOpKind::CodeCopy:
+    case MemoryOpKind::ReturnDataCopy:
+    case MemoryOpKind::ExtCodeCopy:
+      Summary.add(MemoryEffectFlag::WritesMemory);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::MCopy:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::WritesMemory);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::Log:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::ExternalizesMemory);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::Return:
+    case MemoryOpKind::Revert:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::ExternalizesMemory);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::TerminatesFrame);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::Call:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::WritesMemory);
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::ExternalizesMemory);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::Create:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::ExternalizesMemory);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::MSize:
+      Summary.add(MemoryEffectFlag::ObservesMemorySize);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      break;
+    case MemoryOpKind::Gas:
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      break;
+    case MemoryOpKind::CallDataLoad:
+    case MemoryOpKind::Other:
+      break;
+    }
+
+    switch (Opcode) {
+    case OP_EXP:
+    case OP_BALANCE:
+    case OP_EXTCODESIZE:
+    case OP_EXTCODEHASH:
+    case OP_SLOAD:
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::ChargesDynamicGas);
+      Summary.add(MemoryEffectFlag::MayExhaustGas);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      break;
+    case OP_SSTORE:
+    case OP_TSTORE:
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::ChargesDynamicGas);
+      Summary.add(MemoryEffectFlag::MayExhaustGas);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      break;
+    case OP_SELFDESTRUCT:
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::ChargesDynamicGas);
+      Summary.add(MemoryEffectFlag::MayExhaustGas);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      Summary.add(MemoryEffectFlag::TerminatesFrame);
+      break;
+    case OP_INVALID:
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      Summary.add(MemoryEffectFlag::TerminatesFrame);
+      break;
+    default:
+      break;
+    }
+    return Summary;
   }
 
   void observePush(evmc_opcode Opcode, uint64_t Pc, const uint8_t *Bytecode,
@@ -865,7 +1090,7 @@ private:
   }
 
   void observeGenericOpcode(evmc_opcode Opcode, uint64_t Pc) {
-    const auto &Metrics = evmc_get_instruction_metrics_table(EVMC_CANCUN);
+    const auto &Metrics = evmc_get_instruction_metrics_table(Revision);
     const auto &Metric = Metrics[static_cast<uint8_t>(Opcode)];
     const int PopCount = Metric.stack_height_required;
     const int PushCount = PopCount + Metric.stack_height_change;
@@ -875,7 +1100,7 @@ private:
     for (int I = 0; I < PushCount; ++I) {
       pushUnknown();
     }
-    if (isUnknownEffectBarrierOpcode(Opcode)) {
+    if (requiresEffectOnlyRecord(Opcode)) {
       noteBlockFact(
           addOp(Pc, Opcode, MemoryOpKind::Other, MemoryEffect::Unknown));
     }

--- a/src/compiler/evm_frontend/evm_runtime_helper_effects.h
+++ b/src/compiler/evm_frontend/evm_runtime_helper_effects.h
@@ -1,0 +1,168 @@
+// Copyright (C) 2025 the DTVM authors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef COMPILER_EVM_FRONTEND_EVM_RUNTIME_HELPER_EFFECTS_H
+#define COMPILER_EVM_FRONTEND_EVM_RUNTIME_HELPER_EFFECTS_H
+
+#include "compiler/evm_frontend/evm_memory_facts.h"
+
+#include <cstdint>
+
+namespace COMPILER {
+
+enum class RuntimeMemoryHelperId : uint8_t {
+  Unknown,
+  CodeCopyNoExpand,
+  CallDataCopyNoExpand,
+  KeccakNoExpand,
+  TwoWordKeccakNoExpand,
+  ReturnNoExpand,
+  RevertNoExpand,
+  ExpandMemoryNoGas,
+  CallNoExpand
+};
+
+enum class RuntimeProofRequirementFlag : uint16_t {
+  LogicalSize = 1U << 0,
+  AccessRange = 1U << 1,
+  DynamicGasCharged = 1U << 2,
+  BoundsValidated = 1U << 3,
+  OrderToken = 1U << 4,
+  CallArgumentsRange = 1U << 5,
+  CallReturnRange = 1U << 6
+};
+
+// Lowering accumulates obligations as it emits the corresponding operations.
+// Prepared-memory helpers accept this typed token instead of a preassembled
+// bit mask, making the discharge order explicit at each call site.
+class RuntimeProofToken {
+public:
+  void establish(RuntimeProofRequirementFlag Requirement) {
+    Provided |= static_cast<uint16_t>(Requirement);
+  }
+
+  bool provides(RuntimeProofRequirementFlag Requirement) const {
+    return (Provided & static_cast<uint16_t>(Requirement)) != 0;
+  }
+
+  uint16_t bits() const { return Provided; }
+
+private:
+  uint16_t Provided = 0;
+};
+
+// Contract for prepared-memory runtime helpers. Requirements are obligations
+// discharged by lowering before the call; effects describe the helper's
+// normal-success transition. Exceptional behavior remains fail closed through
+// MayTrapOrHalt and OrderToken.
+struct RuntimeMemoryHelperContract {
+  uint16_t Requirements = 0;
+  MemoryEffectSummary Effects;
+  bool EstablishesLogicalSize = false;
+  bool Valid = false;
+
+  void require(RuntimeProofRequirementFlag Requirement) {
+    Requirements |= static_cast<uint16_t>(Requirement);
+  }
+
+  bool
+    requires(RuntimeProofRequirementFlag Requirement)
+  const {
+    return (Requirements & static_cast<uint16_t>(Requirement)) != 0;
+  }
+};
+
+inline bool satisfiesRuntimeMemoryHelperContract(
+    const RuntimeMemoryHelperContract &Contract,
+    const RuntimeProofToken &Proofs) {
+  return Contract.Valid &&
+         (Contract.Requirements & Proofs.bits()) == Contract.Requirements;
+}
+
+inline RuntimeMemoryHelperContract
+getRuntimeMemoryHelperContract(RuntimeMemoryHelperId Helper) {
+  RuntimeMemoryHelperContract Contract;
+  auto RequirePreparedRange = [&Contract]() {
+    Contract.require(RuntimeProofRequirementFlag::LogicalSize);
+    Contract.require(RuntimeProofRequirementFlag::AccessRange);
+  };
+  auto RequireObservableOrder = [&Contract]() {
+    Contract.require(RuntimeProofRequirementFlag::OrderToken);
+    Contract.Effects.add(MemoryEffectFlag::RequiresOrderToken);
+  };
+
+  switch (Helper) {
+  case RuntimeMemoryHelperId::Unknown:
+    return Contract;
+
+  case RuntimeMemoryHelperId::CodeCopyNoExpand:
+  case RuntimeMemoryHelperId::CallDataCopyNoExpand:
+    Contract.Valid = true;
+    RequirePreparedRange();
+    Contract.require(RuntimeProofRequirementFlag::DynamicGasCharged);
+    Contract.Effects.add(MemoryEffectFlag::WritesMemory);
+    break;
+
+  case RuntimeMemoryHelperId::KeccakNoExpand:
+    Contract.Valid = true;
+    RequirePreparedRange();
+    Contract.require(RuntimeProofRequirementFlag::DynamicGasCharged);
+    Contract.Effects.add(MemoryEffectFlag::ReadsMemory);
+    break;
+
+  case RuntimeMemoryHelperId::TwoWordKeccakNoExpand:
+    Contract.Valid = true;
+    RequirePreparedRange();
+    Contract.Effects.add(MemoryEffectFlag::ReadsMemory);
+    Contract.Effects.add(MemoryEffectFlag::WritesMemory);
+    Contract.Effects.add(MemoryEffectFlag::ObservesGas);
+    Contract.Effects.add(MemoryEffectFlag::ChargesDynamicGas);
+    Contract.Effects.add(MemoryEffectFlag::MayExhaustGas);
+    Contract.Effects.add(MemoryEffectFlag::MayTrapOrHalt);
+    RequireObservableOrder();
+    break;
+
+  case RuntimeMemoryHelperId::ReturnNoExpand:
+  case RuntimeMemoryHelperId::RevertNoExpand:
+    Contract.Valid = true;
+    RequirePreparedRange();
+    Contract.Effects.add(MemoryEffectFlag::ReadsMemory);
+    Contract.Effects.add(MemoryEffectFlag::ExternalizesMemory);
+    Contract.Effects.add(MemoryEffectFlag::TerminatesFrame);
+    RequireObservableOrder();
+    break;
+
+  case RuntimeMemoryHelperId::ExpandMemoryNoGas:
+    Contract.Valid = true;
+    Contract.require(RuntimeProofRequirementFlag::DynamicGasCharged);
+    Contract.require(RuntimeProofRequirementFlag::BoundsValidated);
+    Contract.Effects.add(MemoryEffectFlag::MayGrowMemory);
+    Contract.Effects.add(MemoryEffectFlag::MayRebaseMemory);
+    Contract.Effects.add(MemoryEffectFlag::MayTrapOrHalt);
+    RequireObservableOrder();
+    Contract.EstablishesLogicalSize = true;
+    break;
+
+  case RuntimeMemoryHelperId::CallNoExpand:
+    Contract.Valid = true;
+    Contract.require(RuntimeProofRequirementFlag::LogicalSize);
+    Contract.require(RuntimeProofRequirementFlag::CallArgumentsRange);
+    Contract.require(RuntimeProofRequirementFlag::CallReturnRange);
+    Contract.Effects.add(MemoryEffectFlag::ReadsMemory);
+    Contract.Effects.add(MemoryEffectFlag::WritesMemory);
+    Contract.Effects.add(MemoryEffectFlag::ObservesGas);
+    Contract.Effects.add(MemoryEffectFlag::ChargesDynamicGas);
+    Contract.Effects.add(MemoryEffectFlag::MayExhaustGas);
+    Contract.Effects.add(MemoryEffectFlag::MayRebaseMemory);
+    Contract.Effects.add(MemoryEffectFlag::MayTrapOrHalt);
+    Contract.Effects.add(MemoryEffectFlag::ExternalizesMemory);
+    RequireObservableOrder();
+    break;
+  }
+
+  return Contract;
+}
+
+} // namespace COMPILER
+
+#endif // COMPILER_EVM_FRONTEND_EVM_RUNTIME_HELPER_EFFECTS_H

--- a/src/tests/evm_jit_frontend_tests.cpp
+++ b/src/tests/evm_jit_frontend_tests.cpp
@@ -11,6 +11,7 @@
 #include "compiler/evm_frontend/evm_memory_grouping.h"
 #include "compiler/evm_frontend/evm_memory_precheck.h"
 #include "compiler/evm_frontend/evm_mir_compiler.h"
+#include "compiler/evm_frontend/evm_runtime_helper_effects.h"
 #include "compiler/mir/module.h"
 #include "compiler/mir/pass/verifier.h"
 
@@ -366,8 +367,9 @@ std::vector<uint8_t> makeLargeStaticDynamicOffsetMStoreBlock(uint64_t Ops) {
   return Bytecode;
 }
 
-COMPILER::MemoryFacts collectMemoryFacts(const std::vector<uint8_t> &Bytecode) {
-  COMPILER::MemoryFactsBuilder FactsBuilder;
+COMPILER::MemoryFacts collectMemoryFacts(const std::vector<uint8_t> &Bytecode,
+                                         evmc_revision Revision = EVMC_CANCUN) {
+  COMPILER::MemoryFactsBuilder FactsBuilder(Revision);
   FactsBuilder.beginBlock(0, 0);
 
   size_t PC = 0;
@@ -389,7 +391,9 @@ collectAnalyzerMemoryFacts(const std::vector<uint8_t> &Bytecode) {
   const uint8_t *Data = Bytecode.empty() ? nullptr : Bytecode.data();
   COMPILER::MemoryEntryAddressAnalysis EntryAddresses(Analyzer, Data,
                                                       Bytecode.size());
-  COMPILER::MemoryFactsBuilder FactsBuilder;
+  COMPILER::MemoryFactsBuilder FactsBuilder(EVMC_CANCUN);
+  const std::vector<uint64_t> DynamicDispatchSources =
+      Analyzer.getDynamicJumpDispatchSourceBlocks();
   const auto &Blocks = Analyzer.getBlockInfos();
   for (const auto &[EntryPC, BlockInfo] : Blocks) {
     const bool HasReliableEntryStack =
@@ -401,9 +405,17 @@ collectAnalyzerMemoryFacts(const std::vector<uint8_t> &Bytecode) {
     std::vector<COMPILER::MemoryEntryValue> EntryValues =
         EntryAddresses.getEntryValues(EntryPC,
                                       static_cast<uint32_t>(EntryDepth));
+    const std::vector<uint64_t> PotentialPredecessors =
+        Analyzer.getPotentialEntryPredecessorsForBlock(EntryPC);
+    const bool PredecessorsAreStatic =
+        Analyzer.getDynamicJumpSourceBlocksForBlock(EntryPC).empty();
+    const bool PredecessorsComplete =
+        Analyzer.dynamicJumpTargetPredecessorsAreComplete(
+            EntryPC, DynamicDispatchSources);
     FactsBuilder.beginBlock(EntryPC, BlockInfo.BodyStartPC, BlockInfo.BodyEndPC,
                             EntryValues, BlockInfo.Successors,
-                            BlockInfo.Predecessors, HasReliableEntryStack);
+                            PotentialPredecessors, HasReliableEntryStack,
+                            PredecessorsComplete, PredecessorsAreStatic);
 
     if (!HasReliableEntryStack) {
       continue;
@@ -430,6 +442,8 @@ struct MemoryFactBlockSpec {
   std::vector<uint64_t> Successors;
   std::vector<uint64_t> Predecessors;
   bool HasCompleteOpcodeFacts = true;
+  bool PredecessorsComplete = true;
+  bool PredecessorsAreStatic = true;
 };
 
 COMPILER::MemoryFacts
@@ -438,9 +452,10 @@ collectManualBlockMemoryFacts(const std::vector<uint8_t> &Bytecode,
   COMPILER::MemoryFactsBuilder FactsBuilder;
   const uint8_t *Data = Bytecode.empty() ? nullptr : Bytecode.data();
   for (const MemoryFactBlockSpec &Block : Blocks) {
-    FactsBuilder.beginBlock(Block.EntryPC, Block.BodyStartPC, Block.BodyEndPC,
-                            {}, Block.Successors, Block.Predecessors,
-                            Block.HasCompleteOpcodeFacts);
+    FactsBuilder.beginBlock(
+        Block.EntryPC, Block.BodyStartPC, Block.BodyEndPC, {}, Block.Successors,
+        Block.Predecessors, Block.HasCompleteOpcodeFacts,
+        Block.PredecessorsComplete, Block.PredecessorsAreStatic);
 
     if (!Block.HasCompleteOpcodeFacts) {
       continue;
@@ -479,6 +494,190 @@ TEST(EVMMemoryFactsBuilderTest, RecordsConstMStoreWriteInterval) {
   EXPECT_EQ(Op.Writes[0].Addr.Offset, 0x80);
   ASSERT_TRUE(Op.Writes[0].Size.Known);
   EXPECT_EQ(Op.Writes[0].Size.Value, 32u);
+}
+
+TEST(EVMMemoryFactsBuilderTest, SeparatesPlacementBaseAndLogicalSizeEffects) {
+  const std::vector<uint8_t> MStoreBytecode = {OP_PUSH1, 0x2a, OP_PUSH1, 0x80,
+                                               OP_MSTORE};
+  COMPILER::MemoryFacts MStoreFacts = collectMemoryFacts(MStoreBytecode);
+
+  ASSERT_EQ(MStoreFacts.Ops.size(), 1u);
+  const COMPILER::MemoryEffectSummary &MStore =
+      MStoreFacts.Ops[0].ObservableEffects;
+  EXPECT_EQ(MStore.StackPop, 2u);
+  EXPECT_EQ(MStore.StackPush, 0u);
+  EXPECT_TRUE(MStore.readsOrWritesMemory());
+  EXPECT_TRUE(MStore.mayGrowMemory());
+  EXPECT_TRUE(MStore.mayRebaseMemory());
+  EXPECT_TRUE(MStore.chargesDynamicGas());
+  EXPECT_TRUE(MStore.mayExhaustGas());
+  EXPECT_FALSE(MStore.requiresOrderToken());
+  EXPECT_TRUE(MStore.preservesLogicalSizeProof());
+  EXPECT_FALSE(MStore.preservesCachedMemoryBase());
+
+  COMPILER::MemoryFacts GasFacts = collectMemoryFacts({OP_GAS, OP_POP});
+  ASSERT_EQ(GasFacts.Ops.size(), 1u);
+  const COMPILER::MemoryEffectSummary &Gas = GasFacts.Ops[0].ObservableEffects;
+  EXPECT_TRUE(Gas.observesGas());
+  EXPECT_TRUE(Gas.requiresOrderToken());
+  EXPECT_TRUE(Gas.preservesLogicalSizeProof());
+  EXPECT_TRUE(Gas.preservesCachedMemoryBase());
+
+  COMPILER::MemoryFacts MSizeFacts = collectMemoryFacts({OP_MSIZE, OP_POP});
+  ASSERT_EQ(MSizeFacts.Ops.size(), 1u);
+  const COMPILER::MemoryEffectSummary &MSize =
+      MSizeFacts.Ops[0].ObservableEffects;
+  EXPECT_TRUE(MSize.observesMemorySize());
+  EXPECT_TRUE(MSize.requiresOrderToken());
+  EXPECT_TRUE(MSize.preservesLogicalSizeProof());
+  EXPECT_TRUE(MSize.preservesCachedMemoryBase());
+}
+
+TEST(EVMMemoryFactsBuilderTest, RecordsDynamicGasOpcodesAsOrderEffects) {
+  const evmc_opcode Opcodes[] = {OP_EXP, OP_BALANCE, OP_EXTCODESIZE,
+                                 OP_EXTCODEHASH, OP_SLOAD};
+  for (evmc_opcode Opcode : Opcodes) {
+    COMPILER::MemoryFacts Facts =
+        collectMemoryFacts({static_cast<uint8_t>(Opcode)});
+    ASSERT_EQ(Facts.Ops.size(), 1u) << static_cast<int>(Opcode);
+    const COMPILER::MemoryEffectSummary &Effect =
+        Facts.Ops[0].ObservableEffects;
+    EXPECT_TRUE(Effect.observesGas());
+    EXPECT_TRUE(Effect.chargesDynamicGas());
+    EXPECT_TRUE(Effect.mayExhaustGas());
+    EXPECT_TRUE(Effect.requiresOrderToken());
+    EXPECT_TRUE(Effect.mayTrapOrHalt());
+    EXPECT_TRUE(Effect.preservesLogicalSizeProof());
+  }
+}
+
+TEST(EVMMemoryFactsBuilderTest, RecordsSelfDestructGasAndTerminationEffects) {
+  COMPILER::MemoryFacts Facts = collectMemoryFacts({OP_SELFDESTRUCT});
+  ASSERT_EQ(Facts.Ops.size(), 1u);
+  const COMPILER::MemoryEffectSummary &Effect = Facts.Ops[0].ObservableEffects;
+  EXPECT_TRUE(Effect.observesGas());
+  EXPECT_TRUE(Effect.chargesDynamicGas());
+  EXPECT_TRUE(Effect.mayExhaustGas());
+  EXPECT_TRUE(Effect.requiresOrderToken());
+  EXPECT_TRUE(Effect.mayTrapOrHalt());
+  EXPECT_TRUE(Effect.terminatesFrame());
+}
+
+TEST(EVMMemoryFactsBuilderTest, TreatsPreForkCallOpcodesAsTerminatingBarriers) {
+  struct InvalidOpcodeCase {
+    evmc_opcode Opcode;
+    evmc_revision Revision;
+  };
+  const InvalidOpcodeCase Cases[] = {
+      {OP_DELEGATECALL, EVMC_FRONTIER},
+      {OP_STATICCALL, EVMC_SPURIOUS_DRAGON},
+  };
+
+  for (const InvalidOpcodeCase &Case : Cases) {
+    COMPILER::MemoryFacts Facts =
+        collectMemoryFacts({static_cast<uint8_t>(Case.Opcode)}, Case.Revision);
+    ASSERT_EQ(Facts.Ops.size(), 1u);
+    const COMPILER::MemoryOp &Op = Facts.Ops[0];
+    EXPECT_EQ(Op.Kind, COMPILER::MemoryOpKind::Other);
+    EXPECT_EQ(Op.Effect, COMPILER::MemoryEffect::Unknown);
+    EXPECT_TRUE(Op.ObservableEffects.requiresOrderToken());
+    EXPECT_TRUE(Op.ObservableEffects.mayTrapOrHalt());
+    EXPECT_TRUE(Op.ObservableEffects.terminatesFrame());
+    EXPECT_TRUE(Op.Reads.empty());
+    EXPECT_TRUE(Op.Writes.empty());
+  }
+}
+
+TEST(EVMRuntimeMemoryHelperContractTest,
+     SeparatesPreparedRangeAndExpansionHelperContracts) {
+  using COMPILER::RuntimeMemoryHelperId;
+  using COMPILER::RuntimeProofRequirementFlag;
+  const COMPILER::RuntimeMemoryHelperContract Copy =
+      COMPILER::getRuntimeMemoryHelperContract(
+          RuntimeMemoryHelperId::CodeCopyNoExpand);
+  EXPECT_TRUE(Copy.requires(RuntimeProofRequirementFlag::LogicalSize));
+  EXPECT_TRUE(Copy.requires(RuntimeProofRequirementFlag::AccessRange));
+  EXPECT_TRUE(Copy.requires(RuntimeProofRequirementFlag::DynamicGasCharged));
+  EXPECT_TRUE(Copy.Effects.has(COMPILER::MemoryEffectFlag::WritesMemory));
+  EXPECT_FALSE(Copy.Effects.mayGrowMemory());
+
+  const COMPILER::RuntimeMemoryHelperContract Expand =
+      COMPILER::getRuntimeMemoryHelperContract(
+          RuntimeMemoryHelperId::ExpandMemoryNoGas);
+  EXPECT_TRUE(Expand.requires(RuntimeProofRequirementFlag::DynamicGasCharged));
+  EXPECT_TRUE(Expand.requires(RuntimeProofRequirementFlag::BoundsValidated));
+  EXPECT_TRUE(Expand.EstablishesLogicalSize);
+  EXPECT_TRUE(Expand.Effects.mayGrowMemory());
+  EXPECT_TRUE(Expand.Effects.mayRebaseMemory());
+}
+
+TEST(EVMRuntimeMemoryHelperContractTest,
+     RecordsTwoWordKeccakDynamicGasAndFailureEffects) {
+  const COMPILER::RuntimeMemoryHelperContract Contract =
+      COMPILER::getRuntimeMemoryHelperContract(
+          COMPILER::RuntimeMemoryHelperId::TwoWordKeccakNoExpand);
+  EXPECT_TRUE(Contract.Valid);
+  EXPECT_TRUE(Contract.Effects.observesGas());
+  EXPECT_TRUE(Contract.Effects.chargesDynamicGas());
+  EXPECT_TRUE(Contract.Effects.mayExhaustGas());
+  EXPECT_TRUE(Contract.Effects.mayTrapOrHalt());
+  EXPECT_TRUE(Contract.Effects.requiresOrderToken());
+}
+
+TEST(EVMRuntimeMemoryHelperContractTest,
+     RequiresIndependentCallArgumentAndReturnProofs) {
+  using COMPILER::RuntimeMemoryHelperId;
+  using COMPILER::RuntimeProofRequirementFlag;
+  const COMPILER::RuntimeMemoryHelperContract Contract =
+      COMPILER::getRuntimeMemoryHelperContract(
+          RuntimeMemoryHelperId::CallNoExpand);
+  const RuntimeProofRequirementFlag Required[] = {
+      RuntimeProofRequirementFlag::LogicalSize,
+      RuntimeProofRequirementFlag::CallArgumentsRange,
+      RuntimeProofRequirementFlag::CallReturnRange,
+      RuntimeProofRequirementFlag::OrderToken,
+  };
+  EXPECT_TRUE(Contract.Valid);
+  for (RuntimeProofRequirementFlag Missing : Required) {
+    COMPILER::RuntimeProofToken Incomplete;
+    for (RuntimeProofRequirementFlag Requirement : Required) {
+      if (Requirement != Missing) {
+        Incomplete.establish(Requirement);
+      }
+    }
+    EXPECT_FALSE(
+        COMPILER::satisfiesRuntimeMemoryHelperContract(Contract, Incomplete));
+  }
+}
+
+TEST(EVMRuntimeMemoryHelperContractTest,
+     RejectsSelectionsMissingAnyPreparedHelperRequirement) {
+  using COMPILER::RuntimeMemoryHelperId;
+  using COMPILER::RuntimeProofRequirementFlag;
+  const COMPILER::RuntimeMemoryHelperContract Contract =
+      COMPILER::getRuntimeMemoryHelperContract(
+          RuntimeMemoryHelperId::CallDataCopyNoExpand);
+  const RuntimeProofRequirementFlag Required[] = {
+      RuntimeProofRequirementFlag::LogicalSize,
+      RuntimeProofRequirementFlag::AccessRange,
+      RuntimeProofRequirementFlag::DynamicGasCharged,
+  };
+  COMPILER::RuntimeProofToken Complete;
+  for (RuntimeProofRequirementFlag Requirement : Required) {
+    Complete.establish(Requirement);
+  }
+  EXPECT_TRUE(
+      COMPILER::satisfiesRuntimeMemoryHelperContract(Contract, Complete));
+  for (RuntimeProofRequirementFlag Missing : Required) {
+    COMPILER::RuntimeProofToken Incomplete;
+    for (RuntimeProofRequirementFlag Requirement : Required) {
+      if (Requirement != Missing) {
+        Incomplete.establish(Requirement);
+      }
+    }
+    EXPECT_FALSE(
+        COMPILER::satisfiesRuntimeMemoryHelperContract(Contract, Incomplete));
+  }
 }
 
 TEST(EVMMemoryFactsBuilderTest, AttributesOpsToAnalyzerBlocks) {
@@ -632,6 +831,42 @@ TEST(EVMMemoryGuaranteedMinBytesAnalysisTest, RejectedMergeKeepsMinimumZero) {
   EXPECT_EQ(Guaranteed.getGuaranteedMinBytesAtEntry(14), 0u);
 }
 
+TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
+     DynamicDispatchPredecessorPreventsStaticPathProof) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH0,    OP_CALLDATALOAD,
+                                         OP_PUSH1,    0x09,
+                                         OP_JUMPI,    OP_PUSH1,
+                                         0x20,        OP_CALLDATALOAD,
+                                         OP_JUMP,     OP_JUMPDEST,
+                                         OP_PUSH1,    0x01,
+                                         OP_PUSH1,    0x00,
+                                         OP_MSTORE,   OP_PUSH1,
+                                         0x12,        OP_JUMP,
+                                         OP_JUMPDEST, OP_PUSH1,
+                                         0x00,        OP_MLOAD,
+                                         OP_STOP};
+  COMPILER::MemoryFacts Facts = collectAnalyzerMemoryFacts(Bytecode);
+  const COMPILER::MemoryBlockFacts *Target = Facts.getBlock(18);
+  ASSERT_NE(Target, nullptr);
+  EXPECT_EQ(Target->Predecessors, std::vector<uint64_t>({9, 5}));
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Guaranteed(Facts);
+  EXPECT_EQ(Guaranteed.getGuaranteedMinBytesAtEntry(18), 0u);
+}
+
+TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
+     IncompleteDynamicDispatchPredecessorsDropProof) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1,    0x01,     OP_PUSH1,    0x00,     OP_MSTORE, OP_PUSH1,
+      0x0c,        OP_JUMP,  OP_JUMPDEST, OP_JUMP,  OP_STOP,   OP_STOP,
+      OP_JUMPDEST, OP_PUSH1, 0x00,        OP_MLOAD, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectAnalyzerMemoryFacts(Bytecode);
+  const COMPILER::MemoryBlockFacts *Target = Facts.getBlock(12);
+  ASSERT_NE(Target, nullptr);
+  EXPECT_FALSE(Target->PredecessorsComplete);
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Guaranteed(Facts);
+  EXPECT_EQ(Guaranteed.getGuaranteedMinBytesAtEntry(12), 0u);
+}
+
 TEST(EVMMemoryGuaranteedMinBytesAnalysisTest, RecordsGuaranteeBeforeEachOp) {
   const std::vector<uint8_t> Bytecode = {
       OP_PUSH1, 0x01, OP_PUSH1, 0x80, OP_MSTORE, OP_PUSH1, 0x40, OP_MLOAD};
@@ -644,8 +879,40 @@ TEST(EVMMemoryGuaranteedMinBytesAnalysisTest, RecordsGuaranteeBeforeEachOp) {
   EXPECT_EQ(Guaranteed.getGuaranteedMinBytesBeforeOp(Facts.Ops[1].Id), 0xa0u);
 }
 
+TEST(EVMMemoryProofLifetimeAnalysisTest,
+     ReusesRangeButRejectsExpansionMotionAcrossGas) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,     OP_PUSH1, 0x80,     OP_MSTORE, OP_GAS,
+      OP_POP,   OP_PUSH1, 0x80,     OP_MLOAD, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  COMPILER::MemoryProofLifetimeAnalysis Lifetime(Facts);
+  ASSERT_EQ(Facts.Ops.size(), 3u);
+  const COMPILER::MemoryProofAvailability Proof =
+      Lifetime.queryBeforeOp(Facts.Ops[2].Id, Facts.Ops[2].Reads[0]);
+  EXPECT_EQ(Proof.GuaranteedMinBytes, 0xa0u);
+  EXPECT_TRUE(Proof.canReuseWithoutExpansion());
+  EXPECT_FALSE(
+      Lifetime.canMoveExpansionBetween(Facts.Ops[0].Id, Facts.Ops[2].Id));
+}
+
+TEST(EVMMemoryProofLifetimeAnalysisTest,
+     ReusesRangeButRejectsExpansionMotionAcrossMSize) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,     OP_PUSH1, 0x40,     OP_MSTORE, OP_MSIZE,
+      OP_POP,   OP_PUSH1, 0x40,     OP_MLOAD, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  COMPILER::MemoryProofLifetimeAnalysis Lifetime(Facts);
+  ASSERT_EQ(Facts.Ops.size(), 3u);
+  const COMPILER::MemoryProofAvailability Proof =
+      Lifetime.queryBeforeOp(Facts.Ops[2].Id, Facts.Ops[2].Reads[0]);
+  EXPECT_EQ(Proof.GuaranteedMinBytes, 0x60u);
+  EXPECT_TRUE(Proof.canReuseWithoutExpansion());
+  EXPECT_FALSE(
+      Lifetime.canMoveExpansionBetween(Facts.Ops[0].Id, Facts.Ops[2].Id));
+}
+
 TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
-     DoesNotLearnNewGuaranteesAfterBarrier) {
+     ContinuesLearningLogicalExtentAcrossGasObserver) {
   const std::vector<uint8_t> Bytecode = {
       OP_PUSH1, 0x01,     OP_PUSH1, 0x00,      OP_MSTORE, OP_GAS, OP_PUSH1,
       0x02,     OP_PUSH1, 0x80,     OP_MSTORE, OP_PUSH1,  0x80,   OP_MLOAD};
@@ -654,7 +921,7 @@ TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
   COMPILER::MemoryGuaranteedMinBytesAnalysis Guaranteed(Facts);
 
   ASSERT_EQ(Facts.Ops.size(), 4u);
-  EXPECT_EQ(Guaranteed.getGuaranteedMinBytesBeforeOp(Facts.Ops[3].Id), 32u);
+  EXPECT_EQ(Guaranteed.getGuaranteedMinBytesBeforeOp(Facts.Ops[3].Id), 0xa0u);
 }
 
 TEST(EVMMemoryGuaranteedMinBytesAnalysisTest, LearnsConstMCopyUnionEnd) {
@@ -2587,6 +2854,37 @@ class DynamicPushMockEVMBuilder : public MockEVMBuilder {
 public:
   Operand handlePush(const zen::common::Bytes &) { return Operand(); }
 };
+
+class MemoryFactsCapturingBuilder : public MockEVMBuilder {
+public:
+  void setMemoryFacts(const COMPILER::MemoryFacts &Facts) {
+    CapturedFacts = Facts;
+  }
+
+  COMPILER::MemoryFacts CapturedFacts;
+};
+
+TEST(EVMJITFrontendVisitorTest, UsesActiveRevisionForMemoryEffectFacts) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH0, OP_PUSH0, OP_PUSH0, OP_MCOPY,
+                                         OP_STOP};
+
+  COMPILER::EVMFrontendContext Ctx;
+  Ctx.setRevision(EVMC_SHANGHAI);
+  Ctx.setBytecode(reinterpret_cast<const zen::common::Byte *>(Bytecode.data()),
+                  Bytecode.size());
+
+  MemoryFactsCapturingBuilder Builder;
+  COMPILER::EVMByteCodeVisitor<MemoryFactsCapturingBuilder> Visitor(Builder,
+                                                                    &Ctx);
+  EXPECT_TRUE(Visitor.compile());
+  ASSERT_EQ(Builder.CapturedFacts.Ops.size(), 1u);
+  const COMPILER::MemoryOp &Op = Builder.CapturedFacts.Ops[0];
+  EXPECT_EQ(Op.Opcode, OP_MCOPY);
+  EXPECT_EQ(Op.Kind, COMPILER::MemoryOpKind::Other);
+  EXPECT_EQ(Op.Effect, COMPILER::MemoryEffect::Unknown);
+  EXPECT_TRUE(Op.ObservableEffects.mayTrapOrHalt());
+  EXPECT_TRUE(Op.ObservableEffects.terminatesFrame());
+}
 
 TEST(EVMMirBuilderConstFoldTest, ExpFoldsConstantOperands) {
   MirBuilderConstFoldHarness Harness;


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y

Refs #595

#### 2. What is the scope of this PR (e.g. component or file name):

EVM multipass memory facts, proof-lifetime analysis, runtime helper contracts, frontend tests, and compiler documentation.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [ ] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [x] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

This PR defines revision-aware protocol-observable memory effects and typed proof requirements for prepared-memory runtime helpers. It preserves recovered memory facts only across complete, statically known paths whose effects are compatible with the requested proof.

Unknown effects, incomplete CFGs, dynamic dispatch, joins, cycles, unsupported paths, and termination barriers fail closed. Proof validity remains separate from the legality of moving gas charges, expansion checks, traps, external effects, or termination. CALL argument and return ranges remain separate obligations, and LOG is not introduced as a typed cross-block consumer.

This is PR 1 of the ordered production series described in #595. It has no dependency on experiment policy, telemetry, certificates, witness serialization, benchmark artifacts, or paper assets.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y

No public ABI or runtime-helper implementation changes.

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [x] Unit test
- [x] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

Validation on LLVM 15 Release multipass configuration:

- `./tools/format.sh format`
- `./tools/format.sh check`
- `git diff --check`
- LLVM 15 target build: pass
- EVM fixture generation: 209/209
- `evmJitFrontendTests`: 146/146
- `evmDifferentialTests`: 71/71

No performance benchmark was run or claimed.

#### 6. Release note

```release-note
Add effect-aware EVM memory proof lifetime and typed prepared-helper contracts.
```