### PR TITLE
refactor(evm): enforce prepared-memory helper proof contracts

### DIFF
--- a/docs/changes/2026-08-05-budgeted-memory-proof-recovery/README.md
+++ b/docs/changes/2026-08-05-budgeted-memory-proof-recovery/README.md
@@ -1,0 +1,58 @@
+# Change: Recover memory proofs on demand within fixed budgets
+
+- **Status**: Proposed
+- **Date**: 2026-08-05
+- **Tier**: Full
+
+## Overview
+
+This change avoids eager construction of every EVM memory analysis. A cheap
+opportunity scan admits planning only when a compatible consumer exists;
+individual proof services are activated on demand, indexed, cached, and bounded
+by deterministic work budgets.
+
+When a query exceeds its budget or encounters incomplete facts, cycles, dynamic
+predecessors, or unsupported control flow, it returns a conservative result and
+the existing generic lowering remains in use.
+
+## Motivation
+
+Prepared-memory optimizations should not impose their full analysis cost on
+contracts that cannot consume a proof. Demand-driven recovery keeps the no-hit
+path small while retaining proof availability for eligible consumers.
+
+## Design
+
+The bytecode visitor first records a compact opportunity summary. Full memory
+facts and planning state are constructed only after admission. Stable operation
+indexes replace repeated scans, and region, extent, dead-store, and forwarding
+components activate only when queried.
+
+Sparse proof queries use deterministic per-query and per-compilation budgets and
+cache both successful and conservative outcomes. Repeated dense demand may
+promote to a bounded global analysis; failed or over-budget promotion remains a
+permanent conservative fallback for that compilation.
+
+## Impact
+
+The change affects only EVM multipass compilation. It preserves deterministic
+results and does not add runtime policy selection, telemetry publication,
+certificate emission, benchmark output, or paper artifacts. Budget exhaustion
+can reduce optimization coverage but cannot authorize an unsafe transformation.
+
+This proposal depends on the effect-aware proof-query contract. Prepared-helper
+consumer enforcement is layered on top in a subsequent change.
+
+## Validation
+
+Focused frontend tests cover no-hit admission, dense-hit preservation, lazy
+activation, cache identity, budget exhaustion, deterministic promotion, cycles,
+entry backedges, incomplete predecessors, and conservative fallback.
+Differential tests continue to compare interpreter and multipass behavior.
+
+## Checklist
+
+- [x] Production implementation and focused tests prepared
+- [x] Compiler module specification updated
+- [x] Budgets and promotion decisions are deterministic
+- [x] Telemetry, certificates, experiment policy, and paper assets excluded

--- a/docs/changes/2026-08-05-effect-aware-memory-proof-lifetime/README.md
+++ b/docs/changes/2026-08-05-effect-aware-memory-proof-lifetime/README.md
@@ -1,0 +1,60 @@
+# Change: Model effect-aware memory proof lifetime
+
+- **Status**: Proposed
+- **Date**: 2026-08-05
+- **Tier**: Full
+
+## Overview
+
+This change defines typed memory-proof requirements for EVM runtime helpers and
+tracks when a recovered proof remains valid across control-flow edges. Unknown
+effects, incomplete control flow, dynamic dispatch, and unsupported paths fail
+closed.
+
+The proof only establishes the memory facts represented by its typed token. It
+does not authorize moving gas charges, expansion checks, traps, termination, or
+other protocol-observable behavior.
+
+## Motivation
+
+Existing prepared-memory helpers can reuse facts recovered by the multipass
+frontend, but cross-block reuse needs one shared definition of which operations
+preserve or invalidate those facts. Encoding the contract centrally prevents
+individual lowering sites from making ad hoc assumptions about proof lifetime.
+
+## Design
+
+Opcode and runtime-helper effects are summarized with explicit flags for memory
+reads and writes, logical-size observation, dynamic gas, external calls,
+externalization, ordering, and termination. Runtime helper contracts state the
+exact proof obligations that a caller must satisfy.
+
+The proof-lifetime query follows only complete, statically known control flow.
+It rejects joins, cycles, dynamic dispatch, unknown effects, and paths whose
+observable behavior cannot be proven safe. `LOG` is classified as an observable
+memory reader but is not introduced as a typed cross-block consumer here.
+
+## Impact
+
+The change is limited to EVM multipass analysis and its internal helper
+contracts. It does not change a public ABI, runtime helper implementation,
+protocol-visible ordering, or the interpreter. Conservative rejection may
+reduce optimization opportunities but preserves the existing generic path.
+
+This proposal is the foundation for budgeted proof recovery and prepared-helper
+contract enforcement. It has no dependency on experiment policies, telemetry,
+certificate publication, or witness serialization.
+
+## Validation
+
+Focused frontend tests cover opcode effects, helper requirements, logical-size
+preservation, unique-predecessor reuse, and fail-closed behavior for calls,
+termination, incomplete CFGs, dynamic dispatch, and unknown effects.
+Differential tests continue to compare interpreter and multipass behavior.
+
+## Checklist
+
+- [x] Production implementation and focused tests prepared
+- [x] Compiler module specification updated
+- [x] Unknown or incomplete cases fail closed
+- [x] Experiment and paper-only surfaces excluded

--- a/docs/changes/2026-08-05-prepared-memory-proof-contracts/README.md
+++ b/docs/changes/2026-08-05-prepared-memory-proof-contracts/README.md
@@ -1,0 +1,56 @@
+# Change: Enforce prepared-memory helper proof contracts
+
+- **Status**: Proposed
+- **Date**: 2026-08-05
+- **Tier**: Full
+
+## Overview
+
+This change requires existing prepared-memory COPY, KECCAK, RETURN, REVERT, and
+CALL-family lowering paths to present the typed proof tokens required by their
+runtime helper contracts. A missing or mismatched obligation selects the
+existing generic helper.
+
+## Motivation
+
+The multipass compiler already contains prepared-memory helpers. Central proof
+contracts are useful only if every optimized call site checks the exact facts it
+relies on. Explicit enforcement makes the safety boundary reviewable and keeps
+new consumers from silently bypassing proof requirements.
+
+## Design
+
+COPY and KECCAK require logical-size, access-range, dynamic-gas, and ordering
+proofs appropriate to their helpers. RETURN and REVERT additionally preserve
+terminal behavior. CALL, CALLCODE, DELEGATECALL, and STATICCALL retain separate
+argument-range and return-range obligations; coverage of one range never
+substitutes for the other.
+
+The checks do not move memory expansion, gas charging, account access, EIP-150
+handling, external calls, return-data updates, or termination. `LOG` remains
+outside this typed consumer series.
+
+## Impact
+
+The change is internal to EVM multipass lowering and reuses existing runtime
+helpers. It does not change their ABI or implementation. Conservative fallback
+may select a generic helper more often, but protocol-visible behavior remains on
+the established path.
+
+This proposal depends on the effect-aware proof contract and budgeted proof
+service. It does not depend on telemetry, certificates, witnesses, experiment
+policies, or paper artifacts.
+
+## Validation
+
+Frontend and differential tests cover COPY and KECCAK proof requirements,
+RETURN and REVERT termination behavior, zero-length and overflow fallback, and
+independent CALL argument and return obligations while preserving gas and
+external-effect ordering.
+
+## Checklist
+
+- [x] Production enforcement and focused tests prepared
+- [x] CALL argument and return obligations remain separate
+- [x] `LOG` is not claimed as a typed consumer
+- [x] Certificate and experiment-only surfaces excluded

--- a/docs/modules/compiler/spec.md
+++ b/docs/modules/compiler/spec.md
@@ -183,6 +183,21 @@ component has been established. Cached host-base and memory-content proof
 domains are deliberately not propagated until a lowering consumer requires
 them.
 
+Memory proof recovery is admitted and budgeted for online compilation. The
+initial bytecode scan records a conservative `MemoryOpportunitySummary` and a
+direct opcode-PC index. Modules without a reusable consumer opportunity skip
+planner setup, while revision-invalid opcodes still retain the effect facts
+needed for fail-closed lowering. Optional extent, region, dead-store, and load-
+forwarding analyses are constructed only when a matching query is issued.
+
+Guaranteed extent is recovered by a sparse demand oracle with independent
+per-query and compilation-wide limits on block, operation, and CFG-edge work.
+Only a completed query publishes its touched facts; incomplete CFGs, cycles,
+or exhausted budgets retain the generic expansion path without a partial
+proof. Repeated uncached queries may schedule a bounded full analysis, but the
+promotion result becomes visible only after the full run completes. Cache
+hits neither spend query budget nor trigger eager promotion.
+
 The framework may eliminate only the write of an exact, fully overwritten
 `MSTORE` or `MSTORE8`, and may forward an exact 32-byte `MSTORE` value to a
 later `MLOAD`. Both transformations are block-local, require strict

--- a/docs/modules/compiler/spec.md
+++ b/docs/modules/compiler/spec.md
@@ -162,8 +162,26 @@ Block prechecks select one maximal safe window with at least two proven direct
 memory operations. The plan records explicit operation IDs, is emitted at the
 first covered operation, and may cover gaps or overlapping intervals because
 expansion grouping does not transform memory values. Per-operation guaranteed
-bytes include proven earlier expansion in the same block, but stop learning
-new guarantees after a hard barrier.
+bytes include proven earlier expansion in the same block.
+
+`MemoryProofLifetimeAnalysis` separates two questions that are distinct under
+EVM semantics. A successful memory operation may establish a logical minimum
+extent that remains true after an opcode such as `GAS` or `MSIZE`; this permits
+a later consumer to reuse the extent proof. It does not permit the compiler to
+move a later expansion, gas charge, trap, log, return, or external call across
+that opcode. The placement query therefore remains fail closed across
+observable-order, trapping, externalization, termination, unknown-effect, and
+unsafe CFG boundaries even when the logical-size proof survives.
+
+Proof propagation uses the analyzer's complete predecessor relation. The
+invocation entry starts with a zero-byte guarantee even when it has a backedge,
+and blocks with incomplete dynamic-dispatch predecessors receive no cross-block
+guarantee. Revision-undefined opcodes are terminating barriers. Prepared-memory
+runtime helpers declare typed proof requirements and normal-success memory
+effects; a helper contract is satisfied only when every required proof
+component has been established. Cached host-base and memory-content proof
+domains are deliberately not propagated until a lowering consumer requires
+them.
 
 The framework may eliminate only the write of an exact, fully overwritten
 `MSTORE` or `MSTORE8`, and may forward an exact 32-byte `MSTORE` value to a

--- a/src/action/evm_bytecode_visitor.h
+++ b/src/action/evm_bytecode_visitor.h
@@ -143,8 +143,11 @@ private:
   void buildMemoryFacts(const EVMAnalyzer &Analyzer, const uint8_t *Bytecode,
                         size_t BytecodeSize) {
     MemoryFacts.reset();
+    MemoryFacts.setRevision(Analyzer.getRevision());
     MemoryEntryAddressAnalysis EntryAddresses(Analyzer, Bytecode, BytecodeSize);
     const auto &BlockInfos = Analyzer.getBlockInfos();
+    const std::vector<uint64_t> DynamicDispatchSources =
+        Analyzer.getDynamicJumpDispatchSourceBlocks();
 
     for (const auto &[EntryPC, BlockInfo] : BlockInfos) {
       const bool HasReliableEntryStack =
@@ -155,9 +158,17 @@ private:
           HasReliableEntryStack ? BlockInfo.ResolvedEntryStackDepth : 0;
       std::vector<MemoryEntryValue> EntryValues = EntryAddresses.getEntryValues(
           EntryPC, static_cast<uint32_t>(EntryDepth));
+      const std::vector<uint64_t> PotentialPredecessors =
+          Analyzer.getPotentialEntryPredecessorsForBlock(EntryPC);
+      const bool PredecessorsAreStatic =
+          Analyzer.getDynamicJumpSourceBlocksForBlock(EntryPC).empty();
+      const bool PredecessorsComplete =
+          Analyzer.dynamicJumpTargetPredecessorsAreComplete(
+              EntryPC, DynamicDispatchSources);
       MemoryFacts.beginBlock(
           EntryPC, BlockInfo.BodyStartPC, BlockInfo.BodyEndPC, EntryValues,
-          BlockInfo.Successors, BlockInfo.Predecessors, HasReliableEntryStack);
+          BlockInfo.Successors, PotentialPredecessors, HasReliableEntryStack,
+          PredecessorsComplete, PredecessorsAreStatic);
 
       // Memory facts model stack-relative addresses.  An unresolved,
       // inconsistent, or dynamic-dispatch-derived entry depth cannot reliably

--- a/src/action/evm_bytecode_visitor.h
+++ b/src/action/evm_bytecode_visitor.h
@@ -142,7 +142,7 @@ private:
 
   void buildMemoryFacts(const EVMAnalyzer &Analyzer, const uint8_t *Bytecode,
                         size_t BytecodeSize) {
-    MemoryFacts.reset();
+    MemoryFacts.reset(BytecodeSize);
     MemoryFacts.setRevision(Analyzer.getRevision());
     MemoryEntryAddressAnalysis EntryAddresses(Analyzer, Bytecode, BytecodeSize);
     const auto &BlockInfos = Analyzer.getBlockInfos();
@@ -300,8 +300,10 @@ private:
       }
       Analyzer.analyze(Bytecode, BytecodeSize);
       if constexpr (HasSetMemoryFacts<IRBuilder>::value) {
-        buildMemoryFacts(Analyzer, Bytecode, BytecodeSize);
-        setMemoryFactsCompat();
+        if (Analyzer.shouldBuildMemoryFacts()) {
+          buildMemoryFacts(Analyzer, Bytecode, BytecodeSize);
+          setMemoryFactsCompat();
+        }
       }
       initializeLiftedBlocks(Analyzer);
 

--- a/src/compiler/evm_frontend/evm_analyzer.h
+++ b/src/compiler/evm_frontend/evm_analyzer.h
@@ -361,6 +361,17 @@ public:
     return PredBlockPCs;
   }
 
+  std::vector<uint64_t> getDynamicJumpDispatchSourceBlocks() const {
+    return collectAllDynamicJumpDispatchSourceBlocks();
+  }
+
+  bool dynamicJumpTargetPredecessorsAreComplete(
+      uint64_t BlockPC,
+      const std::vector<uint64_t> &DispatchSourceBlocks) const {
+    return dynamicJumpTargetPredecessorsCoverCodegenEdges(BlockPC,
+                                                          DispatchSourceBlocks);
+  }
+
   std::vector<uint64_t>
   getCompatibleDynamicJumpTargetBlocksForSourceBlock(uint64_t BlockPC) const {
     auto It = BlockInfos.find(BlockPC);

--- a/src/compiler/evm_frontend/evm_analyzer.h
+++ b/src/compiler/evm_frontend/evm_analyzer.h
@@ -5,6 +5,7 @@
 #define EVM_FRONTEND_EVM_ANALYZER_H
 
 #include "common/defines.h"
+#include "compiler/evm_frontend/evm_memory_facts.h"
 #include "compiler/evm_frontend/evm_value_range.h"
 #include "evm/evm.h"
 #include "evmc/evmc.h"
@@ -117,6 +118,13 @@ struct JITSuitabilityResult {
   size_t MaxConsecutiveExpensive = 0; // longest unbroken run
   size_t MaxBlockExpensiveCount = 0;  // max RA-expensive ops in one block
   size_t DupFeedbackPatternCount = 0; // DUPn immediately before RA-expensive
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+  bool HasMemoryPlanningRoot = false;
+  bool RequiresMemoryEffectFacts = false;
+  bool HasPotentialMultiBlockControlFlow = false;
+  bool UseMemoryOpportunityScout = false;
+  bool ShouldBuildMemoryFacts = false;
+#endif
 };
 
 /// Thresholds for JIT suitability fallback. These limits bound bytecode size
@@ -133,7 +141,9 @@ class EVMAnalyzer {
   using Byte = zen::common::Byte;
 
 public:
-  EVMAnalyzer(evmc_revision Rev = zen::evm::DEFAULT_REVISION) : Revision(Rev) {
+  EVMAnalyzer(evmc_revision Rev = zen::evm::DEFAULT_REVISION)
+      : Revision(Rev),
+        MemoryOpportunityScout(Rev, MemoryFactsBuildMode::OpportunitySummary) {
     InstructionMetrics = evmc_get_instruction_metrics_table(Revision);
     if (!InstructionMetrics) {
       InstructionMetrics =
@@ -487,6 +497,14 @@ public:
 
   bool hasUnknownDynamicJumpTargets() const { return HasUnknownDynamicJump; }
 
+  bool shouldBuildMemoryFacts() const {
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+    return JITResult.ShouldBuildMemoryFacts;
+#else
+    return true;
+#endif
+  }
+
   bool analyzeSuitabilityOnly(const uint8_t *Bytecode, size_t BytecodeSize) {
     resetAnalysisState();
     analyzeSuitability(Bytecode, BytecodeSize);
@@ -498,6 +516,9 @@ public:
     analyzeSuitability(Bytecode, BytecodeSize);
     buildJumpDestRuns(Bytecode, BytecodeSize);
     buildBlocks(Bytecode, BytecodeSize);
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+    finalizeMemoryPlanningAdmission();
+#endif
     linkPredecessors();
     resolveEntryDepths();
     markDynamicJumpTargetCandidates();
@@ -631,6 +652,9 @@ private:
     JumpDestCanonicalPCs.clear();
     EntryBlockPC = 0;
     HasUnknownDynamicJump = false;
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+    MemoryOpportunityScout.reset();
+#endif
   }
 
   struct AbstractValue {
@@ -699,6 +723,60 @@ private:
     return 0;
   }
 
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+  static bool isMemoryPlanningRootOpcode(evmc_opcode Opcode) {
+    switch (Opcode) {
+    case OP_KECCAK256:
+    case OP_CALLDATACOPY:
+    case OP_CODECOPY:
+    case OP_EXTCODECOPY:
+    case OP_RETURNDATACOPY:
+    case OP_MLOAD:
+    case OP_MSTORE:
+    case OP_MSTORE8:
+    case OP_MCOPY:
+    case OP_LOG0:
+    case OP_LOG1:
+    case OP_LOG2:
+    case OP_LOG3:
+    case OP_LOG4:
+    case OP_CREATE:
+    case OP_CREATE2:
+    case OP_CALL:
+    case OP_CALLCODE:
+    case OP_DELEGATECALL:
+    case OP_STATICCALL:
+    case OP_RETURN:
+    case OP_REVERT:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  void finalizeMemoryPlanningAdmission() {
+    if (JITResult.RequiresMemoryEffectFacts) {
+      // Preserve the active-revision effect record for undefined opcodes. The
+      // frontend may use it to terminate conservatively even though the opcode
+      // is not a memory-planning root.
+      JITResult.ShouldBuildMemoryFacts = true;
+      return;
+    }
+    if (!JITResult.HasMemoryPlanningRoot) {
+      JITResult.ShouldBuildMemoryFacts = false;
+      return;
+    }
+    if (!JITResult.UseMemoryOpportunityScout) {
+      // The cheap scout deliberately does not model cross-block stack flow.
+      // Preserve every potential multi-block opportunity for the full builder.
+      JITResult.ShouldBuildMemoryFacts = true;
+      return;
+    }
+    JITResult.ShouldBuildMemoryFacts =
+        MemoryOpportunityScout.getFacts().Opportunities.hasPlannerOpportunity();
+  }
+#endif
+
   void analyzeSuitability(const uint8_t *Bytecode, size_t BytecodeSize) {
     JITResult = JITSuitabilityResult();
     JITResult.BytecodeSize = BytecodeSize;
@@ -711,6 +789,18 @@ private:
     while (PCIndex < BytecodeSize) {
       evmc_opcode Opcode = static_cast<evmc_opcode>(Bytecode[PCIndex]);
       uint8_t OpcodeU8 = static_cast<uint8_t>(Opcode);
+
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+      const bool IsDefined =
+          InstructionNames != nullptr && InstructionNames[OpcodeU8] != nullptr;
+      JITResult.RequiresMemoryEffectFacts |= !IsDefined;
+      if (IsDefined && isMemoryPlanningRootOpcode(Opcode)) {
+        JITResult.HasMemoryPlanningRoot = true;
+      }
+      if (Opcode == OP_JUMP || Opcode == OP_JUMPI || Opcode == OP_JUMPDEST) {
+        JITResult.HasPotentialMultiBlockControlFlow = true;
+      }
+#endif
 
       JITResult.MirEstimate += MIR_OPCODE_WEIGHT[OpcodeU8];
 
@@ -758,6 +848,11 @@ private:
         JITResult.MaxConsecutiveExpensive > MAX_CONSECUTIVE_RA_EXPENSIVE ||
         JITResult.MaxBlockExpensiveCount > MAX_BLOCK_RA_EXPENSIVE ||
         JITResult.DupFeedbackPatternCount > MAX_DUP_FEEDBACK_PATTERN;
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+    JITResult.UseMemoryOpportunityScout =
+        JITResult.HasMemoryPlanningRoot &&
+        !JITResult.HasPotentialMultiBlockControlFlow;
+#endif
   }
 
   void buildJumpDestRuns(const uint8_t *Bytecode, size_t BytecodeSize) {
@@ -846,6 +941,13 @@ private:
                      NextBodyStartPC, HasNextBlock);
         break;
       }
+
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+      if (JITResult.UseMemoryOpportunityScout) {
+        MemoryOpportunityScout.observeOpcode(
+            Opcode, static_cast<uint64_t>(ScanPC), Bytecode, BytecodeSize);
+      }
+#endif
 
       uint8_t OpcodeU8 = static_cast<uint8_t>(Opcode);
       if (isRAExpensiveOpcode(OpcodeU8)) {
@@ -1029,8 +1131,18 @@ private:
       uint64_t NextEntryPC = 0;
       size_t NextBodyStartPC = BytecodeSize;
       bool HasNextBlock = false;
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+      if (JITResult.UseMemoryOpportunityScout) {
+        MemoryOpportunityScout.beginBlock(CurEntryPC, 0);
+      }
+#endif
       analyzeBlockBody(Info, Bytecode, BytecodeSize, ScanPC, NextEntryPC,
                        NextBodyStartPC, HasNextBlock);
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+      if (JITResult.UseMemoryOpportunityScout) {
+        MemoryOpportunityScout.endBlock();
+      }
+#endif
       BlockInfos[CurEntryPC] = Info;
       if (!HasNextBlock) {
         break;
@@ -2358,6 +2470,7 @@ private:
   const evmc_instruction_metrics *InstructionMetrics = nullptr;
   const char *const *InstructionNames = nullptr;
   JITSuitabilityResult JITResult;
+  MemoryFactsBuilder MemoryOpportunityScout;
   const std::unordered_map<uint32_t, uint32_t> *SharedResolvedJumpTargets =
       nullptr;
 };

--- a/src/compiler/evm_frontend/evm_memory_analysis.h
+++ b/src/compiler/evm_frontend/evm_memory_analysis.h
@@ -842,26 +842,6 @@ public:
   }
 
 private:
-  static bool isHardBarrier(const MemoryOp &Op) {
-    switch (Op.Kind) {
-    case MemoryOpKind::Log:
-    case MemoryOpKind::Call:
-    case MemoryOpKind::Create:
-    case MemoryOpKind::Return:
-    case MemoryOpKind::Revert:
-    case MemoryOpKind::MSize:
-    case MemoryOpKind::Gas:
-      return true;
-    default:
-      break;
-    }
-
-    return Op.Effect == MemoryEffect::Escape ||
-           Op.Effect == MemoryEffect::MemorySizeObserver ||
-           Op.Effect == MemoryEffect::GasSensitive ||
-           Op.Effect == MemoryEffect::Unknown;
-  }
-
   static bool getIntervalEnd(const MemoryInterval &Interval, uint64_t &End) {
     if (Interval.Space != AddressSpace::Memory || Interval.Empty ||
         !Interval.Addr.isKnown() ||
@@ -877,54 +857,51 @@ private:
     return true;
   }
 
-  static bool getDirectRequiredBytes(const MemoryOp &Op, uint64_t &End) {
-    switch (Op.Kind) {
-    case MemoryOpKind::MLoad:
-      return Op.Reads.size() == 1 && getIntervalEnd(Op.Reads[0], End);
-    case MemoryOpKind::Keccak:
-      return Op.Reads.size() == 1 && getIntervalEnd(Op.Reads[0], End);
-    case MemoryOpKind::MStore:
-    case MemoryOpKind::MStore8:
-      return Op.Writes.size() == 1 && getIntervalEnd(Op.Writes[0], End);
-    case MemoryOpKind::CallDataCopy:
-    case MemoryOpKind::CodeCopy:
-      return Op.Writes.size() == 1 && getIntervalEnd(Op.Writes[0], End);
-    case MemoryOpKind::MCopy: {
-      if (Op.Reads.size() != 1 || Op.Writes.size() != 1) {
-        return false;
+  static bool getGuaranteedRequiredBytes(const MemoryOp &Op, uint64_t &End) {
+    bool Found = false;
+    End = 0;
+    auto Accumulate = [&Found, &End](const MemoryInterval &Interval) {
+      uint64_t IntervalEnd = 0;
+      if (getIntervalEnd(Interval, IntervalEnd)) {
+        End = std::max(End, IntervalEnd);
+        Found = true;
       }
-      uint64_t ReadEnd = 0;
-      uint64_t WriteEnd = 0;
-      if (!getIntervalEnd(Op.Reads[0], ReadEnd) ||
-          !getIntervalEnd(Op.Writes[0], WriteEnd)) {
-        return false;
-      }
-      End = std::max(ReadEnd, WriteEnd);
-      return true;
+    };
+    for (const MemoryInterval &Read : Op.Reads) {
+      Accumulate(Read);
     }
-    default:
-      return false;
+    for (const MemoryInterval &Write : Op.Writes) {
+      Accumulate(Write);
     }
+    return Found;
   }
 
-  uint64_t transfer(const MemoryBlockFacts &Block,
-                    uint64_t EntryBytesValue) const {
+  struct TransferResult {
+    uint64_t Bytes = 0;
+    bool HasNormalExit = true;
+  };
+
+  TransferResult transfer(const MemoryBlockFacts &Block,
+                          uint64_t EntryBytesValue) const {
     if (!Block.HasCompleteOpcodeFacts) {
-      return 0;
+      return {.Bytes = 0};
     }
     uint64_t Current = EntryBytesValue;
     for (size_t I = Block.OpsBegin; I < Block.OpsEnd && I < Facts.Ops.size();
          ++I) {
       const MemoryOp &Op = Facts.Ops[I];
-      if (isHardBarrier(Op)) {
-        return Current;
+      if (!Op.ObservableEffects.preservesLogicalSizeProof()) {
+        Current = 0;
       }
       uint64_t RequiredBytes = 0;
-      if (getDirectRequiredBytes(Op, RequiredBytes)) {
+      if (getGuaranteedRequiredBytes(Op, RequiredBytes)) {
         Current = std::max(Current, RequiredBytes);
       }
+      if (Op.ObservableEffects.terminatesFrame()) {
+        return {.Bytes = 0, .HasNormalExit = false};
+      }
     }
-    return Current;
+    return {.Bytes = Current};
   }
 
   void recordBeforeOpBytes(const MemoryBlockFacts &Block,
@@ -933,34 +910,35 @@ private:
       return;
     }
     uint64_t Current = EntryBytesValue;
-    bool SeenBarrier = false;
     for (size_t I = Block.OpsBegin; I < Block.OpsEnd && I < Facts.Ops.size();
          ++I) {
       const MemoryOp &Op = Facts.Ops[I];
       BeforeOpBytes[Op.Id] = Current;
-      if (isHardBarrier(Op)) {
-        SeenBarrier = true;
-        continue;
-      }
-      if (SeenBarrier) {
-        continue;
+      if (!Op.ObservableEffects.preservesLogicalSizeProof()) {
+        Current = 0;
       }
       uint64_t RequiredBytes = 0;
-      if (getDirectRequiredBytes(Op, RequiredBytes)) {
+      if (getGuaranteedRequiredBytes(Op, RequiredBytes)) {
         Current = std::max(Current, RequiredBytes);
+      }
+      if (Op.ObservableEffects.terminatesFrame()) {
+        return;
       }
     }
   }
 
   uint64_t computeEntryFromPredecessors(const MemoryBlockFacts &Block) const {
-    if (!Block.HasCompleteOpcodeFacts) {
-      return 0;
-    }
-    if (Block.Predecessors.empty()) {
+    if (!Block.HasCompleteOpcodeFacts || Block.EntryPC == 0 ||
+        !Block.PredecessorsComplete || !Block.PredecessorsAreStatic ||
+        Block.Predecessors.empty()) {
       return 0;
     }
     uint64_t Result = std::numeric_limits<uint64_t>::max();
     for (uint64_t PredPC : Block.Predecessors) {
+      auto PredValidIt = ExitAvailable.find(PredPC);
+      if (PredValidIt == ExitAvailable.end() || !PredValidIt->second) {
+        return 0;
+      }
       auto PredExitIt = ExitBytes.find(PredPC);
       const uint64_t PredExit =
           PredExitIt == ExitBytes.end() ? 0 : PredExitIt->second;
@@ -973,11 +951,22 @@ private:
     std::queue<uint64_t> WorkList;
     std::map<uint64_t, bool> InQueue;
     for (const auto &[EntryPC, Block] : Facts.Blocks) {
-      (void)Block;
       EntryBytes[EntryPC] = 0;
       ExitBytes[EntryPC] = 0;
+      ExitAvailable[EntryPC] = false;
       WorkList.push(EntryPC);
       InQueue[EntryPC] = true;
+      for (uint64_t PredPC : Block.Predecessors) {
+        Dependents[PredPC].push_back(EntryPC);
+      }
+      for (uint64_t SuccPC : Block.Successors) {
+        Dependents[EntryPC].push_back(SuccPC);
+      }
+    }
+    for (auto &[EntryPC, Targets] : Dependents) {
+      (void)EntryPC;
+      std::sort(Targets.begin(), Targets.end());
+      Targets.erase(std::unique(Targets.begin(), Targets.end()), Targets.end());
     }
 
     while (!WorkList.empty()) {
@@ -992,13 +981,19 @@ private:
       const MemoryBlockFacts &Block = BlockIt->second;
       const uint64_t NewEntry = computeEntryFromPredecessors(Block);
       EntryBytes[EntryPC] = NewEntry;
-      const uint64_t NewExit = transfer(Block, NewEntry);
-      if (NewExit == ExitBytes[EntryPC]) {
+      const TransferResult NewExit = transfer(Block, NewEntry);
+      if (!NewExit.HasNormalExit) {
+        ExitAvailable[EntryPC] = false;
+        ExitBytes[EntryPC] = 0;
         continue;
       }
-      ExitBytes[EntryPC] = NewExit;
+      if (ExitAvailable[EntryPC] && NewExit.Bytes == ExitBytes[EntryPC]) {
+        continue;
+      }
+      ExitAvailable[EntryPC] = true;
+      ExitBytes[EntryPC] = NewExit.Bytes;
 
-      for (uint64_t SuccPC : Block.Successors) {
+      for (uint64_t SuccPC : Dependents[EntryPC]) {
         if (Facts.Blocks.find(SuccPC) == Facts.Blocks.end()) {
           continue;
         }
@@ -1017,7 +1012,110 @@ private:
   const MemoryFacts &Facts;
   std::map<uint64_t, uint64_t> EntryBytes;
   std::map<uint64_t, uint64_t> ExitBytes;
+  std::map<uint64_t, bool> ExitAvailable;
+  std::map<uint64_t, std::vector<uint64_t>> Dependents;
   std::map<uint32_t, uint64_t> BeforeOpBytes;
+};
+
+struct MemoryProofAvailability {
+  uint64_t GuaranteedMinBytes = 0;
+  bool HasLogicalSize = false;
+  bool HasAccessRange = false;
+
+  bool canReuseWithoutExpansion() const {
+    return HasLogicalSize && HasAccessRange;
+  }
+};
+
+// Proof availability and placement legality are separate queries. Logical
+// extent survives observers such as GAS and MSIZE, but an expansion may not be
+// moved across their protocol-visible ordering points.
+class MemoryProofLifetimeAnalysis {
+public:
+  explicit MemoryProofLifetimeAnalysis(const MemoryFacts &Facts)
+      : Facts(Facts), GuaranteedBytes(Facts) {}
+
+  MemoryProofAvailability
+  queryBeforeOp(uint32_t OpId, const MemoryInterval &RequiredRange,
+                uint64_t AdditionalGuaranteedBytes = 0) const {
+    if (Facts.getOp(OpId) == nullptr) {
+      return {};
+    }
+
+    MemoryProofAvailability Result;
+    Result.GuaranteedMinBytes =
+        std::max(AdditionalGuaranteedBytes,
+                 GuaranteedBytes.getGuaranteedMinBytesBeforeOp(OpId));
+    Result.HasLogicalSize = true;
+
+    if (RequiredRange.Empty) {
+      Result.HasAccessRange = true;
+      return Result;
+    }
+
+    uint64_t RequiredEnd = 0;
+    Result.HasAccessRange = getExactMemoryEnd(RequiredRange, RequiredEnd) &&
+                            RequiredEnd <= Result.GuaranteedMinBytes;
+    return Result;
+  }
+
+  bool canMoveExpansionBetween(uint32_t ProducerOpId,
+                               uint32_t ConsumerOpId) const {
+    size_t ProducerIndex = 0;
+    size_t ConsumerIndex = 0;
+    if (!findOpIndex(ProducerOpId, ProducerIndex) ||
+        !findOpIndex(ConsumerOpId, ConsumerIndex) ||
+        ProducerIndex >= ConsumerIndex) {
+      return false;
+    }
+
+    const MemoryOp &Producer = Facts.Ops[ProducerIndex];
+    const MemoryOp &Consumer = Facts.Ops[ConsumerIndex];
+    if (Producer.BlockEntryPC != Consumer.BlockEntryPC) {
+      return false;
+    }
+
+    for (size_t I = ProducerIndex + 1; I < ConsumerIndex; ++I) {
+      const MemoryOp &Op = Facts.Ops[I];
+      const MemoryEffectSummary &Effects = Op.ObservableEffects;
+      if (Effects.requiresOrderToken() || Effects.mayTrapOrHalt() ||
+          Effects.externalizesMemory() || Effects.terminatesFrame() ||
+          Op.Effect == MemoryEffect::Escape ||
+          Op.Effect == MemoryEffect::Unknown) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+private:
+  static bool getExactMemoryEnd(const MemoryInterval &Interval, uint64_t &End) {
+    if (Interval.Space != AddressSpace::Memory || Interval.Empty ||
+        !Interval.Addr.isKnown() ||
+        Interval.Addr.Kind != AddressBaseKind::Const || !Interval.Size.Known ||
+        Interval.Addr.Offset < 0) {
+      return false;
+    }
+    const uint64_t Begin = static_cast<uint64_t>(Interval.Addr.Offset);
+    if (Interval.Size.Value > std::numeric_limits<uint64_t>::max() - Begin) {
+      return false;
+    }
+    End = Begin + Interval.Size.Value;
+    return true;
+  }
+
+  bool findOpIndex(uint32_t OpId, size_t &Index) const {
+    for (size_t I = 0; I < Facts.Ops.size(); ++I) {
+      if (Facts.Ops[I].Id == OpId) {
+        Index = I;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  const MemoryFacts &Facts;
+  MemoryGuaranteedMinBytesAnalysis GuaranteedBytes;
 };
 
 } // namespace COMPILER

--- a/src/compiler/evm_frontend/evm_memory_analysis.h
+++ b/src/compiler/evm_frontend/evm_memory_analysis.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <limits>
 #include <map>
+#include <memory>
 #include <optional>
 #include <queue>
 #include <set>
@@ -476,14 +477,7 @@ public:
 
   const MemoryFacts &getFacts() const { return Facts; }
 
-  const MemoryOp *getOp(uint32_t OpId) const {
-    for (const MemoryOp &Op : Facts.Ops) {
-      if (Op.Id == OpId) {
-        return &Op;
-      }
-    }
-    return nullptr;
-  }
+  const MemoryOp *getOp(uint32_t OpId) const { return Facts.getOp(OpId); }
 
   MemoryBarrierKind getBarrierKind(const MemoryOp &Op) const {
     return Barriers.getBarrierKind(Op);
@@ -819,12 +813,30 @@ private:
   const char *const *InstructionNames = nullptr;
 };
 
+struct MemoryGlobalAnalysisBudget {
+  uint64_t MaxBlockTransfers = std::numeric_limits<uint64_t>::max();
+  uint64_t MaxOpVisits = std::numeric_limits<uint64_t>::max();
+  uint64_t MaxEdgeVisits = std::numeric_limits<uint64_t>::max();
+};
+
+struct MemoryGlobalAnalysisStats {
+  uint64_t BlockTransfers = 0;
+  uint64_t OpVisits = 0;
+  uint64_t EdgeVisits = 0;
+  uint64_t BudgetExhaustions = 0;
+};
+
 class MemoryGuaranteedMinBytesAnalysis {
 public:
-  explicit MemoryGuaranteedMinBytesAnalysis(const MemoryFacts &Facts)
-      : Facts(Facts) {
+  explicit MemoryGuaranteedMinBytesAnalysis(
+      const MemoryFacts &Facts, MemoryGlobalAnalysisBudget Budget = {})
+      : Facts(Facts), Budget(Budget) {
     run();
   }
+
+  bool isComplete() const { return Complete; }
+
+  const MemoryGlobalAnalysisStats &getStats() const { return Stats; }
 
   uint64_t getGuaranteedMinBytesAtEntry(uint64_t EntryPC) const {
     auto It = EntryBytes.find(EntryPC);
@@ -879,16 +891,36 @@ private:
   struct TransferResult {
     uint64_t Bytes = 0;
     bool HasNormalExit = true;
+    bool WithinBudget = true;
   };
 
+  bool consumeOpVisit() {
+    if (Stats.OpVisits >= Budget.MaxOpVisits) {
+      return false;
+    }
+    ++Stats.OpVisits;
+    return true;
+  }
+
+  bool consumeEdgeVisit() {
+    if (Stats.EdgeVisits >= Budget.MaxEdgeVisits) {
+      return false;
+    }
+    ++Stats.EdgeVisits;
+    return true;
+  }
+
   TransferResult transfer(const MemoryBlockFacts &Block,
-                          uint64_t EntryBytesValue) const {
+                          uint64_t EntryBytesValue) {
     if (!Block.HasCompleteOpcodeFacts) {
       return {.Bytes = 0};
     }
     uint64_t Current = EntryBytesValue;
     for (size_t I = Block.OpsBegin; I < Block.OpsEnd && I < Facts.Ops.size();
          ++I) {
+      if (!consumeOpVisit()) {
+        return {.WithinBudget = false};
+      }
       const MemoryOp &Op = Facts.Ops[I];
       if (!Op.ObservableEffects.preservesLogicalSizeProof()) {
         Current = 0;
@@ -904,14 +936,17 @@ private:
     return {.Bytes = Current};
   }
 
-  void recordBeforeOpBytes(const MemoryBlockFacts &Block,
+  bool recordBeforeOpBytes(const MemoryBlockFacts &Block,
                            uint64_t EntryBytesValue) {
     if (!Block.HasCompleteOpcodeFacts) {
-      return;
+      return true;
     }
     uint64_t Current = EntryBytesValue;
     for (size_t I = Block.OpsBegin; I < Block.OpsEnd && I < Facts.Ops.size();
          ++I) {
+      if (!consumeOpVisit()) {
+        return false;
+      }
       const MemoryOp &Op = Facts.Ops[I];
       BeforeOpBytes[Op.Id] = Current;
       if (!Op.ObservableEffects.preservesLogicalSizeProof()) {
@@ -922,32 +957,43 @@ private:
         Current = std::max(Current, RequiredBytes);
       }
       if (Op.ObservableEffects.terminatesFrame()) {
-        return;
+        return true;
       }
     }
+    return true;
   }
 
-  uint64_t computeEntryFromPredecessors(const MemoryBlockFacts &Block) const {
+  bool computeEntryFromPredecessors(const MemoryBlockFacts &Block,
+                                    uint64_t &Result) {
     if (!Block.HasCompleteOpcodeFacts || Block.EntryPC == 0 ||
         !Block.PredecessorsComplete || !Block.PredecessorsAreStatic ||
         Block.Predecessors.empty()) {
-      return 0;
+      Result = 0;
+      return true;
     }
-    uint64_t Result = std::numeric_limits<uint64_t>::max();
+    Result = std::numeric_limits<uint64_t>::max();
     for (uint64_t PredPC : Block.Predecessors) {
+      if (!consumeEdgeVisit()) {
+        return false;
+      }
       auto PredValidIt = ExitAvailable.find(PredPC);
       if (PredValidIt == ExitAvailable.end() || !PredValidIt->second) {
-        return 0;
+        Result = 0;
+        return true;
       }
       auto PredExitIt = ExitBytes.find(PredPC);
       const uint64_t PredExit =
           PredExitIt == ExitBytes.end() ? 0 : PredExitIt->second;
       Result = std::min(Result, PredExit);
     }
-    return Result == std::numeric_limits<uint64_t>::max() ? 0 : Result;
+    if (Result == std::numeric_limits<uint64_t>::max()) {
+      Result = 0;
+    }
+    return true;
   }
 
   void run() {
+    Complete = false;
     std::queue<uint64_t> WorkList;
     std::map<uint64_t, bool> InQueue;
     for (const auto &[EntryPC, Block] : Facts.Blocks) {
@@ -957,9 +1003,17 @@ private:
       WorkList.push(EntryPC);
       InQueue[EntryPC] = true;
       for (uint64_t PredPC : Block.Predecessors) {
+        if (!consumeEdgeVisit()) {
+          failBudget();
+          return;
+        }
         Dependents[PredPC].push_back(EntryPC);
       }
       for (uint64_t SuccPC : Block.Successors) {
+        if (!consumeEdgeVisit()) {
+          failBudget();
+          return;
+        }
         Dependents[EntryPC].push_back(SuccPC);
       }
     }
@@ -979,9 +1033,22 @@ private:
         continue;
       }
       const MemoryBlockFacts &Block = BlockIt->second;
-      const uint64_t NewEntry = computeEntryFromPredecessors(Block);
+      if (Stats.BlockTransfers >= Budget.MaxBlockTransfers) {
+        failBudget();
+        return;
+      }
+      ++Stats.BlockTransfers;
+      uint64_t NewEntry = 0;
+      if (!computeEntryFromPredecessors(Block, NewEntry)) {
+        failBudget();
+        return;
+      }
       EntryBytes[EntryPC] = NewEntry;
       const TransferResult NewExit = transfer(Block, NewEntry);
+      if (!NewExit.WithinBudget) {
+        failBudget();
+        return;
+      }
       if (!NewExit.HasNormalExit) {
         ExitAvailable[EntryPC] = false;
         ExitBytes[EntryPC] = 0;
@@ -994,6 +1061,10 @@ private:
       ExitBytes[EntryPC] = NewExit.Bytes;
 
       for (uint64_t SuccPC : Dependents[EntryPC]) {
+        if (!consumeEdgeVisit()) {
+          failBudget();
+          return;
+        }
         if (Facts.Blocks.find(SuccPC) == Facts.Blocks.end()) {
           continue;
         }
@@ -1005,16 +1076,600 @@ private:
     }
 
     for (const auto &[EntryPC, Block] : Facts.Blocks) {
-      recordBeforeOpBytes(Block, getGuaranteedMinBytesAtEntry(EntryPC));
+      if (!recordBeforeOpBytes(Block, getGuaranteedMinBytesAtEntry(EntryPC))) {
+        failBudget();
+        return;
+      }
     }
+    Complete = true;
+  }
+
+  void failBudget() {
+    ++Stats.BudgetExhaustions;
+    EntryBytes.clear();
+    ExitBytes.clear();
+    ExitAvailable.clear();
+    Dependents.clear();
+    BeforeOpBytes.clear();
+    Complete = false;
   }
 
   const MemoryFacts &Facts;
+  MemoryGlobalAnalysisBudget Budget;
+  MemoryGlobalAnalysisStats Stats;
+  bool Complete = false;
   std::map<uint64_t, uint64_t> EntryBytes;
   std::map<uint64_t, uint64_t> ExitBytes;
   std::map<uint64_t, bool> ExitAvailable;
   std::map<uint64_t, std::vector<uint64_t>> Dependents;
   std::map<uint32_t, uint64_t> BeforeOpBytes;
+};
+
+struct MemoryProofQueryBudget {
+  uint32_t MaxBlockVisits = 64;
+  uint32_t MaxOpVisits = 1024;
+  uint32_t MaxEdgeVisits = 256;
+  uint64_t MaxCompilationBlockVisits = 4096;
+  uint64_t MaxCompilationOpVisits = 65536;
+  uint64_t MaxCompilationEdgeVisits = 16384;
+};
+
+struct MemoryProofPromotionPolicy {
+  bool Enabled = true;
+  uint32_t DemandComputationThreshold = 8;
+  uint32_t DemandWorkMultiplier = 2;
+  uint32_t FailureThreshold = 2;
+  uint32_t MaxBlocks = 256;
+  uint32_t MaxOps = 4096;
+  uint64_t MaxGlobalBlockTransfers = 4096;
+  uint64_t MaxGlobalOpVisits = 65536;
+  uint64_t MaxGlobalEdgeVisits = 65536;
+};
+
+enum class MemoryExtentQueryStatus : uint8_t {
+  Available,
+  BudgetExhausted,
+  CompilationBudgetExhausted,
+  Cycle,
+  IncompleteCFG,
+  InvalidProgramPoint,
+  NoNormalExit
+};
+
+struct MemoryExtentQueryResult {
+  MemoryExtentQueryStatus Status = MemoryExtentQueryStatus::InvalidProgramPoint;
+  uint64_t GuaranteedMinBytes = 0;
+
+  bool available() const {
+    return Status == MemoryExtentQueryStatus::Available;
+  }
+};
+
+struct MemoryExtentOracleStats {
+  uint64_t QueryCount = 0;
+  uint64_t QueryCacheHits = 0;
+  uint64_t DemandComputations = 0;
+  uint64_t InternalCacheHits = 0;
+  uint64_t BlockVisits = 0;
+  uint64_t OpVisits = 0;
+  uint64_t EdgeVisits = 0;
+  uint64_t BudgetExhaustions = 0;
+  uint64_t CompilationBudgetExhaustions = 0;
+  uint64_t CycleCutoffs = 0;
+  uint64_t IncompleteCFGRejects = 0;
+  uint64_t InvalidProgramPointRejects = 0;
+  uint64_t NoNormalExitRejects = 0;
+  uint64_t PromotionSchedules = 0;
+  uint64_t PromotionPending = 0;
+  uint64_t PromotionSizeCapRejects = 0;
+  uint64_t GlobalPromotionAttempts = 0;
+  uint64_t GlobalPromotions = 0;
+  uint64_t GlobalQueries = 0;
+  uint64_t GlobalBlockTransfers = 0;
+  uint64_t GlobalOpVisits = 0;
+  uint64_t GlobalEdgeVisits = 0;
+  uint64_t GlobalBudgetExhaustions = 0;
+};
+
+// Demand-driven lower-bound oracle for EVM logical memory extent. Every
+// uncached query has a deterministic local budget and also consumes a bounded
+// compilation-wide budget. Query-local facts are published only after the
+// complete query succeeds, so repeated failures cannot accumulate a proof.
+class MemoryGuaranteedExtentOracle {
+public:
+  explicit MemoryGuaranteedExtentOracle(
+      const MemoryFacts &Facts, MemoryProofQueryBudget Budget = {},
+      MemoryProofPromotionPolicy Promotion = {})
+      : Facts(Facts), Budget(Budget), Promotion(Promotion),
+        BeforeOpBytes(Facts.Ops.size(), 0),
+        BeforeOpValid(Facts.Ops.size(), false) {}
+
+  MemoryExtentQueryResult queryAtEntry(uint64_t EntryPC) const {
+    ++Stats.QueryCount;
+    if (Facts.getBlock(EntryPC) == nullptr) {
+      ++Stats.IncompleteCFGRejects;
+      return {MemoryExtentQueryStatus::IncompleteCFG, 0};
+    }
+    if (GlobalAnalysis) {
+      ++Stats.GlobalQueries;
+      return {MemoryExtentQueryStatus::Available,
+              GlobalAnalysis->getGuaranteedMinBytesAtEntry(EntryPC)};
+    }
+    auto Cached = EntryBytes.find(EntryPC);
+    if (Cached != EntryBytes.end()) {
+      ++Stats.QueryCacheHits;
+      return {MemoryExtentQueryStatus::Available, Cached->second};
+    }
+    if (tryPendingPromotion()) {
+      ++Stats.GlobalQueries;
+      return {MemoryExtentQueryStatus::Available,
+              GlobalAnalysis->getGuaranteedMinBytesAtEntry(EntryPC)};
+    }
+
+    ++Stats.DemandComputations;
+    QueryContext Context(*this);
+    uint64_t Result = 0;
+    const MemoryExtentQueryStatus Status =
+        computeEntry(EntryPC, Context, Result);
+    finishQuery(Context, Status);
+    if (Status == MemoryExtentQueryStatus::Available) {
+      commit(Context);
+    }
+    if (shouldSchedulePromotion(Status)) {
+      schedulePromotion();
+    }
+    return {Status, Status == MemoryExtentQueryStatus::Available ? Result : 0};
+  }
+
+  MemoryExtentQueryResult queryBeforeOp(uint32_t OpId) const {
+    ++Stats.QueryCount;
+    if (Facts.getOp(OpId) == nullptr) {
+      ++Stats.InvalidProgramPointRejects;
+      return {MemoryExtentQueryStatus::InvalidProgramPoint, 0};
+    }
+    if (GlobalAnalysis) {
+      ++Stats.GlobalQueries;
+      return {MemoryExtentQueryStatus::Available,
+              GlobalAnalysis->getGuaranteedMinBytesBeforeOp(OpId)};
+    }
+    if (OpId < BeforeOpValid.size() && BeforeOpValid[OpId]) {
+      ++Stats.QueryCacheHits;
+      return {MemoryExtentQueryStatus::Available, BeforeOpBytes[OpId]};
+    }
+    if (tryPendingPromotion()) {
+      ++Stats.GlobalQueries;
+      return {MemoryExtentQueryStatus::Available,
+              GlobalAnalysis->getGuaranteedMinBytesBeforeOp(OpId)};
+    }
+
+    ++Stats.DemandComputations;
+    QueryContext Context(*this);
+    uint64_t Result = 0;
+    const MemoryExtentQueryStatus Status =
+        computeBeforeOp(OpId, Context, Result);
+    finishQuery(Context, Status);
+    if (Status == MemoryExtentQueryStatus::Available) {
+      commit(Context);
+    }
+    if (shouldSchedulePromotion(Status)) {
+      schedulePromotion();
+    }
+    return {Status, Status == MemoryExtentQueryStatus::Available ? Result : 0};
+  }
+
+  const MemoryExtentOracleStats &getStats() const {
+    Stats.PromotionPending = PromotionPending ? 1 : 0;
+    return Stats;
+  }
+
+private:
+  struct QueryContext {
+    explicit QueryContext(const MemoryGuaranteedExtentOracle &Oracle)
+        : Oracle(Oracle) {}
+
+    bool visitBlock(uint64_t EntryPC) {
+      if (VisitedBlocks.count(EntryPC) != 0) {
+        return true;
+      }
+      if (Oracle.Stats.BlockVisits + VisitedBlocks.size() >=
+          Oracle.Budget.MaxCompilationBlockVisits) {
+        Failure = MemoryExtentQueryStatus::CompilationBudgetExhausted;
+        return false;
+      }
+      if (VisitedBlocks.size() >= Oracle.Budget.MaxBlockVisits) {
+        Failure = MemoryExtentQueryStatus::BudgetExhausted;
+        return false;
+      }
+      VisitedBlocks.insert(EntryPC);
+      return true;
+    }
+
+    bool visitOp() {
+      if (Oracle.Stats.OpVisits + OpVisits >=
+          Oracle.Budget.MaxCompilationOpVisits) {
+        Failure = MemoryExtentQueryStatus::CompilationBudgetExhausted;
+        return false;
+      }
+      if (OpVisits >= Oracle.Budget.MaxOpVisits) {
+        Failure = MemoryExtentQueryStatus::BudgetExhausted;
+        return false;
+      }
+      ++OpVisits;
+      return true;
+    }
+
+    bool visitEdge() {
+      if (Oracle.Stats.EdgeVisits + EdgeVisits >=
+          Oracle.Budget.MaxCompilationEdgeVisits) {
+        Failure = MemoryExtentQueryStatus::CompilationBudgetExhausted;
+        return false;
+      }
+      if (EdgeVisits >= Oracle.Budget.MaxEdgeVisits) {
+        Failure = MemoryExtentQueryStatus::BudgetExhausted;
+        return false;
+      }
+      ++EdgeVisits;
+      return true;
+    }
+
+    MemoryExtentQueryStatus budgetFailure() const { return Failure; }
+
+    const MemoryGuaranteedExtentOracle &Oracle;
+    std::set<uint64_t> VisitedBlocks;
+    std::set<uint64_t> VisitingEntries;
+    uint32_t OpVisits = 0;
+    uint32_t EdgeVisits = 0;
+    MemoryExtentQueryStatus Failure = MemoryExtentQueryStatus::BudgetExhausted;
+    std::map<uint64_t, uint64_t> LocalEntryBytes;
+    std::map<uint64_t, uint64_t> LocalExitBytes;
+    std::map<uint32_t, uint64_t> LocalBeforeOpBytes;
+  };
+
+  static bool getIntervalEnd(const MemoryInterval &Interval, uint64_t &End) {
+    if (Interval.Space != AddressSpace::Memory || Interval.Empty ||
+        !Interval.Addr.isKnown() ||
+        Interval.Addr.Kind != AddressBaseKind::Const || !Interval.Size.Known ||
+        Interval.Addr.Offset < 0) {
+      return false;
+    }
+    const uint64_t Begin = static_cast<uint64_t>(Interval.Addr.Offset);
+    if (Interval.Size.Value > std::numeric_limits<uint64_t>::max() - Begin) {
+      return false;
+    }
+    End = Begin + Interval.Size.Value;
+    return true;
+  }
+
+  static bool getGuaranteedRequiredBytes(const MemoryOp &Op, uint64_t &End) {
+    bool Found = false;
+    End = 0;
+    auto Accumulate = [&Found, &End](const MemoryInterval &Interval) {
+      uint64_t IntervalEnd = 0;
+      if (getIntervalEnd(Interval, IntervalEnd)) {
+        End = std::max(End, IntervalEnd);
+        Found = true;
+      }
+    };
+    for (const MemoryInterval &Read : Op.Reads) {
+      Accumulate(Read);
+    }
+    for (const MemoryInterval &Write : Op.Writes) {
+      Accumulate(Write);
+    }
+    return Found;
+  }
+
+  static void transferOp(const MemoryOp &Op, uint64_t &Current) {
+    if (!Op.ObservableEffects.preservesLogicalSizeProof()) {
+      Current = 0;
+    }
+    uint64_t RequiredBytes = 0;
+    if (getGuaranteedRequiredBytes(Op, RequiredBytes)) {
+      Current = std::max(Current, RequiredBytes);
+    }
+  }
+
+  bool lookupEntry(uint64_t EntryPC, const QueryContext &Context,
+                   uint64_t &Result) const {
+    auto Local = Context.LocalEntryBytes.find(EntryPC);
+    if (Local != Context.LocalEntryBytes.end()) {
+      ++Stats.InternalCacheHits;
+      Result = Local->second;
+      return true;
+    }
+    auto Cached = EntryBytes.find(EntryPC);
+    if (Cached != EntryBytes.end()) {
+      ++Stats.InternalCacheHits;
+      Result = Cached->second;
+      return true;
+    }
+    return false;
+  }
+
+  bool lookupExit(uint64_t EntryPC, const QueryContext &Context,
+                  uint64_t &Result) const {
+    auto Local = Context.LocalExitBytes.find(EntryPC);
+    if (Local != Context.LocalExitBytes.end()) {
+      ++Stats.InternalCacheHits;
+      Result = Local->second;
+      return true;
+    }
+    auto Cached = ExitBytes.find(EntryPC);
+    if (Cached != ExitBytes.end()) {
+      ++Stats.InternalCacheHits;
+      Result = Cached->second;
+      return true;
+    }
+    return false;
+  }
+
+  MemoryExtentQueryStatus computeEntry(uint64_t EntryPC, QueryContext &Context,
+                                       uint64_t &Result) const {
+    if (lookupEntry(EntryPC, Context, Result)) {
+      return MemoryExtentQueryStatus::Available;
+    }
+    if (!Context.visitBlock(EntryPC)) {
+      return Context.budgetFailure();
+    }
+    const MemoryBlockFacts *Block = Facts.getBlock(EntryPC);
+    if (Block == nullptr) {
+      return MemoryExtentQueryStatus::IncompleteCFG;
+    }
+    if (!Block->HasCompleteOpcodeFacts) {
+      return MemoryExtentQueryStatus::IncompleteCFG;
+    }
+    // A backedge into the entry block cannot establish a fact for the first
+    // execution of that block.
+    if (EntryPC == 0) {
+      Result = 0;
+      Context.LocalEntryBytes[EntryPC] = Result;
+      return MemoryExtentQueryStatus::Available;
+    }
+    if (!Block->PredecessorsComplete || !Block->PredecessorsAreStatic) {
+      return MemoryExtentQueryStatus::IncompleteCFG;
+    }
+    if (Block->Predecessors.empty()) {
+      Result = 0;
+      Context.LocalEntryBytes[EntryPC] = Result;
+      return MemoryExtentQueryStatus::Available;
+    }
+    if (Context.VisitingEntries.count(EntryPC) != 0) {
+      return MemoryExtentQueryStatus::Cycle;
+    }
+
+    Context.VisitingEntries.insert(EntryPC);
+    uint64_t Meet = std::numeric_limits<uint64_t>::max();
+    for (uint64_t PredPC : Block->Predecessors) {
+      if (!Context.visitEdge()) {
+        Context.VisitingEntries.erase(EntryPC);
+        return Context.budgetFailure();
+      }
+      uint64_t PredExit = 0;
+      const MemoryExtentQueryStatus Status =
+          computeExit(PredPC, Context, PredExit);
+      if (Status != MemoryExtentQueryStatus::Available) {
+        Context.VisitingEntries.erase(EntryPC);
+        return Status;
+      }
+      Meet = std::min(Meet, PredExit);
+      if (Meet == 0) {
+        break;
+      }
+    }
+    Context.VisitingEntries.erase(EntryPC);
+    Result = Meet == std::numeric_limits<uint64_t>::max() ? 0 : Meet;
+    Context.LocalEntryBytes[EntryPC] = Result;
+    return MemoryExtentQueryStatus::Available;
+  }
+
+  MemoryExtentQueryStatus computeExit(uint64_t EntryPC, QueryContext &Context,
+                                      uint64_t &Result) const {
+    if (lookupExit(EntryPC, Context, Result)) {
+      return MemoryExtentQueryStatus::Available;
+    }
+    if (!Context.visitBlock(EntryPC)) {
+      return Context.budgetFailure();
+    }
+    const MemoryBlockFacts *Block = Facts.getBlock(EntryPC);
+    if (Block == nullptr) {
+      return MemoryExtentQueryStatus::IncompleteCFG;
+    }
+    const MemoryExtentQueryStatus EntryStatus =
+        computeEntry(EntryPC, Context, Result);
+    if (EntryStatus != MemoryExtentQueryStatus::Available) {
+      return EntryStatus;
+    }
+    for (size_t I = Block->OpsBegin; I < Block->OpsEnd && I < Facts.Ops.size();
+         ++I) {
+      if (!Context.visitOp()) {
+        return Context.budgetFailure();
+      }
+      const MemoryOp &Op = Facts.Ops[I];
+      Context.LocalBeforeOpBytes[Op.Id] = Result;
+      transferOp(Op, Result);
+      if (Op.ObservableEffects.terminatesFrame()) {
+        return MemoryExtentQueryStatus::NoNormalExit;
+      }
+    }
+    Context.LocalExitBytes[EntryPC] = Result;
+    return MemoryExtentQueryStatus::Available;
+  }
+
+  MemoryExtentQueryStatus computeBeforeOp(uint32_t OpId, QueryContext &Context,
+                                          uint64_t &Result) const {
+    const MemoryOp *Target = Facts.getOp(OpId);
+    if (Target == nullptr) {
+      return MemoryExtentQueryStatus::InvalidProgramPoint;
+    }
+    const MemoryBlockFacts *Block = Facts.getBlock(Target->BlockEntryPC);
+    if (Block == nullptr) {
+      return MemoryExtentQueryStatus::IncompleteCFG;
+    }
+    if (!Context.visitBlock(Block->EntryPC)) {
+      return Context.budgetFailure();
+    }
+    const MemoryExtentQueryStatus EntryStatus =
+        computeEntry(Block->EntryPC, Context, Result);
+    if (EntryStatus != MemoryExtentQueryStatus::Available) {
+      return EntryStatus;
+    }
+    for (size_t I = Block->OpsBegin; I < Block->OpsEnd && I < Facts.Ops.size();
+         ++I) {
+      if (!Context.visitOp()) {
+        return Context.budgetFailure();
+      }
+      const MemoryOp &Op = Facts.Ops[I];
+      Context.LocalBeforeOpBytes[Op.Id] = Result;
+      if (Op.Id == OpId) {
+        return MemoryExtentQueryStatus::Available;
+      }
+      transferOp(Op, Result);
+      if (Op.ObservableEffects.terminatesFrame()) {
+        return MemoryExtentQueryStatus::NoNormalExit;
+      }
+    }
+    return MemoryExtentQueryStatus::InvalidProgramPoint;
+  }
+
+  void finishQuery(const QueryContext &Context,
+                   MemoryExtentQueryStatus Status) const {
+    Stats.BlockVisits += Context.VisitedBlocks.size();
+    Stats.OpVisits += Context.OpVisits;
+    Stats.EdgeVisits += Context.EdgeVisits;
+    switch (Status) {
+    case MemoryExtentQueryStatus::BudgetExhausted:
+      ++Stats.BudgetExhaustions;
+      break;
+    case MemoryExtentQueryStatus::CompilationBudgetExhausted:
+      ++Stats.CompilationBudgetExhaustions;
+      break;
+    case MemoryExtentQueryStatus::Cycle:
+      ++Stats.CycleCutoffs;
+      break;
+    case MemoryExtentQueryStatus::IncompleteCFG:
+      ++Stats.IncompleteCFGRejects;
+      break;
+    case MemoryExtentQueryStatus::InvalidProgramPoint:
+      ++Stats.InvalidProgramPointRejects;
+      break;
+    case MemoryExtentQueryStatus::NoNormalExit:
+      ++Stats.NoNormalExitRejects;
+      break;
+    case MemoryExtentQueryStatus::Available:
+      break;
+    }
+  }
+
+  void commit(const QueryContext &Context) const {
+    EntryBytes.insert(Context.LocalEntryBytes.begin(),
+                      Context.LocalEntryBytes.end());
+    ExitBytes.insert(Context.LocalExitBytes.begin(),
+                     Context.LocalExitBytes.end());
+    for (const auto &[OpId, Bytes] : Context.LocalBeforeOpBytes) {
+      if (OpId >= BeforeOpValid.size()) {
+        continue;
+      }
+      BeforeOpBytes[OpId] = Bytes;
+      BeforeOpValid[OpId] = true;
+    }
+  }
+
+  bool shouldSchedulePromotion(MemoryExtentQueryStatus Status) const {
+    if (!Promotion.Enabled || PromotionPending ||
+        PromotionPermanentlyDisabled || GlobalAnalysis) {
+      return false;
+    }
+    bool Triggered = false;
+    if (Status == MemoryExtentQueryStatus::Available) {
+      const uint64_t DemandWork =
+          Stats.BlockVisits + Stats.OpVisits + Stats.EdgeVisits;
+      const uint64_t FullWorkEstimate =
+          (Facts.Blocks.size() + Facts.Ops.size()) *
+          Promotion.DemandWorkMultiplier;
+      Triggered =
+          Stats.DemandComputations >= Promotion.DemandComputationThreshold &&
+          DemandWork >= FullWorkEstimate;
+    } else if (Status == MemoryExtentQueryStatus::BudgetExhausted ||
+               Status == MemoryExtentQueryStatus::Cycle) {
+      Triggered = Stats.BudgetExhaustions + Stats.CycleCutoffs >=
+                  Promotion.FailureThreshold;
+    }
+    if (!Triggered) {
+      return false;
+    }
+    if (Facts.Blocks.size() > Promotion.MaxBlocks ||
+        Facts.Ops.size() > Promotion.MaxOps) {
+      ++Stats.PromotionSizeCapRejects;
+      PromotionPermanentlyDisabled = true;
+      return false;
+    }
+    return true;
+  }
+
+  void schedulePromotion() const {
+    PromotionPending = true;
+    ++Stats.PromotionSchedules;
+  }
+
+  bool tryPendingPromotion() const {
+    if (!PromotionPending || PromotionPermanentlyDisabled || GlobalAnalysis) {
+      return false;
+    }
+    PromotionPending = false;
+    return promoteToGlobal();
+  }
+
+  bool promoteToGlobal() const {
+    ++Stats.GlobalPromotionAttempts;
+    const uint64_t RemainingBlocks =
+        Stats.BlockVisits >= Budget.MaxCompilationBlockVisits
+            ? 0
+            : Budget.MaxCompilationBlockVisits - Stats.BlockVisits;
+    const uint64_t RemainingOps =
+        Stats.OpVisits >= Budget.MaxCompilationOpVisits
+            ? 0
+            : Budget.MaxCompilationOpVisits - Stats.OpVisits;
+    const uint64_t RemainingEdges =
+        Stats.EdgeVisits >= Budget.MaxCompilationEdgeVisits
+            ? 0
+            : Budget.MaxCompilationEdgeVisits - Stats.EdgeVisits;
+    MemoryGlobalAnalysisBudget GlobalBudget;
+    GlobalBudget.MaxBlockTransfers =
+        std::min(Promotion.MaxGlobalBlockTransfers, RemainingBlocks);
+    GlobalBudget.MaxOpVisits =
+        std::min(Promotion.MaxGlobalOpVisits, RemainingOps);
+    GlobalBudget.MaxEdgeVisits =
+        std::min(Promotion.MaxGlobalEdgeVisits, RemainingEdges);
+    auto Candidate =
+        std::make_unique<MemoryGuaranteedMinBytesAnalysis>(Facts, GlobalBudget);
+    const MemoryGlobalAnalysisStats CandidateStats = Candidate->getStats();
+    Stats.BlockVisits += CandidateStats.BlockTransfers;
+    Stats.OpVisits += CandidateStats.OpVisits;
+    Stats.EdgeVisits += CandidateStats.EdgeVisits;
+    Stats.GlobalBlockTransfers += CandidateStats.BlockTransfers;
+    Stats.GlobalOpVisits += CandidateStats.OpVisits;
+    Stats.GlobalEdgeVisits += CandidateStats.EdgeVisits;
+    Stats.GlobalBudgetExhaustions += CandidateStats.BudgetExhaustions;
+    if (!Candidate->isComplete()) {
+      PromotionPermanentlyDisabled = true;
+      return false;
+    }
+    GlobalAnalysis = std::move(Candidate);
+    ++Stats.GlobalPromotions;
+    return true;
+  }
+
+  const MemoryFacts &Facts;
+  MemoryProofQueryBudget Budget;
+  MemoryProofPromotionPolicy Promotion;
+  mutable MemoryExtentOracleStats Stats;
+  mutable std::unique_ptr<MemoryGuaranteedMinBytesAnalysis> GlobalAnalysis;
+  mutable bool PromotionPending = false;
+  mutable bool PromotionPermanentlyDisabled = false;
+  mutable std::map<uint64_t, uint64_t> EntryBytes;
+  mutable std::map<uint64_t, uint64_t> ExitBytes;
+  mutable std::vector<uint64_t> BeforeOpBytes;
+  mutable std::vector<bool> BeforeOpValid;
 };
 
 struct MemoryProofAvailability {
@@ -1032,8 +1687,9 @@ struct MemoryProofAvailability {
 // moved across their protocol-visible ordering points.
 class MemoryProofLifetimeAnalysis {
 public:
-  explicit MemoryProofLifetimeAnalysis(const MemoryFacts &Facts)
-      : Facts(Facts), GuaranteedBytes(Facts) {}
+  explicit MemoryProofLifetimeAnalysis(const MemoryFacts &Facts,
+                                       MemoryProofQueryBudget Budget = {})
+      : Facts(Facts), GuaranteedBytes(Facts, Budget) {}
 
   MemoryProofAvailability
   queryBeforeOp(uint32_t OpId, const MemoryInterval &RequiredRange,
@@ -1043,9 +1699,7 @@ public:
     }
 
     MemoryProofAvailability Result;
-    Result.GuaranteedMinBytes =
-        std::max(AdditionalGuaranteedBytes,
-                 GuaranteedBytes.getGuaranteedMinBytesBeforeOp(OpId));
+    Result.GuaranteedMinBytes = AdditionalGuaranteedBytes;
     Result.HasLogicalSize = true;
 
     if (RequiredRange.Empty) {
@@ -1054,9 +1708,23 @@ public:
     }
 
     uint64_t RequiredEnd = 0;
-    Result.HasAccessRange = getExactMemoryEnd(RequiredRange, RequiredEnd) &&
-                            RequiredEnd <= Result.GuaranteedMinBytes;
+    if (!getExactMemoryEnd(RequiredRange, RequiredEnd)) {
+      return Result;
+    }
+    if (RequiredEnd > Result.GuaranteedMinBytes) {
+      const MemoryExtentQueryResult Guaranteed =
+          GuaranteedBytes.queryBeforeOp(OpId);
+      if (Guaranteed.available()) {
+        Result.GuaranteedMinBytes =
+            std::max(Result.GuaranteedMinBytes, Guaranteed.GuaranteedMinBytes);
+      }
+    }
+    Result.HasAccessRange = RequiredEnd <= Result.GuaranteedMinBytes;
     return Result;
+  }
+
+  const MemoryExtentOracleStats &getExtentOracleStats() const {
+    return GuaranteedBytes.getStats();
   }
 
   bool canMoveExpansionBetween(uint32_t ProducerOpId,
@@ -1115,7 +1783,7 @@ private:
   }
 
   const MemoryFacts &Facts;
-  MemoryGuaranteedMinBytesAnalysis GuaranteedBytes;
+  mutable MemoryGuaranteedExtentOracle GuaranteedBytes;
 };
 
 } // namespace COMPILER

--- a/src/compiler/evm_frontend/evm_memory_analysis.h
+++ b/src/compiler/evm_frontend/evm_memory_analysis.h
@@ -1691,6 +1691,9 @@ public:
                                        MemoryProofQueryBudget Budget = {})
       : Facts(Facts), GuaranteedBytes(Facts, Budget) {}
 
+  // AdditionalGuaranteedBytes is trusted proof input: callers must establish
+  // that it is a true lower bound on every path reaching OpId. This analysis
+  // does not validate or infer that caller-provided bound.
   MemoryProofAvailability
   queryBeforeOp(uint32_t OpId, const MemoryInterval &RequiredRange,
                 uint64_t AdditionalGuaranteedBytes = 0) const {
@@ -1729,11 +1732,10 @@ public:
 
   bool canMoveExpansionBetween(uint32_t ProducerOpId,
                                uint32_t ConsumerOpId) const {
-    size_t ProducerIndex = 0;
-    size_t ConsumerIndex = 0;
-    if (!findOpIndex(ProducerOpId, ProducerIndex) ||
-        !findOpIndex(ConsumerOpId, ConsumerIndex) ||
-        ProducerIndex >= ConsumerIndex) {
+    const size_t ProducerIndex = Facts.getOpIndex(ProducerOpId);
+    const size_t ConsumerIndex = Facts.getOpIndex(ConsumerOpId);
+    if (ProducerIndex == Facts.Ops.size() ||
+        ConsumerIndex == Facts.Ops.size() || ProducerIndex >= ConsumerIndex) {
       return false;
     }
 
@@ -1770,16 +1772,6 @@ private:
     }
     End = Begin + Interval.Size.Value;
     return true;
-  }
-
-  bool findOpIndex(uint32_t OpId, size_t &Index) const {
-    for (size_t I = 0; I < Facts.Ops.size(); ++I) {
-      if (Facts.Ops[I].Id == OpId) {
-        Index = I;
-        return true;
-      }
-    }
-    return false;
   }
 
   const MemoryFacts &Facts;

--- a/src/compiler/evm_frontend/evm_memory_facts.h
+++ b/src/compiler/evm_frontend/evm_memory_facts.h
@@ -289,13 +289,40 @@ struct MemoryBlockFacts {
   }
 };
 
+// Cheap admission facts collected during the bytecode walk. False positives
+// only enable a later lazy analysis; false negatives would suppress an
+// optimization and are therefore not allowed.
+struct MemoryOpportunitySummary {
+  uint64_t ClassifiedOps = 0;
+  uint64_t ExactMemoryOps = 0;
+  uint64_t ExactDirectMemoryOps = 0;
+  bool HasExtentReuseOpportunity = false;
+  bool HasSharedPrecheckOpportunity = false;
+  bool HasDeadStoreOpportunity = false;
+  bool HasLoadForwardingOpportunity = false;
+
+  bool hasPlannerOpportunity() const {
+    return HasExtentReuseOpportunity || hasRegionOpportunity() ||
+           HasSharedPrecheckOpportunity || HasDeadStoreOpportunity ||
+           HasLoadForwardingOpportunity;
+  }
+
+  bool hasRegionOpportunity() const { return ExactDirectMemoryOps >= 2; }
+};
+
 struct MemoryFacts {
+  static constexpr uint32_t InvalidOpId = std::numeric_limits<uint32_t>::max();
+
   std::vector<MemoryOp> Ops;
   std::map<uint64_t, MemoryBlockFacts> Blocks;
+  std::vector<uint32_t> OpIdByPC;
+  MemoryOpportunitySummary Opportunities;
 
-  void clear() {
+  void clear(size_t BytecodeSize = 0) {
     Ops.clear();
     Blocks.clear();
+    OpIdByPC.assign(BytecodeSize, InvalidOpId);
+    Opportunities = {};
   }
   bool empty() const { return Ops.empty(); }
   size_t size() const { return Ops.size(); }
@@ -311,28 +338,42 @@ struct MemoryFacts {
     return getOp(OpId) == nullptr ? Ops.size() : static_cast<size_t>(OpId);
   }
 
+  const MemoryOp *getOpByPC(uint64_t PC) const {
+    if (PC >= OpIdByPC.size()) {
+      return nullptr;
+    }
+    return getOp(OpIdByPC[static_cast<size_t>(PC)]);
+  }
+
   const MemoryBlockFacts *getBlock(uint64_t EntryPC) const {
     auto It = Blocks.find(EntryPC);
     return It == Blocks.end() ? nullptr : &It->second;
   }
 };
 
+enum class MemoryFactsBuildMode : uint8_t { Full, OpportunitySummary };
+
 // Fact builder: consumes bytecode order and builds MemoryFacts. It has no
 // dependency on MIR builder, analysis, or optimization consumers.
 class MemoryFactsBuilder {
 public:
-  explicit MemoryFactsBuilder(evmc_revision Revision = EVMC_CANCUN)
-      : Revision(Revision) {}
+  explicit MemoryFactsBuilder(
+      evmc_revision Revision = EVMC_CANCUN,
+      MemoryFactsBuildMode BuildMode = MemoryFactsBuildMode::Full)
+      : Revision(Revision), BuildMode(BuildMode) {}
 
   void setRevision(evmc_revision NewRevision) { Revision = NewRevision; }
   evmc_revision getRevision() const { return Revision; }
 
-  void reset() {
+  void reset(size_t BytecodeSize = 0) {
     endBlock();
-    Facts.clear();
+    Facts.clear(BuildMode == MemoryFactsBuildMode::Full ? BytecodeSize : 0);
     Stack.clear();
     NextValueId = 1;
     CurrentBlockEntryPC = 0;
+    CurrentBlockExactPlanningOps = 0;
+    CurrentBlockStores = 0;
+    CurrentBlockWrites = 0;
     HasCurrentBlock = false;
   }
 
@@ -352,19 +393,32 @@ public:
     endBlock();
     HasCurrentBlock = true;
     CurrentBlockEntryPC = EntryPC;
+    CurrentBlockExactPlanningOps = 0;
+    CurrentBlockStores = 0;
+    CurrentBlockWrites = 0;
 
-    MemoryBlockFacts Block;
-    Block.EntryPC = EntryPC;
-    Block.BodyStartPC = BodyStartPC;
-    Block.BodyEndPC = BodyEndPC;
-    Block.OpsBegin = Facts.Ops.size();
-    Block.OpsEnd = Facts.Ops.size();
-    Block.HasCompleteOpcodeFacts = HasCompleteOpcodeFacts;
-    Block.PredecessorsComplete = PredecessorsComplete;
-    Block.PredecessorsAreStatic = PredecessorsAreStatic;
-    Block.Successors = Successors;
-    Block.Predecessors = Predecessors;
-    Facts.Blocks[EntryPC] = std::move(Block);
+    if (BuildMode == MemoryFactsBuildMode::Full) {
+      MemoryBlockFacts Block;
+      Block.EntryPC = EntryPC;
+      Block.BodyStartPC = BodyStartPC;
+      Block.BodyEndPC = BodyEndPC;
+      Block.OpsBegin = Facts.Ops.size();
+      Block.OpsEnd = Facts.Ops.size();
+      Block.HasCompleteOpcodeFacts = HasCompleteOpcodeFacts;
+      Block.PredecessorsComplete = PredecessorsComplete;
+      Block.PredecessorsAreStatic = PredecessorsAreStatic;
+      Block.Successors = Successors;
+      Block.Predecessors = Predecessors;
+      std::sort(Block.Successors.begin(), Block.Successors.end());
+      Block.Successors.erase(
+          std::unique(Block.Successors.begin(), Block.Successors.end()),
+          Block.Successors.end());
+      std::sort(Block.Predecessors.begin(), Block.Predecessors.end());
+      Block.Predecessors.erase(
+          std::unique(Block.Predecessors.begin(), Block.Predecessors.end()),
+          Block.Predecessors.end());
+      Facts.Blocks[EntryPC] = std::move(Block);
+    }
 
     Stack.clear();
     for (const MemoryEntryValue &EntryValue : EntryValues) {
@@ -380,16 +434,18 @@ public:
     if (!HasCurrentBlock) {
       return;
     }
-    auto It = Facts.Blocks.find(CurrentBlockEntryPC);
-    if (It != Facts.Blocks.end()) {
-      It->second.OpsEnd = Facts.Ops.size();
+    if (BuildMode == MemoryFactsBuildMode::Full) {
+      auto It = Facts.Blocks.find(CurrentBlockEntryPC);
+      if (It != Facts.Blocks.end()) {
+        It->second.OpsEnd = Facts.Ops.size();
+      }
     }
     HasCurrentBlock = false;
   }
 
   void observeOpcode(evmc_opcode Opcode, uint64_t Pc, const uint8_t *Bytecode,
                      size_t BytecodeSize) {
-    if (HasCurrentBlock) {
+    if (BuildMode == MemoryFactsBuildMode::Full && HasCurrentBlock) {
       auto It = Facts.Blocks.find(CurrentBlockEntryPC);
       if (It == Facts.Blocks.end() || !It->second.HasCompleteOpcodeFacts) {
         return;
@@ -522,8 +578,13 @@ private:
   MemoryFacts Facts;
   std::vector<StackValue> Stack;
   evmc_revision Revision = EVMC_CANCUN;
+  MemoryFactsBuildMode BuildMode = MemoryFactsBuildMode::Full;
+  MemoryOp SummaryOp;
   uint32_t NextValueId = 1;
   uint64_t CurrentBlockEntryPC = 0;
+  uint32_t CurrentBlockExactPlanningOps = 0;
+  uint32_t CurrentBlockStores = 0;
+  uint32_t CurrentBlockWrites = 0;
   bool HasCurrentBlock = false;
 
   static MemoryHardBarrierKind getHardBarrierKind(const MemoryOp &Op) {
@@ -628,7 +689,100 @@ private:
     return Interval != nullptr && getDirectMemoryIntervalEnd(*Interval, End);
   }
 
+  static const MemoryInterval *getDirectInterval(const MemoryOp &Op) {
+    switch (Op.Kind) {
+    case MemoryOpKind::MLoad:
+      return Op.Reads.size() == 1 ? &Op.Reads[0] : nullptr;
+    case MemoryOpKind::MStore:
+    case MemoryOpKind::MStore8:
+      return Op.Writes.size() == 1 ? &Op.Writes[0] : nullptr;
+    default:
+      return nullptr;
+    }
+  }
+
+  static bool isExactConstMemoryInterval(const MemoryInterval &Interval) {
+    if (Interval.Empty || Interval.Space != AddressSpace::Memory ||
+        Interval.Addr.Kind != AddressBaseKind::Const ||
+        !Interval.Addr.isKnown() || !Interval.Size.Known ||
+        Interval.Addr.Offset < 0) {
+      return false;
+    }
+    const uint64_t Begin = static_cast<uint64_t>(Interval.Addr.Offset);
+    return Interval.Size.Value <= std::numeric_limits<uint64_t>::max() - Begin;
+  }
+
+  static bool hasExactMemoryInterval(const MemoryOp &Op) {
+    for (const MemoryInterval &Read : Op.Reads) {
+      if (isExactConstMemoryInterval(Read)) {
+        return true;
+      }
+    }
+    for (const MemoryInterval &Write : Op.Writes) {
+      if (isExactConstMemoryInterval(Write)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static bool isExactConstDirectMemoryOp(const MemoryOp &Op) {
+    const MemoryInterval *Interval = getDirectInterval(Op);
+    return Interval != nullptr && isExactConstMemoryInterval(*Interval);
+  }
+
+  static bool isExactPlanningOp(const MemoryOp &Op) {
+    if (isExactConstDirectMemoryOp(Op)) {
+      return true;
+    }
+    if (Op.Kind != MemoryOpKind::MCopy ||
+        (Op.Reads.empty() && Op.Writes.empty())) {
+      return false;
+    }
+    for (const MemoryInterval &Read : Op.Reads) {
+      if (!isExactConstMemoryInterval(Read)) {
+        return false;
+      }
+    }
+    for (const MemoryInterval &Write : Op.Writes) {
+      if (!isExactConstMemoryInterval(Write)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void noteOpportunity(const MemoryOp &Op) {
+    MemoryOpportunitySummary &Summary = Facts.Opportunities;
+    ++Summary.ClassifiedOps;
+
+    if (hasExactMemoryInterval(Op) && ++Summary.ExactMemoryOps >= 2) {
+      Summary.HasExtentReuseOpportunity = true;
+    }
+    if (isExactConstDirectMemoryOp(Op)) {
+      ++Summary.ExactDirectMemoryOps;
+    }
+    if (isExactPlanningOp(Op) && ++CurrentBlockExactPlanningOps >= 2) {
+      Summary.HasSharedPrecheckOpportunity = true;
+    }
+
+    if (Op.Kind == MemoryOpKind::MStore || Op.Kind == MemoryOpKind::MStore8) {
+      if (++CurrentBlockWrites >= 2) {
+        Summary.HasDeadStoreOpportunity = true;
+      }
+      if (Op.Kind == MemoryOpKind::MStore) {
+        ++CurrentBlockStores;
+      }
+    } else if (Op.Kind == MemoryOpKind::MLoad && CurrentBlockStores != 0) {
+      Summary.HasLoadForwardingOpportunity = true;
+    }
+  }
+
   void noteBlockFact(const MemoryOp &Op) {
+    noteOpportunity(Op);
+    if (BuildMode == MemoryFactsBuildMode::OpportunitySummary) {
+      return;
+    }
     if (!HasCurrentBlock) {
       return;
     }
@@ -768,14 +922,29 @@ private:
   MemoryOp &addOp(uint64_t Pc, evmc_opcode Opcode, MemoryOpKind Kind,
                   MemoryEffect Effect) {
     MemoryOp Op;
-    Op.Id = static_cast<uint32_t>(Facts.Ops.size());
+    Op.Id = BuildMode == MemoryFactsBuildMode::Full
+                ? static_cast<uint32_t>(Facts.Ops.size())
+                : static_cast<uint32_t>(Facts.Opportunities.ClassifiedOps);
     Op.Pc = Pc;
     Op.BlockEntryPC = CurrentBlockEntryPC;
     Op.Opcode = Opcode;
     Op.Kind = Kind;
     Op.Effect = Effect;
     Op.ObservableEffects = summarizeEffects(Opcode, Kind);
+    if (BuildMode == MemoryFactsBuildMode::OpportunitySummary) {
+      SummaryOp = std::move(Op);
+      return SummaryOp;
+    }
     Facts.Ops.push_back(std::move(Op));
+    if (Pc <= static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+      const size_t Index = static_cast<size_t>(Pc);
+      if (Facts.OpIdByPC.size() <= Index) {
+        Facts.OpIdByPC.resize(Index + 1, MemoryFacts::InvalidOpId);
+      }
+      if (Facts.OpIdByPC[Index] == MemoryFacts::InvalidOpId) {
+        Facts.OpIdByPC[Index] = Facts.Ops.back().Id;
+      }
+    }
     return Facts.Ops.back();
   }
 

--- a/src/compiler/evm_frontend/evm_memory_facts.h
+++ b/src/compiler/evm_frontend/evm_memory_facts.h
@@ -140,6 +140,81 @@ enum class MemoryEffect : uint8_t {
   Unknown
 };
 
+enum class MemoryEffectFlag : uint16_t {
+  ReadsMemory = 1U << 0,
+  WritesMemory = 1U << 1,
+  ObservesMemorySize = 1U << 2,
+  ObservesGas = 1U << 3,
+  MayGrowMemory = 1U << 4,
+  MayRebaseMemory = 1U << 5,
+  MayTrapOrHalt = 1U << 6,
+  ExternalizesMemory = 1U << 7,
+  RequiresOrderToken = 1U << 8,
+  TerminatesFrame = 1U << 9,
+  ResetsLogicalMemory = 1U << 10,
+  ChargesDynamicGas = 1U << 11,
+  MayExhaustGas = 1U << 12
+};
+
+// Orthogonal EVM-observable effects. Placement barriers, logical memory-size
+// proofs, and cached host pointers deliberately query different dimensions.
+struct MemoryEffectSummary {
+  uint8_t StackPop = 0;
+  uint8_t StackPush = 0;
+  uint16_t Flags = 0;
+
+  void add(MemoryEffectFlag Flag) { Flags |= static_cast<uint16_t>(Flag); }
+
+  bool has(MemoryEffectFlag Flag) const {
+    return (Flags & static_cast<uint16_t>(Flag)) != 0;
+  }
+
+  bool readsOrWritesMemory() const {
+    return has(MemoryEffectFlag::ReadsMemory) ||
+           has(MemoryEffectFlag::WritesMemory);
+  }
+
+  bool observesMemorySize() const {
+    return has(MemoryEffectFlag::ObservesMemorySize);
+  }
+
+  bool observesGas() const { return has(MemoryEffectFlag::ObservesGas); }
+
+  bool chargesDynamicGas() const {
+    return has(MemoryEffectFlag::ChargesDynamicGas);
+  }
+
+  bool mayExhaustGas() const { return has(MemoryEffectFlag::MayExhaustGas); }
+
+  bool mayGrowMemory() const { return has(MemoryEffectFlag::MayGrowMemory); }
+
+  bool mayRebaseMemory() const {
+    return has(MemoryEffectFlag::MayRebaseMemory);
+  }
+
+  bool mayTrapOrHalt() const { return has(MemoryEffectFlag::MayTrapOrHalt); }
+
+  bool externalizesMemory() const {
+    return has(MemoryEffectFlag::ExternalizesMemory);
+  }
+
+  bool requiresOrderToken() const {
+    return has(MemoryEffectFlag::RequiresOrderToken);
+  }
+
+  bool terminatesFrame() const {
+    return has(MemoryEffectFlag::TerminatesFrame);
+  }
+
+  bool preservesLogicalSizeProof() const {
+    return !has(MemoryEffectFlag::ResetsLogicalMemory);
+  }
+
+  bool preservesCachedMemoryBase() const {
+    return !has(MemoryEffectFlag::MayRebaseMemory);
+  }
+};
+
 enum class MemoryOpKind : uint8_t {
   MLoad,
   MStore,
@@ -188,6 +263,7 @@ struct MemoryOp {
   std::vector<MemoryInterval> Reads;
   std::vector<MemoryInterval> Writes;
   MemoryEffect Effect = MemoryEffect::None;
+  MemoryEffectSummary ObservableEffects;
   bool IsTerminator = false;
 };
 
@@ -203,6 +279,8 @@ struct MemoryBlockFacts {
   evmc_opcode FirstHardBarrierOpcode = OP_STOP;
   uint64_t FirstHardBarrierPC = 0;
   uint64_t MaxConstRequiredSize = 0;
+  bool PredecessorsComplete = true;
+  bool PredecessorsAreStatic = true;
   std::vector<uint64_t> Successors;
   std::vector<uint64_t> Predecessors;
 
@@ -222,6 +300,17 @@ struct MemoryFacts {
   bool empty() const { return Ops.empty(); }
   size_t size() const { return Ops.size(); }
 
+  const MemoryOp *getOp(uint32_t OpId) const {
+    if (OpId >= Ops.size() || Ops[OpId].Id != OpId) {
+      return nullptr;
+    }
+    return &Ops[OpId];
+  }
+
+  size_t getOpIndex(uint32_t OpId) const {
+    return getOp(OpId) == nullptr ? Ops.size() : static_cast<size_t>(OpId);
+  }
+
   const MemoryBlockFacts *getBlock(uint64_t EntryPC) const {
     auto It = Blocks.find(EntryPC);
     return It == Blocks.end() ? nullptr : &It->second;
@@ -232,7 +321,11 @@ struct MemoryFacts {
 // dependency on MIR builder, analysis, or optimization consumers.
 class MemoryFactsBuilder {
 public:
-  MemoryFactsBuilder() = default;
+  explicit MemoryFactsBuilder(evmc_revision Revision = EVMC_CANCUN)
+      : Revision(Revision) {}
+
+  void setRevision(evmc_revision NewRevision) { Revision = NewRevision; }
+  evmc_revision getRevision() const { return Revision; }
 
   void reset() {
     endBlock();
@@ -253,7 +346,9 @@ public:
                   const std::vector<MemoryEntryValue> &EntryValues,
                   const std::vector<uint64_t> &Successors = {},
                   const std::vector<uint64_t> &Predecessors = {},
-                  bool HasCompleteOpcodeFacts = true) {
+                  bool HasCompleteOpcodeFacts = true,
+                  bool PredecessorsComplete = true,
+                  bool PredecessorsAreStatic = true) {
     endBlock();
     HasCurrentBlock = true;
     CurrentBlockEntryPC = EntryPC;
@@ -265,6 +360,8 @@ public:
     Block.OpsBegin = Facts.Ops.size();
     Block.OpsEnd = Facts.Ops.size();
     Block.HasCompleteOpcodeFacts = HasCompleteOpcodeFacts;
+    Block.PredecessorsComplete = PredecessorsComplete;
+    Block.PredecessorsAreStatic = PredecessorsAreStatic;
     Block.Successors = Successors;
     Block.Predecessors = Predecessors;
     Facts.Blocks[EntryPC] = std::move(Block);
@@ -298,6 +395,18 @@ public:
         return;
       }
     }
+    const auto *InstructionNames = evmc_get_instruction_names_table(Revision);
+    if (InstructionNames == nullptr ||
+        InstructionNames[static_cast<uint8_t>(Opcode)] == nullptr) {
+      MemoryOp &Op =
+          addOp(Pc, Opcode, MemoryOpKind::Other, MemoryEffect::Unknown);
+      Op.ObservableEffects.add(MemoryEffectFlag::RequiresOrderToken);
+      Op.ObservableEffects.add(MemoryEffectFlag::MayTrapOrHalt);
+      Op.ObservableEffects.add(MemoryEffectFlag::TerminatesFrame);
+      noteBlockFact(Op);
+      return;
+    }
+
     if (Opcode >= OP_PUSH0 && Opcode <= OP_PUSH32) {
       observePush(Opcode, Pc, Bytecode, BytecodeSize);
       return;
@@ -412,22 +521,10 @@ private:
 
   MemoryFacts Facts;
   std::vector<StackValue> Stack;
+  evmc_revision Revision = EVMC_CANCUN;
   uint32_t NextValueId = 1;
   uint64_t CurrentBlockEntryPC = 0;
   bool HasCurrentBlock = false;
-
-  static bool isHardBarrierEffect(MemoryEffect Effect, MemoryOpKind Kind) {
-    if (Kind == MemoryOpKind::Log || Kind == MemoryOpKind::Call ||
-        Kind == MemoryOpKind::Create || Kind == MemoryOpKind::Return ||
-        Kind == MemoryOpKind::Revert || Kind == MemoryOpKind::MSize ||
-        Kind == MemoryOpKind::Gas) {
-      return true;
-    }
-    return Effect == MemoryEffect::Escape ||
-           Effect == MemoryEffect::MemorySizeObserver ||
-           Effect == MemoryEffect::GasSensitive ||
-           Effect == MemoryEffect::Unknown;
-  }
 
   static MemoryHardBarrierKind getHardBarrierKind(const MemoryOp &Op) {
     switch (Op.Kind) {
@@ -479,10 +576,18 @@ private:
     return MemoryHardBarrierKind::None;
   }
 
-  static bool isUnknownEffectBarrierOpcode(evmc_opcode Opcode) {
+  static bool requiresEffectOnlyRecord(evmc_opcode Opcode) {
     switch (Opcode) {
+    case OP_EXP:
+    case OP_BALANCE:
+    case OP_EXTCODESIZE:
+    case OP_EXTCODEHASH:
+    case OP_SLOAD:
     case OP_SSTORE:
     case OP_TSTORE:
+      // Dynamic gas or host-state access must remain ordered with respect to
+      // memory expansion even though it does not access EVM linear memory.
+      return true;
     case OP_SELFDESTRUCT:
     case OP_INVALID:
       return true;
@@ -533,7 +638,7 @@ private:
     }
     MemoryBlockFacts &Block = It->second;
     Block.OpsEnd = Facts.Ops.size();
-    if (isHardBarrierEffect(Op.Effect, Op.Kind)) {
+    if (Op.ObservableEffects.requiresOrderToken()) {
       Block.HasBarrier = true;
       if (Block.FirstHardBarrierKind == MemoryHardBarrierKind::None) {
         Block.FirstHardBarrierKind = getHardBarrierKind(Op);
@@ -669,8 +774,128 @@ private:
     Op.Opcode = Opcode;
     Op.Kind = Kind;
     Op.Effect = Effect;
+    Op.ObservableEffects = summarizeEffects(Opcode, Kind);
     Facts.Ops.push_back(std::move(Op));
     return Facts.Ops.back();
+  }
+
+  MemoryEffectSummary summarizeEffects(evmc_opcode Opcode,
+                                       MemoryOpKind Kind) const {
+    MemoryEffectSummary Summary;
+    const auto &Metrics = evmc_get_instruction_metrics_table(Revision);
+    const auto &Metric = Metrics[static_cast<uint8_t>(Opcode)];
+    const int PopCount =
+        std::max(0, static_cast<int>(Metric.stack_height_required));
+    const int PushCount = std::max(0, PopCount + Metric.stack_height_change);
+    Summary.StackPop = static_cast<uint8_t>(PopCount);
+    Summary.StackPush = static_cast<uint8_t>(PushCount);
+
+    auto AddMemoryAccessEffects = [&Summary]() {
+      Summary.add(MemoryEffectFlag::MayGrowMemory);
+      Summary.add(MemoryEffectFlag::MayRebaseMemory);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      Summary.add(MemoryEffectFlag::ChargesDynamicGas);
+      Summary.add(MemoryEffectFlag::MayExhaustGas);
+    };
+
+    switch (Kind) {
+    case MemoryOpKind::MLoad:
+    case MemoryOpKind::Keccak:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::MStore:
+    case MemoryOpKind::MStore8:
+    case MemoryOpKind::CallDataCopy:
+    case MemoryOpKind::CodeCopy:
+    case MemoryOpKind::ReturnDataCopy:
+    case MemoryOpKind::ExtCodeCopy:
+      Summary.add(MemoryEffectFlag::WritesMemory);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::MCopy:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::WritesMemory);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::Log:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::ExternalizesMemory);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::Return:
+    case MemoryOpKind::Revert:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::ExternalizesMemory);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::TerminatesFrame);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::Call:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::WritesMemory);
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::ExternalizesMemory);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::Create:
+      Summary.add(MemoryEffectFlag::ReadsMemory);
+      Summary.add(MemoryEffectFlag::ExternalizesMemory);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      AddMemoryAccessEffects();
+      break;
+    case MemoryOpKind::MSize:
+      Summary.add(MemoryEffectFlag::ObservesMemorySize);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      break;
+    case MemoryOpKind::Gas:
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      break;
+    case MemoryOpKind::CallDataLoad:
+    case MemoryOpKind::Other:
+      break;
+    }
+
+    switch (Opcode) {
+    case OP_EXP:
+    case OP_BALANCE:
+    case OP_EXTCODESIZE:
+    case OP_EXTCODEHASH:
+    case OP_SLOAD:
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::ChargesDynamicGas);
+      Summary.add(MemoryEffectFlag::MayExhaustGas);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      break;
+    case OP_SSTORE:
+    case OP_TSTORE:
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::ChargesDynamicGas);
+      Summary.add(MemoryEffectFlag::MayExhaustGas);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      break;
+    case OP_SELFDESTRUCT:
+      Summary.add(MemoryEffectFlag::ObservesGas);
+      Summary.add(MemoryEffectFlag::ChargesDynamicGas);
+      Summary.add(MemoryEffectFlag::MayExhaustGas);
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      Summary.add(MemoryEffectFlag::TerminatesFrame);
+      break;
+    case OP_INVALID:
+      Summary.add(MemoryEffectFlag::RequiresOrderToken);
+      Summary.add(MemoryEffectFlag::MayTrapOrHalt);
+      Summary.add(MemoryEffectFlag::TerminatesFrame);
+      break;
+    default:
+      break;
+    }
+    return Summary;
   }
 
   void observePush(evmc_opcode Opcode, uint64_t Pc, const uint8_t *Bytecode,
@@ -865,7 +1090,7 @@ private:
   }
 
   void observeGenericOpcode(evmc_opcode Opcode, uint64_t Pc) {
-    const auto &Metrics = evmc_get_instruction_metrics_table(EVMC_CANCUN);
+    const auto &Metrics = evmc_get_instruction_metrics_table(Revision);
     const auto &Metric = Metrics[static_cast<uint8_t>(Opcode)];
     const int PopCount = Metric.stack_height_required;
     const int PushCount = PopCount + Metric.stack_height_change;
@@ -875,7 +1100,7 @@ private:
     for (int I = 0; I < PushCount; ++I) {
       pushUnknown();
     }
-    if (isUnknownEffectBarrierOpcode(Opcode)) {
+    if (requiresEffectOnlyRecord(Opcode)) {
       noteBlockFact(
           addOp(Pc, Opcode, MemoryOpKind::Other, MemoryEffect::Unknown));
     }

--- a/src/compiler/evm_frontend/evm_memory_grouping.h
+++ b/src/compiler/evm_frontend/evm_memory_grouping.h
@@ -9,11 +9,14 @@
 #include <algorithm>
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <vector>
 
 namespace COMPILER {
+
+struct MemoryExpansionPlannerTestPeer;
 
 // Consumer result: a consecutive run of MemoryOps that can share one memory
 // expansion precheck. It carries no store optimization decision.
@@ -716,29 +719,32 @@ private:
 class MemoryExpansionPlanner final : public MemoryOptimizationPlanProvider {
 public:
   explicit MemoryExpansionPlanner(const MemoryAnalysisView &View)
-      : View(View), Prechecks(View), Grouping(View, Prechecks),
-        LinearRegions(View), GuaranteedMinBytes(View.getFacts()),
-        DeadStores(View.getFacts()), LoadForwarding(View.getFacts()) {}
+      : View(View), Prechecks(View), Grouping(View, Prechecks) {}
 
   std::optional<MemoryExpansionPlan>
   buildMemoryExpansionPlan(uint64_t EntryPC,
                            uint64_t BodyEndPC) const override {
     LastDiagnostics.clear();
-    LastDiagnostics.noteLinearRegionHeadSelection(
-        LinearRegions.getHeadSelectionInfo(EntryPC));
-
-    if (std::optional<MemoryExpansionPlan> LinearRegionPlan =
-            LinearRegions.buildMemoryExpansionPlan(EntryPC, BodyEndPC)) {
-      ++LastDiagnostics.LinearRegionCandidates;
-      ++LastDiagnostics.LinearRegionAccepted;
-      LastDiagnostics.noteLinearRegionPrefix(
-          LinearRegions.getPrefixInfo(EntryPC), true);
-      return LinearRegionPlan;
+    if (const MemoryLinearRegionConsumer *Regions = getLinearRegions()) {
+      LastDiagnostics.noteLinearRegionHeadSelection(
+          Regions->getHeadSelectionInfo(EntryPC));
+      if (std::optional<MemoryExpansionPlan> LinearRegionPlan =
+              Regions->buildMemoryExpansionPlan(EntryPC, BodyEndPC)) {
+        ++LastDiagnostics.LinearRegionCandidates;
+        ++LastDiagnostics.LinearRegionAccepted;
+        LastDiagnostics.noteLinearRegionPrefix(Regions->getPrefixInfo(EntryPC),
+                                               true);
+        return LinearRegionPlan;
+      }
+      LastDiagnostics.noteLinearRegionPrefix(Regions->getPrefixInfo(EntryPC),
+                                             false);
+      LastDiagnostics.noteLinearRegionReject(Regions->getRejectReason(EntryPC));
     }
-    LastDiagnostics.noteLinearRegionPrefix(LinearRegions.getPrefixInfo(EntryPC),
-                                           false);
-    LastDiagnostics.noteLinearRegionReject(
-        LinearRegions.getRejectReason(EntryPC));
+
+    if (!View.getFacts().Opportunities.HasSharedPrecheckOpportunity) {
+      LastDiagnostics.noteReject(MemoryExpansionPlanRejectReason::NoCandidate);
+      return std::nullopt;
+    }
 
     if (std::optional<SharedPrecheck> Shared =
             Grouping.getSharedPrecheck(EntryPC, BodyEndPC)) {
@@ -781,56 +787,114 @@ public:
   }
 
   uint64_t getGuaranteedMinBytesAtEntry(uint64_t EntryPC) const {
-    return std::max(GuaranteedMinBytes.getGuaranteedMinBytesAtEntry(EntryPC),
-                    LinearRegions.getGuaranteedMinBytesAtEntry(EntryPC));
+    uint64_t GuaranteedBytes = 0;
+    if (MemoryGuaranteedExtentOracle *Oracle = getGuaranteedExtent()) {
+      const MemoryExtentQueryResult Result = Oracle->queryAtEntry(EntryPC);
+      if (Result.available()) {
+        GuaranteedBytes = Result.GuaranteedMinBytes;
+      }
+    }
+    if (const MemoryLinearRegionConsumer *Regions = getLinearRegions()) {
+      GuaranteedBytes = std::max(
+          GuaranteedBytes, Regions->getGuaranteedMinBytesAtEntry(EntryPC));
+    }
+    return GuaranteedBytes;
   }
 
   uint64_t getGuaranteedMinBytesBeforeOp(uint64_t PC) const {
-    for (const MemoryOp &Op : View.getFacts().Ops) {
-      if (Op.Pc != PC) {
-        continue;
-      }
-      return std::max(
-          GuaranteedMinBytes.getGuaranteedMinBytesBeforeOp(Op.Id),
-          LinearRegions.getGuaranteedMinBytesAtEntry(Op.BlockEntryPC));
+    const MemoryOp *Op = View.getFacts().getOpByPC(PC);
+    if (Op == nullptr) {
+      return 0;
     }
-    return 0;
+    uint64_t GuaranteedBytes = 0;
+    if (MemoryGuaranteedExtentOracle *Oracle = getGuaranteedExtent()) {
+      const MemoryExtentQueryResult Result = Oracle->queryBeforeOp(Op->Id);
+      if (Result.available()) {
+        GuaranteedBytes = Result.GuaranteedMinBytes;
+      }
+    }
+    if (const MemoryLinearRegionConsumer *Regions = getLinearRegions()) {
+      GuaranteedBytes =
+          std::max(GuaranteedBytes,
+                   Regions->getGuaranteedMinBytesAtEntry(Op->BlockEntryPC));
+    }
+    return GuaranteedBytes;
   }
 
   bool isDeadStore(uint64_t PC) const {
-    for (const MemoryOp &Op : View.getFacts().Ops) {
-      if (Op.Pc == PC) {
-        return DeadStores.isDeadStore(Op.Id);
-      }
-    }
-    return false;
+    const MemoryOp *Op = View.getFacts().getOpByPC(PC);
+    MemoryDeadStoreAnalysis *Analysis = getDeadStores();
+    return Op != nullptr && Analysis != nullptr &&
+           Analysis->isDeadStore(Op->Id);
   }
 
   std::optional<uint64_t> getForwardingStorePC(uint64_t LoadPC) const {
-    for (const MemoryOp &Op : View.getFacts().Ops) {
-      if (Op.Pc != LoadPC) {
-        continue;
-      }
-      std::optional<uint32_t> StoreId =
-          LoadForwarding.getReachingStoreId(Op.Id);
-      if (!StoreId) {
-        return std::nullopt;
-      }
-      const MemoryOp *Store = View.getOp(*StoreId);
-      return Store == nullptr ? std::nullopt
-                              : std::optional<uint64_t>(Store->Pc);
+    const MemoryOp *Op = View.getFacts().getOpByPC(LoadPC);
+    MemoryLoadForwardingAnalysis *Analysis = getLoadForwarding();
+    if (Op == nullptr || Analysis == nullptr) {
+      return std::nullopt;
     }
-    return std::nullopt;
+    const std::optional<uint32_t> StoreId =
+        Analysis->getReachingStoreId(Op->Id);
+    if (!StoreId) {
+      return std::nullopt;
+    }
+    const MemoryOp *Store = View.getOp(*StoreId);
+    return Store == nullptr ? std::nullopt : std::optional<uint64_t>(Store->Pc);
   }
 
 private:
+  friend struct MemoryExpansionPlannerTestPeer;
+
+  const MemoryLinearRegionConsumer *getLinearRegions() const {
+    if (!View.getFacts().Opportunities.hasRegionOpportunity()) {
+      return nullptr;
+    }
+    if (!LinearRegions) {
+      LinearRegions = std::make_unique<MemoryLinearRegionConsumer>(View);
+    }
+    return LinearRegions.get();
+  }
+
+  MemoryGuaranteedExtentOracle *getGuaranteedExtent() const {
+    if (!View.getFacts().Opportunities.HasExtentReuseOpportunity) {
+      return nullptr;
+    }
+    if (!GuaranteedExtent) {
+      GuaranteedExtent =
+          std::make_unique<MemoryGuaranteedExtentOracle>(View.getFacts());
+    }
+    return GuaranteedExtent.get();
+  }
+
+  MemoryDeadStoreAnalysis *getDeadStores() const {
+    if (!View.getFacts().Opportunities.HasDeadStoreOpportunity) {
+      return nullptr;
+    }
+    if (!DeadStores) {
+      DeadStores = std::make_unique<MemoryDeadStoreAnalysis>(View.getFacts());
+    }
+    return DeadStores.get();
+  }
+
+  MemoryLoadForwardingAnalysis *getLoadForwarding() const {
+    if (!View.getFacts().Opportunities.HasLoadForwardingOpportunity) {
+      return nullptr;
+    }
+    if (!LoadForwarding) {
+      LoadForwarding =
+          std::make_unique<MemoryLoadForwardingAnalysis>(View.getFacts());
+    }
+    return LoadForwarding.get();
+  }
+
   const MemoryAnalysisView &View;
   MemoryPrecheckConsumer Prechecks;
   MemoryGroupingConsumer Grouping;
-  MemoryLinearRegionConsumer LinearRegions;
-  MemoryGuaranteedMinBytesAnalysis GuaranteedMinBytes;
-  MemoryDeadStoreAnalysis DeadStores;
-  MemoryLoadForwardingAnalysis LoadForwarding;
+  mutable std::unique_ptr<MemoryLinearRegionConsumer> LinearRegions;
+  mutable std::unique_ptr<MemoryGuaranteedExtentOracle> GuaranteedExtent;
+  mutable std::unique_ptr<MemoryDeadStoreAnalysis> DeadStores;
+  mutable std::unique_ptr<MemoryLoadForwardingAnalysis> LoadForwarding;
   mutable MemoryExpansionPlanDiagnostics LastDiagnostics;
 };
 

--- a/src/compiler/evm_frontend/evm_memory_precheck.h
+++ b/src/compiler/evm_frontend/evm_memory_precheck.h
@@ -511,12 +511,19 @@ public:
       Current.EntryPC = EntryPC;
     };
 
-    for (const MemoryOp &Op : View.getFacts().Ops) {
-      if (Op.Pc < EntryPC) {
-        continue;
-      }
+    const MemoryFacts &Facts = View.getFacts();
+    const MemoryBlockFacts *Block = Facts.getBlock(EntryPC);
+    if (Block == nullptr) {
+      return std::nullopt;
+    }
+    const size_t OpsEnd = std::min(Block->OpsEnd, Facts.Ops.size());
+    for (size_t I = Block->OpsBegin; I < OpsEnd; ++I) {
+      const MemoryOp &Op = Facts.Ops[I];
       if (Op.Pc >= BodyEndPC) {
         break;
+      }
+      if (Op.Pc < EntryPC) {
+        continue;
       }
 
       const MemoryInterval *Interval = getDirectMemoryInterval(Op);

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -8291,8 +8291,6 @@ void EVMMirBuilder::beginMemoryCompileBlock(uint64_t EntryPC,
   CurrentBlockMStoreValues.clear();
   CurBlockMemStats.Active = true;
   if (MemoryExpansionPlans) {
-    CurrentBlockGuaranteedMinBytes =
-        MemoryExpansionPlans->getGuaranteedMinBytesAtEntry(EntryPC);
     std::optional<MemoryExpansionPlan> Plan =
         MemoryExpansionPlans->buildMemoryExpansionPlan(EntryPC, BodyEndPC);
     noteMemoryExpansionPlanDiagnostics(
@@ -9065,13 +9063,7 @@ bool EVMMirBuilder::tryConsumeConstBlockMemoryPrecheck() {
     }
   }
   if (!CurBlockConstPrecheckPlan.CoveredOpIds.empty()) {
-    const MemoryOp *CurrentOp = nullptr;
-    for (const MemoryOp &Op : MemoryFactsData.Ops) {
-      if (Op.Pc == CurrentMemoryOpPC) {
-        CurrentOp = &Op;
-        break;
-      }
-    }
+    const MemoryOp *CurrentOp = MemoryFactsData.getOpByPC(CurrentMemoryOpPC);
     if (CurrentOp == nullptr ||
         std::find(CurBlockConstPrecheckPlan.CoveredOpIds.begin(),
                   CurBlockConstPrecheckPlan.CoveredOpIds.end(),

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -4739,22 +4739,42 @@ void EVMMirBuilder::handleCodeCopy(Operand DestOffsetComponents,
                                    Operand SizeComponents) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   RuntimeProofToken Proofs;
-  if (preExpandCopyMemory(DestOffsetComponents, SizeComponents)) {
+  const bool EmptyRange = SizeComponents.isZeroConstant();
+  const bool UsePreparedMemory =
+      canUseGuaranteedMemoryRange(DestOffsetComponents, SizeComponents);
+  if (UsePreparedMemory) {
 #ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
-    ++MemStats.CopyGuaranteedElisionCount;
+    if (!EmptyRange) {
+      ++MemStats.CopyGuaranteedElisionCount;
+    }
 #endif
+    Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+    Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+    MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
+    chargeWordCopyGasIR(Size);
+    Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
+    requireRuntimeHelperProofs(RuntimeMemoryHelperId::CodeCopyNoExpand, Proofs);
   }
-  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
-  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
-  MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
-  chargeWordCopyGasIR(Size);
-  Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
+
   uint64_t Non64Value = std::numeric_limits<uint64_t>::max();
   normalizeOperandU64(OffsetComponents, &Non64Value);
-  requireRuntimeHelperProofs(RuntimeMemoryHelperId::CodeCopyNoExpand, Proofs);
+#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
+  if (!UsePreparedMemory) {
+    syncGasToMemory();
+  }
+#endif
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t, uint64_t>(
-      RuntimeFunctions.SetCodeCopyNoExpand, DestOffsetComponents,
-      OffsetComponents, SizeComponents);
+      UsePreparedMemory ? RuntimeFunctions.SetCodeCopyNoExpand
+                        : RuntimeFunctions.SetCodeCopy,
+      DestOffsetComponents, OffsetComponents, SizeComponents);
+#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
+  if (!UsePreparedMemory) {
+    reloadGasFromMemory();
+  }
+#endif
+  if (!UsePreparedMemory) {
+    reloadMemorySizeFromInstance();
+  }
 }
 
 typename EVMMirBuilder::Operand
@@ -5718,23 +5738,27 @@ void EVMMirBuilder::handleReturn(Operand MemOffsetComponents,
                                  Operand LengthComponents) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   RuntimeProofToken Proofs;
+  const bool EmptyRange = LengthComponents.isZeroConstant();
+  const bool UsePreparedMemory =
+      canUseGuaranteedMemoryRange(MemOffsetComponents, LengthComponents);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemoryFull();
 #endif
-  const bool UsedGuaranteedElision =
-      preExpandMemoryRange(MemOffsetComponents, LengthComponents, true);
 #ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
-  if (UsedGuaranteedElision) {
+  if (UsePreparedMemory && !EmptyRange) {
     ++MemStats.ReturnGuaranteedElisionCount;
   }
 #endif
-  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
-  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
-  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
-  requireRuntimeHelperProofs(RuntimeMemoryHelperId::ReturnNoExpand, Proofs);
+  if (UsePreparedMemory) {
+    Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+    Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+    Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+    requireRuntimeHelperProofs(RuntimeMemoryHelperId::ReturnNoExpand, Proofs);
+  }
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t>(
-      RuntimeFunctions.SetReturnNoExpand, MemOffsetComponents,
-      LengthComponents);
+      UsePreparedMemory ? RuntimeFunctions.SetReturnNoExpand
+                        : RuntimeFunctions.SetReturn,
+      MemOffsetComponents, LengthComponents);
 
   // RETURN terminates execution immediately. Keep the direct return path so no
   // shared epilogue rewrites the gas/result state set by the runtime helper.
@@ -5811,22 +5835,26 @@ EVMMirBuilder::handleStaticCall(Operand GasOp, Operand ToAddrOp,
 void EVMMirBuilder::handleRevert(Operand OffsetOp, Operand SizeOp) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   RuntimeProofToken Proofs;
+  const bool EmptyRange = SizeOp.isZeroConstant();
+  const bool UsePreparedMemory = canUseGuaranteedMemoryRange(OffsetOp, SizeOp);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemoryFull();
 #endif
-  const bool UsedGuaranteedElision =
-      preExpandMemoryRange(OffsetOp, SizeOp, true);
 #ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
-  if (UsedGuaranteedElision) {
+  if (UsePreparedMemory && !EmptyRange) {
     ++MemStats.RevertGuaranteedElisionCount;
   }
 #endif
-  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
-  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
-  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
-  requireRuntimeHelperProofs(RuntimeMemoryHelperId::RevertNoExpand, Proofs);
+  if (UsePreparedMemory) {
+    Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+    Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+    Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+    requireRuntimeHelperProofs(RuntimeMemoryHelperId::RevertNoExpand, Proofs);
+  }
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t>(
-      RuntimeFunctions.SetRevertNoExpand, OffsetOp, SizeOp);
+      UsePreparedMemory ? RuntimeFunctions.SetRevertNoExpand
+                        : RuntimeFunctions.SetRevert,
+      OffsetOp, SizeOp);
 
   // REVERT terminates execution immediately. Keep the direct return path so no
   // shared epilogue rewrites the gas/result state set by the runtime helper.
@@ -5948,36 +5976,43 @@ EVMMirBuilder::handleKeccak256(Operand OffsetComponents,
   const uint64_t ConstLength =
       LengthWasConstU64 ? LengthComponents.getConstValue()[0] : 0;
   RuntimeProofToken Proofs;
-  if (LengthWasConstU64 && ConstLength == 0) {
-    normalizeOffsetWithSize(OffsetComponents, LengthComponents);
-#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
-    syncGasToMemory();
-#endif
-  } else {
-    const bool ExpansionCovered = OffsetWasConstU64 && LengthWasConstU64 &&
-                                  tryUseGuaranteedMinBytesExpansionElision(
-                                      true, ConstOffset, ConstLength);
-    if (!ExpansionCovered) {
-      preExpandMemoryRange(OffsetComponents, LengthComponents);
+  const bool EmptyRange = LengthWasConstU64 && ConstLength == 0;
+  const bool UsePreparedMemory =
+      canUseGuaranteedMemoryRange(OffsetComponents, LengthComponents);
+  if (UsePreparedMemory) {
+    if (!EmptyRange) {
+      MInstruction *Length = extractKnownU64LowOperand(LengthComponents);
+      chargeKeccakWordGasIR(Length);
     }
-    MInstruction *Length = extractKnownU64LowOperand(LengthComponents);
-    chargeKeccakWordGasIR(Length);
+#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
+    if (EmptyRange) {
+      syncGasToMemory();
+    }
+#endif
+    Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+    Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+    Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
+    requireRuntimeHelperProofs(RuntimeMemoryHelperId::KeccakNoExpand, Proofs);
   }
-  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
-  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
-  // Zero-length KECCAK has zero word gas, so this obligation is discharged in
-  // both branches.
-  Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
+#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
+  if (!UsePreparedMemory) {
+    syncGasToMemory();
+  }
+#endif
+
   noteKeccak256MemoryAccess(OffsetWasConstU64, ConstOffset, LengthWasConstU64,
                             ConstLength);
-  requireRuntimeHelperProofs(RuntimeMemoryHelperId::KeccakNoExpand, Proofs);
   auto Result =
       callRuntimeForWithErrorCheck<const uint8_t *, uint64_t, uint64_t>(
-          RuntimeFunctions.GetKeccak256NoExpand, OffsetComponents,
-          LengthComponents);
+          UsePreparedMemory ? RuntimeFunctions.GetKeccak256NoExpand
+                            : RuntimeFunctions.GetKeccak256,
+          OffsetComponents, LengthComponents);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
+  if (!UsePreparedMemory) {
+    reloadMemorySizeFromInstance();
+  }
   return Result;
 }
 
@@ -5986,22 +6021,30 @@ EVMMirBuilder::handleKeccak256TwoWord(Operand OffsetComponents, Operand Word0,
                                       Operand Word1) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   RuntimeProofToken Proofs;
-  preExpandKeccakTwoWordMemory(OffsetComponents);
-  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
-  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
-  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
-  requireRuntimeHelperProofs(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
-                             Proofs);
+  Operand SizeComponents = createU256ConstOperand(intx::uint256{64});
+  const bool UsePreparedMemory =
+      canUseGuaranteedMemoryRange(OffsetComponents, SizeComponents);
+  if (UsePreparedMemory) {
+    Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+    Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+    Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+    requireRuntimeHelperProofs(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
+                               Proofs);
+  }
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemory();
 #endif
   auto Result = callRuntimeForWithErrorCheck<
       const uint8_t *, uint64_t, const intx::uint256 &, const intx::uint256 &>(
-      RuntimeFunctions.GetKeccak256TwoWordNoExpand, OffsetComponents, Word0,
-      Word1);
+      UsePreparedMemory ? RuntimeFunctions.GetKeccak256TwoWordNoExpand
+                        : RuntimeFunctions.GetKeccak256TwoWord,
+      OffsetComponents, Word0, Word1);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
+  if (!UsePreparedMemory) {
+    reloadMemorySizeFromInstance();
+  }
   return Result;
 }
 
@@ -6009,12 +6052,16 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleKeccak256CallDataConstSlot(
     Operand OffsetComponents, Operand CallDataOffset, Operand SlotWord) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   RuntimeProofToken Proofs;
-  preExpandKeccakTwoWordMemory(OffsetComponents);
-  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
-  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
-  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
-  requireRuntimeHelperProofs(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
-                             Proofs);
+  Operand SizeComponents = createU256ConstOperand(intx::uint256{64});
+  const bool UsePreparedMemory =
+      canUseGuaranteedMemoryRange(OffsetComponents, SizeComponents);
+  if (UsePreparedMemory) {
+    Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+    Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+    Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+    requireRuntimeHelperProofs(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
+                               Proofs);
+  }
   uint64_t Non64Value = std::numeric_limits<uint64_t>::max();
   normalizeOperandU64(CallDataOffset, &Non64Value);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
@@ -6022,11 +6069,15 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleKeccak256CallDataConstSlot(
 #endif
   auto Result = callRuntimeForWithErrorCheck<const uint8_t *, uint64_t,
                                              uint64_t, const intx::uint256 &>(
-      RuntimeFunctions.GetKeccak256CallDataSlotNoExpand, OffsetComponents,
-      CallDataOffset, SlotWord);
+      UsePreparedMemory ? RuntimeFunctions.GetKeccak256CallDataSlotNoExpand
+                        : RuntimeFunctions.GetKeccak256CallDataSlot,
+      OffsetComponents, CallDataOffset, SlotWord);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
+  if (!UsePreparedMemory) {
+    reloadMemorySizeFromInstance();
+  }
   return Result;
 }
 
@@ -6035,22 +6086,30 @@ EVMMirBuilder::handleKeccak256CallerConstSlot(Operand OffsetComponents,
                                               Operand SlotWord) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   RuntimeProofToken Proofs;
-  preExpandKeccakTwoWordMemory(OffsetComponents);
-  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
-  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
-  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
-  requireRuntimeHelperProofs(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
-                             Proofs);
+  Operand SizeComponents = createU256ConstOperand(intx::uint256{64});
+  const bool UsePreparedMemory =
+      canUseGuaranteedMemoryRange(OffsetComponents, SizeComponents);
+  if (UsePreparedMemory) {
+    Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+    Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+    Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+    requireRuntimeHelperProofs(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
+                               Proofs);
+  }
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemory();
 #endif
   auto Result = callRuntimeForWithErrorCheck<const uint8_t *, uint64_t,
                                              const intx::uint256 &>(
-      RuntimeFunctions.GetKeccak256CallerSlotNoExpand, OffsetComponents,
-      SlotWord);
+      UsePreparedMemory ? RuntimeFunctions.GetKeccak256CallerSlotNoExpand
+                        : RuntimeFunctions.GetKeccak256CallerSlot,
+      OffsetComponents, SlotWord);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
+  if (!UsePreparedMemory) {
+    reloadMemorySizeFromInstance();
+  }
   return Result;
 }
 
@@ -6869,25 +6928,32 @@ void EVMMirBuilder::checkStaticModeIR() {
   setInsertBlock(ContinueBB);
 }
 
-bool EVMMirBuilder::preExpandMemoryRange(Operand &Offset, Operand &Size,
-                                         bool AllowGuaranteedElision) {
-  if (Size.isZeroConstant()) {
-    const U256Value ZeroValue = {0, 0, 0, 0};
-    Offset = Operand(ZeroValue);
-    Size = Operand(ZeroValue);
-    return false;
-  }
-
+bool EVMMirBuilder::canUseGuaranteedMemoryRange(Operand &Offset,
+                                                Operand &Size) {
   const bool OffsetWasConst = Offset.isConstU64();
   const uint64_t ConstOffset = OffsetWasConst ? Offset.getConstValue()[0] : 0;
   const bool SizeWasConst = Size.isConstU64();
   const uint64_t ConstSize = SizeWasConst ? Size.getConstValue()[0] : 0;
+
   normalizeOffsetWithSize(Offset, Size);
-  if (AllowGuaranteedElision && OffsetWasConst && SizeWasConst &&
-      tryUseGuaranteedMinBytesExpansionElision(true, ConstOffset, ConstSize)) {
+  if (SizeWasConst && ConstSize == 0) {
     return true;
   }
+  if (!OffsetWasConst || !SizeWasConst) {
+    return false;
+  }
+  return tryUseGuaranteedMinBytesExpansionElision(true, ConstOffset, ConstSize);
+}
 
+void EVMMirBuilder::preExpandMemoryRange(Operand &Offset, Operand &Size) {
+  if (Size.isZeroConstant()) {
+    const U256Value ZeroValue = {0, 0, 0, 0};
+    Offset = Operand(ZeroValue);
+    Size = Operand(ZeroValue);
+    return;
+  }
+
+  normalizeOffsetWithSize(Offset, Size);
   MType *I64Type = &Ctx.I64Type;
   MInstruction *OffsetLow = extractKnownU64LowOperand(Offset);
   MInstruction *SizeLow = extractKnownU64LowOperand(Size);
@@ -6897,65 +6963,6 @@ bool EVMMirBuilder::preExpandMemoryRange(Operand &Offset, Operand &Size,
       false, CmpInstruction::Predicate::ICMP_ULT, I64Type, RequiredSize,
       OffsetLow);
   expandMemoryIR(RequiredSize, Overflow);
-  return false;
-}
-
-void EVMMirBuilder::preExpandKeccakTwoWordMemory(Operand &OffsetComponents) {
-  const bool OffsetWasConstU64 = OffsetComponents.isConstU64();
-  const uint64_t ConstOffset =
-      OffsetWasConstU64 ? OffsetComponents.getConstValue()[0] : 0;
-
-  MType *I64Type = &Ctx.I64Type;
-  if (OffsetWasConstU64) {
-    constexpr uint64_t KeccakTwoWordLength = 64;
-    const bool Overflowed = ConstOffset > std::numeric_limits<uint64_t>::max() -
-                                              KeccakTwoWordLength;
-    MInstruction *RequiredSize = createIntConstInstruction(
-        I64Type, Overflowed ? 0 : ConstOffset + KeccakTwoWordLength);
-    MInstruction *Overflow =
-        createIntConstInstruction(I64Type, Overflowed ? 1 : 0);
-    expandMemoryIR(RequiredSize, Overflow);
-    return;
-  }
-
-  Operand SizeComponents = createU256ConstOperand(intx::uint256{64});
-  normalizeOffsetWithSize(OffsetComponents, SizeComponents);
-
-  MInstruction *Offset = extractKnownU64LowOperand(OffsetComponents);
-  MInstruction *Length = createIntConstInstruction(I64Type, 64);
-  MInstruction *RequiredSize = createInstruction<BinaryInstruction>(
-      false, OP_add, I64Type, Offset, Length);
-  MInstruction *Overflow = createInstruction<CmpInstruction>(
-      false, CmpInstruction::Predicate::ICMP_ULT, I64Type, RequiredSize,
-      Offset);
-  expandMemoryIR(RequiredSize, Overflow);
-}
-
-bool EVMMirBuilder::preExpandCopyMemory(Operand &DestOffsetComponents,
-                                        Operand &SizeComponents) {
-  const bool DestWasConstU64 = DestOffsetComponents.isConstU64();
-  const uint64_t ConstDest =
-      DestWasConstU64 ? DestOffsetComponents.getConstValue()[0] : 0;
-  const bool SizeWasConstU64 = SizeComponents.isConstU64();
-  const uint64_t ConstSize =
-      SizeWasConstU64 ? SizeComponents.getConstValue()[0] : 0;
-
-  normalizeOffsetWithSize(DestOffsetComponents, SizeComponents);
-  if (DestWasConstU64 && SizeWasConstU64 &&
-      tryUseGuaranteedMinBytesExpansionElision(true, ConstDest, ConstSize)) {
-    return true;
-  }
-
-  MType *I64Type = &Ctx.I64Type;
-  MInstruction *DestOffset = extractKnownU64LowOperand(DestOffsetComponents);
-  MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
-  MInstruction *RequiredSize = createInstruction<BinaryInstruction>(
-      false, OP_add, I64Type, DestOffset, Size);
-  MInstruction *Overflow = createInstruction<CmpInstruction>(
-      false, CmpInstruction::Predicate::ICMP_ULT, I64Type, RequiredSize,
-      DestOffset);
-  expandMemoryIR(RequiredSize, Overflow);
-  return false;
 }
 
 void EVMMirBuilder::chargeWordCopyGasIR(MInstruction *Size) {
@@ -7369,22 +7376,42 @@ void EVMMirBuilder::handleCallDataCopy(Operand DestOffsetComponents,
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   uint64_t Non64Value = std::numeric_limits<uint64_t>::max();
   RuntimeProofToken Proofs;
-  if (preExpandCopyMemory(DestOffsetComponents, SizeComponents)) {
+  const bool EmptyRange = SizeComponents.isZeroConstant();
+  const bool UsePreparedMemory =
+      canUseGuaranteedMemoryRange(DestOffsetComponents, SizeComponents);
+  if (UsePreparedMemory) {
 #ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
-    ++MemStats.CopyGuaranteedElisionCount;
+    if (!EmptyRange) {
+      ++MemStats.CopyGuaranteedElisionCount;
+    }
 #endif
+    Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+    Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+    MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
+    chargeWordCopyGasIR(Size);
+    Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
+    requireRuntimeHelperProofs(RuntimeMemoryHelperId::CallDataCopyNoExpand,
+                               Proofs);
   }
-  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
-  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
-  MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
-  chargeWordCopyGasIR(Size);
-  Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
+
   normalizeOperandU64(OffsetComponents, &Non64Value);
-  requireRuntimeHelperProofs(RuntimeMemoryHelperId::CallDataCopyNoExpand,
-                             Proofs);
+#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
+  if (!UsePreparedMemory) {
+    syncGasToMemory();
+  }
+#endif
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t, uint64_t>(
-      RuntimeFunctions.SetCallDataCopyNoExpand, DestOffsetComponents,
-      OffsetComponents, SizeComponents);
+      UsePreparedMemory ? RuntimeFunctions.SetCallDataCopyNoExpand
+                        : RuntimeFunctions.SetCallDataCopy,
+      DestOffsetComponents, OffsetComponents, SizeComponents);
+#ifdef ZEN_ENABLE_EVM_GAS_REGISTER
+  if (!UsePreparedMemory) {
+    reloadGasFromMemory();
+  }
+#endif
+  if (!UsePreparedMemory) {
+    reloadMemorySizeFromInstance();
+  }
 }
 
 void EVMMirBuilder::handleExtCodeCopy(Operand AddressComponents,
@@ -9740,6 +9767,9 @@ void EVMMirBuilder::expandMemoryIR(MInstruction *RequiredSize,
   // Charge memory expansion gas
   chargeMemoryExpansionGasIR(CurrentSize, AlignedSize);
 
+  // This token is a structural assertion: the dominating control flow has
+  // validated bounds and charged expansion gas before selecting the no-gas
+  // resize helper. It is not a recovered-range proof or a helper-choice gate.
   RuntimeProofToken Proofs;
   Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
   Proofs.establish(RuntimeProofRequirementFlag::BoundsValidated);

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -4,6 +4,7 @@
 #include "compiler/evm_frontend/evm_mir_compiler.h"
 #include "action/evm_bytecode_visitor.h"
 #include "compiler/evm_frontend/evm_imported.h"
+#include "compiler/evm_frontend/evm_runtime_helper_effects.h"
 #include "compiler/mir/constants.h"
 #include "compiler/mir/module.h"
 #include "evm/gas_storage_cost.h"
@@ -17,6 +18,7 @@
 #include <optional>
 #include <queue>
 #include <set>
+#include <stdexcept>
 
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
 #include "compiler/llvm-prebuild/Target/X86/X86Subtarget.h"
@@ -4736,15 +4738,20 @@ void EVMMirBuilder::handleCodeCopy(Operand DestOffsetComponents,
                                    Operand OffsetComponents,
                                    Operand SizeComponents) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
+  RuntimeProofToken Proofs;
   if (preExpandCopyMemory(DestOffsetComponents, SizeComponents)) {
 #ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
     ++MemStats.CopyGuaranteedElisionCount;
 #endif
   }
+  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
   MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
   chargeWordCopyGasIR(Size);
+  Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
   uint64_t Non64Value = std::numeric_limits<uint64_t>::max();
   normalizeOperandU64(OffsetComponents, &Non64Value);
+  requireRuntimeHelperProofs(RuntimeMemoryHelperId::CodeCopyNoExpand, Proofs);
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t, uint64_t>(
       RuntimeFunctions.SetCodeCopyNoExpand, DestOffsetComponents,
       OffsetComponents, SizeComponents);
@@ -5526,7 +5533,6 @@ void EVMMirBuilder::handleLogWithTopics(Operand OffsetOp, Operand SizeOp,
         false, OP_mul, &Ctx.I64Type, SizeParts[0], LogDataGasPerByte);
     chargeDynamicGasIR(LogDataCost);
   }
-
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemory();
 #endif
@@ -5598,19 +5604,43 @@ bool EVMMirBuilder::canUseGuaranteedCallMemoryRanges(const Operand &ArgsOffset,
                                                      const Operand &ArgsSize,
                                                      const Operand &RetOffset,
                                                      const Operand &RetSize) {
-  const auto IsCovered = [this](const Operand &Offset, const Operand &Size) {
-    if (Size.isZeroConstant()) {
-      return true;
-    }
-    if (!Offset.isConstU64() || !Size.isConstU64()) {
-      return false;
-    }
-    return tryUseGuaranteedMinBytesExpansionElision(
-        true, Offset.getConstValue()[0], Size.getConstValue()[0]);
-  };
+  RuntimeProofToken Proofs;
+  const auto EstablishRange =
+      [this, &Proofs](const Operand &Offset, const Operand &Size,
+                      RuntimeProofRequirementFlag Requirement) {
+        if (Size.isZeroConstant()) {
+          Proofs.establish(Requirement);
+          return true;
+        }
+        if (!Offset.isConstU64() || !Size.isConstU64()) {
+          return false;
+        }
+        if (!tryUseGuaranteedMinBytesExpansionElision(
+                true, Offset.getConstValue()[0], Size.getConstValue()[0])) {
+          return false;
+        }
+        Proofs.establish(Requirement);
+        return true;
+      };
 
-  const bool CanReuse =
-      IsCovered(ArgsOffset, ArgsSize) && IsCovered(RetOffset, RetSize);
+  const bool ArgsCovered = EstablishRange(
+      ArgsOffset, ArgsSize, RuntimeProofRequirementFlag::CallArgumentsRange);
+  const bool RetCovered = EstablishRange(
+      RetOffset, RetSize, RuntimeProofRequirementFlag::CallReturnRange);
+  if (ArgsCovered && RetCovered) {
+    Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+  }
+  // The call remains at its original opcode position. Only redundant memory
+  // expansion is skipped; account access, EIP-150 gas handling, and external
+  // effects retain their runtime order.
+  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+
+  const RuntimeMemoryHelperContract Contract =
+      getRuntimeMemoryHelperContract(RuntimeMemoryHelperId::CallNoExpand);
+  const bool CanReuse = satisfiesRuntimeMemoryHelperContract(Contract, Proofs);
+  if (CanReuse) {
+    requireRuntimeHelperProofs(RuntimeMemoryHelperId::CallNoExpand, Proofs);
+  }
 #ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
   if (CanReuse) {
     ZEN_LOG_DEBUG("[EVM-CALL-MEMORY-PROOF] pc=%llu",
@@ -5687,6 +5717,7 @@ EVMMirBuilder::handleCallCode(Operand GasOp, Operand ToAddrOp, Operand ValueOp,
 void EVMMirBuilder::handleReturn(Operand MemOffsetComponents,
                                  Operand LengthComponents) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
+  RuntimeProofToken Proofs;
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemoryFull();
 #endif
@@ -5697,6 +5728,10 @@ void EVMMirBuilder::handleReturn(Operand MemOffsetComponents,
     ++MemStats.ReturnGuaranteedElisionCount;
   }
 #endif
+  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+  requireRuntimeHelperProofs(RuntimeMemoryHelperId::ReturnNoExpand, Proofs);
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t>(
       RuntimeFunctions.SetReturnNoExpand, MemOffsetComponents,
       LengthComponents);
@@ -5775,6 +5810,7 @@ EVMMirBuilder::handleStaticCall(Operand GasOp, Operand ToAddrOp,
 
 void EVMMirBuilder::handleRevert(Operand OffsetOp, Operand SizeOp) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
+  RuntimeProofToken Proofs;
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemoryFull();
 #endif
@@ -5785,6 +5821,10 @@ void EVMMirBuilder::handleRevert(Operand OffsetOp, Operand SizeOp) {
     ++MemStats.RevertGuaranteedElisionCount;
   }
 #endif
+  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+  requireRuntimeHelperProofs(RuntimeMemoryHelperId::RevertNoExpand, Proofs);
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t>(
       RuntimeFunctions.SetRevertNoExpand, OffsetOp, SizeOp);
 
@@ -5907,6 +5947,7 @@ EVMMirBuilder::handleKeccak256(Operand OffsetComponents,
   const bool LengthWasConstU64 = LengthComponents.isConstU64();
   const uint64_t ConstLength =
       LengthWasConstU64 ? LengthComponents.getConstValue()[0] : 0;
+  RuntimeProofToken Proofs;
   if (LengthWasConstU64 && ConstLength == 0) {
     normalizeOffsetWithSize(OffsetComponents, LengthComponents);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
@@ -5922,8 +5963,14 @@ EVMMirBuilder::handleKeccak256(Operand OffsetComponents,
     MInstruction *Length = extractKnownU64LowOperand(LengthComponents);
     chargeKeccakWordGasIR(Length);
   }
+  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+  // Zero-length KECCAK has zero word gas, so this obligation is discharged in
+  // both branches.
+  Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
   noteKeccak256MemoryAccess(OffsetWasConstU64, ConstOffset, LengthWasConstU64,
                             ConstLength);
+  requireRuntimeHelperProofs(RuntimeMemoryHelperId::KeccakNoExpand, Proofs);
   auto Result =
       callRuntimeForWithErrorCheck<const uint8_t *, uint64_t, uint64_t>(
           RuntimeFunctions.GetKeccak256NoExpand, OffsetComponents,
@@ -5938,7 +5985,13 @@ typename EVMMirBuilder::Operand
 EVMMirBuilder::handleKeccak256TwoWord(Operand OffsetComponents, Operand Word0,
                                       Operand Word1) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
+  RuntimeProofToken Proofs;
   preExpandKeccakTwoWordMemory(OffsetComponents);
+  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+  requireRuntimeHelperProofs(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
+                             Proofs);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemory();
 #endif
@@ -5955,7 +6008,13 @@ EVMMirBuilder::handleKeccak256TwoWord(Operand OffsetComponents, Operand Word0,
 typename EVMMirBuilder::Operand EVMMirBuilder::handleKeccak256CallDataConstSlot(
     Operand OffsetComponents, Operand CallDataOffset, Operand SlotWord) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
+  RuntimeProofToken Proofs;
   preExpandKeccakTwoWordMemory(OffsetComponents);
+  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+  requireRuntimeHelperProofs(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
+                             Proofs);
   uint64_t Non64Value = std::numeric_limits<uint64_t>::max();
   normalizeOperandU64(CallDataOffset, &Non64Value);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
@@ -5975,7 +6034,13 @@ typename EVMMirBuilder::Operand
 EVMMirBuilder::handleKeccak256CallerConstSlot(Operand OffsetComponents,
                                               Operand SlotWord) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
+  RuntimeProofToken Proofs;
   preExpandKeccakTwoWordMemory(OffsetComponents);
+  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
+  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+  requireRuntimeHelperProofs(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
+                             Proofs);
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   syncGasToMemory();
 #endif
@@ -5990,6 +6055,16 @@ EVMMirBuilder::handleKeccak256CallerConstSlot(Operand OffsetComponents,
 }
 
 // ==================== Private Helper Methods ====================
+
+void EVMMirBuilder::requireRuntimeHelperProofs(
+    RuntimeMemoryHelperId Helper, const RuntimeProofToken &Proofs) const {
+  const RuntimeMemoryHelperContract Contract =
+      getRuntimeMemoryHelperContract(Helper);
+  if (!satisfiesRuntimeMemoryHelperContract(Contract, Proofs)) {
+    throw std::logic_error(
+        "prepared-memory helper selected without required proofs");
+  }
+}
 
 typename EVMMirBuilder::Operand
 EVMMirBuilder::createU256ConstOperand(const intx::uint256 &V) {
@@ -7293,14 +7368,20 @@ void EVMMirBuilder::handleCallDataCopy(Operand DestOffsetComponents,
                                        Operand SizeComponents) {
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   uint64_t Non64Value = std::numeric_limits<uint64_t>::max();
+  RuntimeProofToken Proofs;
   if (preExpandCopyMemory(DestOffsetComponents, SizeComponents)) {
 #ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
     ++MemStats.CopyGuaranteedElisionCount;
 #endif
   }
+  Proofs.establish(RuntimeProofRequirementFlag::LogicalSize);
+  Proofs.establish(RuntimeProofRequirementFlag::AccessRange);
   MInstruction *Size = extractKnownU64LowOperand(SizeComponents);
   chargeWordCopyGasIR(Size);
+  Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
   normalizeOperandU64(OffsetComponents, &Non64Value);
+  requireRuntimeHelperProofs(RuntimeMemoryHelperId::CallDataCopyNoExpand,
+                             Proofs);
   callRuntimeForWithErrorCheck<void, uint64_t, uint64_t, uint64_t>(
       RuntimeFunctions.SetCallDataCopyNoExpand, DestOffsetComponents,
       OffsetComponents, SizeComponents);
@@ -9658,6 +9739,12 @@ void EVMMirBuilder::expandMemoryIR(MInstruction *RequiredSize,
 
   // Charge memory expansion gas
   chargeMemoryExpansionGasIR(CurrentSize, AlignedSize);
+
+  RuntimeProofToken Proofs;
+  Proofs.establish(RuntimeProofRequirementFlag::DynamicGasCharged);
+  Proofs.establish(RuntimeProofRequirementFlag::BoundsValidated);
+  Proofs.establish(RuntimeProofRequirementFlag::OrderToken);
+  requireRuntimeHelperProofs(RuntimeMemoryHelperId::ExpandMemoryNoGas, Proofs);
 
   const auto &RuntimeFunctions = getRuntimeFunctionTable();
   callRuntimeFor<void, uint64_t>(RuntimeFunctions.ExpandMemoryNoGas,

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -24,6 +24,8 @@
 
 // Forward declaration to avoid circular dependency
 namespace COMPILER {
+enum class RuntimeMemoryHelperId : uint8_t;
+class RuntimeProofToken;
 struct RuntimeFunctions;
 } // namespace COMPILER
 
@@ -1856,6 +1858,8 @@ private:
                                         const Operand &ArgsSize,
                                         const Operand &RetOffset,
                                         const Operand &RetSize);
+  void requireRuntimeHelperProofs(RuntimeMemoryHelperId Helper,
+                                  const RuntimeProofToken &Proofs) const;
   void applyMemoryExpansionPlan(const MemoryExpansionPlan &Plan);
   void noteMemoryExpansionPlan(const MemoryExpansionPlan &Plan);
   void noteMemoryExpansionPlanDiagnostics(

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -1340,8 +1340,8 @@ private:
   MInstruction *extractKnownU64LowOperand(const Operand &Opnd);
   void checkStaticModeIR();
   void normalizeOffsetWithSize(Operand &Offset, Operand &Size);
-  bool preExpandMemoryRange(Operand &Offset, Operand &Size,
-                            bool AllowGuaranteedElision = false);
+  bool canUseGuaranteedMemoryRange(Operand &Offset, Operand &Size);
+  void preExpandMemoryRange(Operand &Offset, Operand &Size);
 
   Operand convertSingleInstrToU256Operand(MInstruction *SingleInstr);
   Operand convertU256InstrToU256Operand(MInstruction *U256Instr);
@@ -1891,9 +1891,6 @@ private:
   MInstruction *getMemorySize();
   void reloadMemorySizeFromInstance();
   void expandMemoryIR(MInstruction *RequiredSize, MInstruction *Overflow);
-  void preExpandKeccakTwoWordMemory(Operand &OffsetComponents);
-  bool preExpandCopyMemory(Operand &DestOffsetComponents,
-                           Operand &SizeComponents);
   void chargeWordCopyGasIR(MInstruction *Size);
   void chargeDynamicGasIR(MInstruction *GasCost);
   void chargeKeccakWordGasIR(MInstruction *Length);

--- a/src/compiler/evm_frontend/evm_runtime_helper_effects.h
+++ b/src/compiler/evm_frontend/evm_runtime_helper_effects.h
@@ -1,0 +1,168 @@
+// Copyright (C) 2025 the DTVM authors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef COMPILER_EVM_FRONTEND_EVM_RUNTIME_HELPER_EFFECTS_H
+#define COMPILER_EVM_FRONTEND_EVM_RUNTIME_HELPER_EFFECTS_H
+
+#include "compiler/evm_frontend/evm_memory_facts.h"
+
+#include <cstdint>
+
+namespace COMPILER {
+
+enum class RuntimeMemoryHelperId : uint8_t {
+  Unknown,
+  CodeCopyNoExpand,
+  CallDataCopyNoExpand,
+  KeccakNoExpand,
+  TwoWordKeccakNoExpand,
+  ReturnNoExpand,
+  RevertNoExpand,
+  ExpandMemoryNoGas,
+  CallNoExpand
+};
+
+enum class RuntimeProofRequirementFlag : uint16_t {
+  LogicalSize = 1U << 0,
+  AccessRange = 1U << 1,
+  DynamicGasCharged = 1U << 2,
+  BoundsValidated = 1U << 3,
+  OrderToken = 1U << 4,
+  CallArgumentsRange = 1U << 5,
+  CallReturnRange = 1U << 6
+};
+
+// Lowering accumulates obligations as it emits the corresponding operations.
+// Prepared-memory helpers accept this typed token instead of a preassembled
+// bit mask, making the discharge order explicit at each call site.
+class RuntimeProofToken {
+public:
+  void establish(RuntimeProofRequirementFlag Requirement) {
+    Provided |= static_cast<uint16_t>(Requirement);
+  }
+
+  bool provides(RuntimeProofRequirementFlag Requirement) const {
+    return (Provided & static_cast<uint16_t>(Requirement)) != 0;
+  }
+
+  uint16_t bits() const { return Provided; }
+
+private:
+  uint16_t Provided = 0;
+};
+
+// Contract for prepared-memory runtime helpers. Requirements are obligations
+// discharged by lowering before the call; effects describe the helper's
+// normal-success transition. Exceptional behavior remains fail closed through
+// MayTrapOrHalt and OrderToken.
+struct RuntimeMemoryHelperContract {
+  uint16_t Requirements = 0;
+  MemoryEffectSummary Effects;
+  bool EstablishesLogicalSize = false;
+  bool Valid = false;
+
+  void require(RuntimeProofRequirementFlag Requirement) {
+    Requirements |= static_cast<uint16_t>(Requirement);
+  }
+
+  bool
+    requires(RuntimeProofRequirementFlag Requirement)
+  const {
+    return (Requirements & static_cast<uint16_t>(Requirement)) != 0;
+  }
+};
+
+inline bool satisfiesRuntimeMemoryHelperContract(
+    const RuntimeMemoryHelperContract &Contract,
+    const RuntimeProofToken &Proofs) {
+  return Contract.Valid &&
+         (Contract.Requirements & Proofs.bits()) == Contract.Requirements;
+}
+
+inline RuntimeMemoryHelperContract
+getRuntimeMemoryHelperContract(RuntimeMemoryHelperId Helper) {
+  RuntimeMemoryHelperContract Contract;
+  auto RequirePreparedRange = [&Contract]() {
+    Contract.require(RuntimeProofRequirementFlag::LogicalSize);
+    Contract.require(RuntimeProofRequirementFlag::AccessRange);
+  };
+  auto RequireObservableOrder = [&Contract]() {
+    Contract.require(RuntimeProofRequirementFlag::OrderToken);
+    Contract.Effects.add(MemoryEffectFlag::RequiresOrderToken);
+  };
+
+  switch (Helper) {
+  case RuntimeMemoryHelperId::Unknown:
+    return Contract;
+
+  case RuntimeMemoryHelperId::CodeCopyNoExpand:
+  case RuntimeMemoryHelperId::CallDataCopyNoExpand:
+    Contract.Valid = true;
+    RequirePreparedRange();
+    Contract.require(RuntimeProofRequirementFlag::DynamicGasCharged);
+    Contract.Effects.add(MemoryEffectFlag::WritesMemory);
+    break;
+
+  case RuntimeMemoryHelperId::KeccakNoExpand:
+    Contract.Valid = true;
+    RequirePreparedRange();
+    Contract.require(RuntimeProofRequirementFlag::DynamicGasCharged);
+    Contract.Effects.add(MemoryEffectFlag::ReadsMemory);
+    break;
+
+  case RuntimeMemoryHelperId::TwoWordKeccakNoExpand:
+    Contract.Valid = true;
+    RequirePreparedRange();
+    Contract.Effects.add(MemoryEffectFlag::ReadsMemory);
+    Contract.Effects.add(MemoryEffectFlag::WritesMemory);
+    Contract.Effects.add(MemoryEffectFlag::ObservesGas);
+    Contract.Effects.add(MemoryEffectFlag::ChargesDynamicGas);
+    Contract.Effects.add(MemoryEffectFlag::MayExhaustGas);
+    Contract.Effects.add(MemoryEffectFlag::MayTrapOrHalt);
+    RequireObservableOrder();
+    break;
+
+  case RuntimeMemoryHelperId::ReturnNoExpand:
+  case RuntimeMemoryHelperId::RevertNoExpand:
+    Contract.Valid = true;
+    RequirePreparedRange();
+    Contract.Effects.add(MemoryEffectFlag::ReadsMemory);
+    Contract.Effects.add(MemoryEffectFlag::ExternalizesMemory);
+    Contract.Effects.add(MemoryEffectFlag::TerminatesFrame);
+    RequireObservableOrder();
+    break;
+
+  case RuntimeMemoryHelperId::ExpandMemoryNoGas:
+    Contract.Valid = true;
+    Contract.require(RuntimeProofRequirementFlag::DynamicGasCharged);
+    Contract.require(RuntimeProofRequirementFlag::BoundsValidated);
+    Contract.Effects.add(MemoryEffectFlag::MayGrowMemory);
+    Contract.Effects.add(MemoryEffectFlag::MayRebaseMemory);
+    Contract.Effects.add(MemoryEffectFlag::MayTrapOrHalt);
+    RequireObservableOrder();
+    Contract.EstablishesLogicalSize = true;
+    break;
+
+  case RuntimeMemoryHelperId::CallNoExpand:
+    Contract.Valid = true;
+    Contract.require(RuntimeProofRequirementFlag::LogicalSize);
+    Contract.require(RuntimeProofRequirementFlag::CallArgumentsRange);
+    Contract.require(RuntimeProofRequirementFlag::CallReturnRange);
+    Contract.Effects.add(MemoryEffectFlag::ReadsMemory);
+    Contract.Effects.add(MemoryEffectFlag::WritesMemory);
+    Contract.Effects.add(MemoryEffectFlag::ObservesGas);
+    Contract.Effects.add(MemoryEffectFlag::ChargesDynamicGas);
+    Contract.Effects.add(MemoryEffectFlag::MayExhaustGas);
+    Contract.Effects.add(MemoryEffectFlag::MayRebaseMemory);
+    Contract.Effects.add(MemoryEffectFlag::MayTrapOrHalt);
+    Contract.Effects.add(MemoryEffectFlag::ExternalizesMemory);
+    RequireObservableOrder();
+    break;
+  }
+
+  return Contract;
+}
+
+} // namespace COMPILER
+
+#endif // COMPILER_EVM_FRONTEND_EVM_RUNTIME_HELPER_EFFECTS_H

--- a/src/compiler/evm_frontend/evm_runtime_helper_effects.h
+++ b/src/compiler/evm_frontend/evm_runtime_helper_effects.h
@@ -65,9 +65,7 @@ struct RuntimeMemoryHelperContract {
     Requirements |= static_cast<uint16_t>(Requirement);
   }
 
-  bool
-    requires(RuntimeProofRequirementFlag Requirement)
-  const {
+  bool hasRequirement(RuntimeProofRequirementFlag Requirement) const {
     return (Requirements & static_cast<uint16_t>(Requirement)) != 0;
   }
 };

--- a/src/tests/evm_call_memory_tests.cpp
+++ b/src/tests/evm_call_memory_tests.cpp
@@ -109,6 +109,60 @@ TEST(EVMMirBuilderCallMemoryProofTest,
   EXPECT_FALSE(containsRuntimeCall(*StaticCallMir,
                                    RuntimeFunctions.HandleStaticCallNoExpand));
 }
+
+TEST(EVMMirBuilderPreparedMemoryProofTest,
+     KeepsGenericRangeHelpersForDynamicOffsets) {
+  const auto &RuntimeFunctions = COMPILER::getRuntimeFunctionTable();
+  const std::vector<uint8_t> CodeCopyBytecode = {
+      OP_PUSH1,        0x20, // copy size
+      OP_PUSH0,              // code offset
+      OP_PUSH0,              // calldata offset
+      OP_CALLDATALOAD,
+      OP_CODECOPY, // dynamic destination offset
+      OP_STOP,
+  };
+  const std::vector<uint8_t> KeccakBytecode = {
+      OP_PUSH1,        0x20, // hash size
+      OP_PUSH0,              // calldata offset
+      OP_CALLDATALOAD,
+      OP_KECCAK256, // dynamic memory offset
+      OP_STOP,
+  };
+  const std::vector<uint8_t> ReturnBytecode = {
+      OP_PUSH1,        0x20, // return size
+      OP_PUSH0,              // calldata offset
+      OP_CALLDATALOAD,
+      OP_RETURN, // dynamic memory offset
+  };
+  const std::vector<uint8_t> RevertBytecode = {
+      OP_PUSH1,        0x20, // revert size
+      OP_PUSH0,              // calldata offset
+      OP_CALLDATALOAD,
+      OP_REVERT, // dynamic memory offset
+  };
+
+  const auto CodeCopyMir = compileCallMemoryMir(CodeCopyBytecode);
+  const auto KeccakMir = compileCallMemoryMir(KeccakBytecode);
+  const auto ReturnMir = compileCallMemoryMir(ReturnBytecode);
+  const auto RevertMir = compileCallMemoryMir(RevertBytecode);
+  ASSERT_TRUE(CodeCopyMir.has_value());
+  ASSERT_TRUE(KeccakMir.has_value());
+  ASSERT_TRUE(ReturnMir.has_value());
+  ASSERT_TRUE(RevertMir.has_value());
+
+  EXPECT_TRUE(containsRuntimeCall(*CodeCopyMir, RuntimeFunctions.SetCodeCopy));
+  EXPECT_FALSE(
+      containsRuntimeCall(*CodeCopyMir, RuntimeFunctions.SetCodeCopyNoExpand));
+  EXPECT_TRUE(containsRuntimeCall(*KeccakMir, RuntimeFunctions.GetKeccak256));
+  EXPECT_FALSE(
+      containsRuntimeCall(*KeccakMir, RuntimeFunctions.GetKeccak256NoExpand));
+  EXPECT_TRUE(containsRuntimeCall(*ReturnMir, RuntimeFunctions.SetReturn));
+  EXPECT_FALSE(
+      containsRuntimeCall(*ReturnMir, RuntimeFunctions.SetReturnNoExpand));
+  EXPECT_TRUE(containsRuntimeCall(*RevertMir, RuntimeFunctions.SetRevert));
+  EXPECT_FALSE(
+      containsRuntimeCall(*RevertMir, RuntimeFunctions.SetRevertNoExpand));
+}
 #endif
 
 } // namespace

--- a/src/tests/evm_differential_tests.cpp
+++ b/src/tests/evm_differential_tests.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "compiler/evm_frontend/evm_analyzer.h"
@@ -1302,7 +1303,7 @@ std::vector<uint8_t> log0StaticHighOffsetBytecode() {
   return Code;
 }
 
-std::vector<uint8_t> staticCallPreparedMemoryBytecode() {
+std::vector<uint8_t> preparedCallMemoryBytecode(evmc_opcode Opcode) {
   std::vector<uint8_t> Code;
   appendPush32Pattern(Code, 0x21);
   Code.insert(Code.end(), {0x60, 0x80, 0x52}); // MSTORE(0x80, pattern)
@@ -1320,15 +1321,32 @@ std::vector<uint8_t> staticCallPreparedMemoryBytecode() {
                               0x60, 0xa0, // return offset
                               0x60, 0x20, // argument size
                               0x60, 0x80, // argument offset
-                              0x60, 0x04, // identity precompile
-                              0x61, 0xff, 0xff,
-                              0xfa,       // STATICCALL
-                              0x50,       // POP success
-                              0x60, 0x20, // RETURN size
-                              0x60, 0xa0, // RETURN offset
+                          });
+  if (Opcode == OP_CALL || Opcode == OP_CALLCODE) {
+    Code.push_back(OP_PUSH0); // value
+  }
+  Code.insert(Code.end(), {
+                              0x60,
+                              0x04, // identity precompile
+                              0x61,
+                              0xff,
+                              0xff,
+                              static_cast<uint8_t>(Opcode),
+                              0x50, // POP success
+                              0x60,
+                              0x20, // RETURN size
+                              0x60,
+                              0xa0, // RETURN offset
                               0xf3,
                           });
   return Code;
+}
+
+std::vector<uint8_t> twoWordKeccakBytecode() {
+  return {
+      OP_CALLER, OP_PUSH0,  OP_MSTORE, OP_PUSH1, 0x05,     OP_PUSH1,
+      0x20,      OP_MSTORE, OP_PUSH1,  0x40,     OP_PUSH0, OP_KECCAK256,
+  };
 }
 
 std::vector<uint8_t> staticCallEmptyHighOffsetsBytecode() {
@@ -1390,9 +1408,56 @@ TEST(EVMLogMemoryPreexpandDifferential, StaticModePrecedesMemoryExpansion) {
 
 TEST(EVMCallMemoryProofDifferential, PreparedIdentityCallMatchesInterpreter) {
   const auto Output = expectInterpMatchesMultipassWithGas(
-      "staticcall_prepared_memory", staticCallPreparedMemoryBytecode(), {});
+      "staticcall_prepared_memory", preparedCallMemoryBytecode(OP_STATICCALL),
+      {});
   EXPECT_EQ(Output,
             "2122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F40");
+}
+
+TEST(EVMCallMemoryProofDifferential,
+     PreparedCallKindsMatchInterpreterOutputAndGas) {
+  const std::pair<evmc_opcode, const char *> Cases[] = {
+      {OP_CALL, "call"},
+      {OP_CALLCODE, "callcode"},
+      {OP_DELEGATECALL, "delegatecall"},
+  };
+  for (const auto &[Opcode, Label] : Cases) {
+    const auto Output = expectInterpMatchesMultipassWithGas(
+        std::string(Label) + "_prepared_memory",
+        preparedCallMemoryBytecode(Opcode), {});
+    EXPECT_EQ(
+        Output,
+        "2122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F40")
+        << Label;
+  }
+}
+
+TEST(EVMKeccakMemoryProofDifferential,
+     TwoWordHelperWordGasOutOfGasBoundaryMatchesInterpreter) {
+  const auto Bytecode = twoWordKeccakBytecode();
+  constexpr uint64_t ProbeGasLimit = 1'000'000;
+  const auto Reference =
+      runEvmBytecode("two_word_keccak_word_gas_reference", Bytecode,
+                     common::RunMode::InterpMode, {}, 0u, true, ProbeGasLimit);
+  ASSERT_EQ(Reference.Status, EVMC_SUCCESS);
+  ASSERT_GE(Reference.GasLeft, 0);
+  const auto RequiredGas =
+      ProbeGasLimit - static_cast<uint64_t>(Reference.GasLeft);
+  ASSERT_GT(RequiredGas, uint64_t{1});
+
+  const auto Interp = runEvmBytecode("two_word_keccak_word_gas_oog_interp",
+                                     Bytecode, common::RunMode::InterpMode, {},
+                                     0u, true, RequiredGas - 1);
+  const auto Multi = runEvmBytecode("two_word_keccak_word_gas_oog_multipass",
+                                    Bytecode, common::RunMode::MultipassMode,
+                                    {}, 0u, true, RequiredGas - 1);
+#ifdef ZEN_ENABLE_JIT
+  EXPECT_TRUE(Multi.JITCompiled);
+#endif
+  EXPECT_EQ(Interp.Status, EVMC_OUT_OF_GAS);
+  EXPECT_EQ(Multi.Status, Interp.Status);
+  EXPECT_EQ(Multi.GasLeft, Interp.GasLeft);
+  EXPECT_EQ(Multi.OutputHex, Interp.OutputHex);
 }
 
 TEST(EVMCallMemoryProofDifferential, EmptyRangesIgnoreHighOffsets) {

--- a/src/tests/evm_differential_tests.cpp
+++ b/src/tests/evm_differential_tests.cpp
@@ -266,6 +266,24 @@ std::string fixtureTestName(const testing::TestParamInfo<std::string> &Info) {
 
 } // namespace
 
+TEST(EVMPreparedCopyFallbackDifferential,
+     DynamicDestinationMatchesInterpreterOutputAndGas) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1,        0x04, // copy size
+      OP_PUSH0,              // code offset
+      OP_PUSH0,              // calldata offset
+      OP_CALLDATALOAD,
+      OP_CODECOPY, // dynamic destination offset
+      OP_PUSH1,        0x04, OP_PUSH1, 0x80, OP_RETURN,
+  };
+  std::vector<uint8_t> CallData(32, 0);
+  CallData.back() = 0x80;
+
+  const auto Output = expectInterpMatchesMultipassWithGas(
+      "codecopy_dynamic_destination_fallback", Bytecode, CallData);
+  EXPECT_EQ(Output, "60045F5F");
+}
+
 TEST(EVMKeccakMemoryProofDifferential,
      CrossBlockProofReusePreservesHashAndGas) {
   const std::vector<uint8_t> Bytecode = {

--- a/src/tests/evm_jit_frontend_tests.cpp
+++ b/src/tests/evm_jit_frontend_tests.cpp
@@ -11,6 +11,7 @@
 #include "compiler/evm_frontend/evm_memory_grouping.h"
 #include "compiler/evm_frontend/evm_memory_precheck.h"
 #include "compiler/evm_frontend/evm_mir_compiler.h"
+#include "compiler/evm_frontend/evm_runtime_helper_effects.h"
 #include "compiler/mir/module.h"
 #include "compiler/mir/pass/verifier.h"
 
@@ -366,8 +367,9 @@ std::vector<uint8_t> makeLargeStaticDynamicOffsetMStoreBlock(uint64_t Ops) {
   return Bytecode;
 }
 
-COMPILER::MemoryFacts collectMemoryFacts(const std::vector<uint8_t> &Bytecode) {
-  COMPILER::MemoryFactsBuilder FactsBuilder;
+COMPILER::MemoryFacts collectMemoryFacts(const std::vector<uint8_t> &Bytecode,
+                                         evmc_revision Revision = EVMC_CANCUN) {
+  COMPILER::MemoryFactsBuilder FactsBuilder(Revision);
   FactsBuilder.beginBlock(0, 0);
 
   size_t PC = 0;
@@ -389,7 +391,9 @@ collectAnalyzerMemoryFacts(const std::vector<uint8_t> &Bytecode) {
   const uint8_t *Data = Bytecode.empty() ? nullptr : Bytecode.data();
   COMPILER::MemoryEntryAddressAnalysis EntryAddresses(Analyzer, Data,
                                                       Bytecode.size());
-  COMPILER::MemoryFactsBuilder FactsBuilder;
+  COMPILER::MemoryFactsBuilder FactsBuilder(EVMC_CANCUN);
+  const std::vector<uint64_t> DynamicDispatchSources =
+      Analyzer.getDynamicJumpDispatchSourceBlocks();
   const auto &Blocks = Analyzer.getBlockInfos();
   for (const auto &[EntryPC, BlockInfo] : Blocks) {
     const bool HasReliableEntryStack =
@@ -401,9 +405,17 @@ collectAnalyzerMemoryFacts(const std::vector<uint8_t> &Bytecode) {
     std::vector<COMPILER::MemoryEntryValue> EntryValues =
         EntryAddresses.getEntryValues(EntryPC,
                                       static_cast<uint32_t>(EntryDepth));
+    const std::vector<uint64_t> PotentialPredecessors =
+        Analyzer.getPotentialEntryPredecessorsForBlock(EntryPC);
+    const bool PredecessorsAreStatic =
+        Analyzer.getDynamicJumpSourceBlocksForBlock(EntryPC).empty();
+    const bool PredecessorsComplete =
+        Analyzer.dynamicJumpTargetPredecessorsAreComplete(
+            EntryPC, DynamicDispatchSources);
     FactsBuilder.beginBlock(EntryPC, BlockInfo.BodyStartPC, BlockInfo.BodyEndPC,
                             EntryValues, BlockInfo.Successors,
-                            BlockInfo.Predecessors, HasReliableEntryStack);
+                            PotentialPredecessors, HasReliableEntryStack,
+                            PredecessorsComplete, PredecessorsAreStatic);
 
     if (!HasReliableEntryStack) {
       continue;
@@ -430,6 +442,8 @@ struct MemoryFactBlockSpec {
   std::vector<uint64_t> Successors;
   std::vector<uint64_t> Predecessors;
   bool HasCompleteOpcodeFacts = true;
+  bool PredecessorsComplete = true;
+  bool PredecessorsAreStatic = true;
 };
 
 COMPILER::MemoryFacts
@@ -438,9 +452,10 @@ collectManualBlockMemoryFacts(const std::vector<uint8_t> &Bytecode,
   COMPILER::MemoryFactsBuilder FactsBuilder;
   const uint8_t *Data = Bytecode.empty() ? nullptr : Bytecode.data();
   for (const MemoryFactBlockSpec &Block : Blocks) {
-    FactsBuilder.beginBlock(Block.EntryPC, Block.BodyStartPC, Block.BodyEndPC,
-                            {}, Block.Successors, Block.Predecessors,
-                            Block.HasCompleteOpcodeFacts);
+    FactsBuilder.beginBlock(
+        Block.EntryPC, Block.BodyStartPC, Block.BodyEndPC, {}, Block.Successors,
+        Block.Predecessors, Block.HasCompleteOpcodeFacts,
+        Block.PredecessorsComplete, Block.PredecessorsAreStatic);
 
     if (!Block.HasCompleteOpcodeFacts) {
       continue;
@@ -479,6 +494,190 @@ TEST(EVMMemoryFactsBuilderTest, RecordsConstMStoreWriteInterval) {
   EXPECT_EQ(Op.Writes[0].Addr.Offset, 0x80);
   ASSERT_TRUE(Op.Writes[0].Size.Known);
   EXPECT_EQ(Op.Writes[0].Size.Value, 32u);
+}
+
+TEST(EVMMemoryFactsBuilderTest, SeparatesPlacementBaseAndLogicalSizeEffects) {
+  const std::vector<uint8_t> MStoreBytecode = {OP_PUSH1, 0x2a, OP_PUSH1, 0x80,
+                                               OP_MSTORE};
+  COMPILER::MemoryFacts MStoreFacts = collectMemoryFacts(MStoreBytecode);
+
+  ASSERT_EQ(MStoreFacts.Ops.size(), 1u);
+  const COMPILER::MemoryEffectSummary &MStore =
+      MStoreFacts.Ops[0].ObservableEffects;
+  EXPECT_EQ(MStore.StackPop, 2u);
+  EXPECT_EQ(MStore.StackPush, 0u);
+  EXPECT_TRUE(MStore.readsOrWritesMemory());
+  EXPECT_TRUE(MStore.mayGrowMemory());
+  EXPECT_TRUE(MStore.mayRebaseMemory());
+  EXPECT_TRUE(MStore.chargesDynamicGas());
+  EXPECT_TRUE(MStore.mayExhaustGas());
+  EXPECT_FALSE(MStore.requiresOrderToken());
+  EXPECT_TRUE(MStore.preservesLogicalSizeProof());
+  EXPECT_FALSE(MStore.preservesCachedMemoryBase());
+
+  COMPILER::MemoryFacts GasFacts = collectMemoryFacts({OP_GAS, OP_POP});
+  ASSERT_EQ(GasFacts.Ops.size(), 1u);
+  const COMPILER::MemoryEffectSummary &Gas = GasFacts.Ops[0].ObservableEffects;
+  EXPECT_TRUE(Gas.observesGas());
+  EXPECT_TRUE(Gas.requiresOrderToken());
+  EXPECT_TRUE(Gas.preservesLogicalSizeProof());
+  EXPECT_TRUE(Gas.preservesCachedMemoryBase());
+
+  COMPILER::MemoryFacts MSizeFacts = collectMemoryFacts({OP_MSIZE, OP_POP});
+  ASSERT_EQ(MSizeFacts.Ops.size(), 1u);
+  const COMPILER::MemoryEffectSummary &MSize =
+      MSizeFacts.Ops[0].ObservableEffects;
+  EXPECT_TRUE(MSize.observesMemorySize());
+  EXPECT_TRUE(MSize.requiresOrderToken());
+  EXPECT_TRUE(MSize.preservesLogicalSizeProof());
+  EXPECT_TRUE(MSize.preservesCachedMemoryBase());
+}
+
+TEST(EVMMemoryFactsBuilderTest, RecordsDynamicGasOpcodesAsOrderEffects) {
+  const evmc_opcode Opcodes[] = {OP_EXP, OP_BALANCE, OP_EXTCODESIZE,
+                                 OP_EXTCODEHASH, OP_SLOAD};
+  for (evmc_opcode Opcode : Opcodes) {
+    COMPILER::MemoryFacts Facts =
+        collectMemoryFacts({static_cast<uint8_t>(Opcode)});
+    ASSERT_EQ(Facts.Ops.size(), 1u) << static_cast<int>(Opcode);
+    const COMPILER::MemoryEffectSummary &Effect =
+        Facts.Ops[0].ObservableEffects;
+    EXPECT_TRUE(Effect.observesGas());
+    EXPECT_TRUE(Effect.chargesDynamicGas());
+    EXPECT_TRUE(Effect.mayExhaustGas());
+    EXPECT_TRUE(Effect.requiresOrderToken());
+    EXPECT_TRUE(Effect.mayTrapOrHalt());
+    EXPECT_TRUE(Effect.preservesLogicalSizeProof());
+  }
+}
+
+TEST(EVMMemoryFactsBuilderTest, RecordsSelfDestructGasAndTerminationEffects) {
+  COMPILER::MemoryFacts Facts = collectMemoryFacts({OP_SELFDESTRUCT});
+  ASSERT_EQ(Facts.Ops.size(), 1u);
+  const COMPILER::MemoryEffectSummary &Effect = Facts.Ops[0].ObservableEffects;
+  EXPECT_TRUE(Effect.observesGas());
+  EXPECT_TRUE(Effect.chargesDynamicGas());
+  EXPECT_TRUE(Effect.mayExhaustGas());
+  EXPECT_TRUE(Effect.requiresOrderToken());
+  EXPECT_TRUE(Effect.mayTrapOrHalt());
+  EXPECT_TRUE(Effect.terminatesFrame());
+}
+
+TEST(EVMMemoryFactsBuilderTest, TreatsPreForkCallOpcodesAsTerminatingBarriers) {
+  struct InvalidOpcodeCase {
+    evmc_opcode Opcode;
+    evmc_revision Revision;
+  };
+  const InvalidOpcodeCase Cases[] = {
+      {OP_DELEGATECALL, EVMC_FRONTIER},
+      {OP_STATICCALL, EVMC_SPURIOUS_DRAGON},
+  };
+
+  for (const InvalidOpcodeCase &Case : Cases) {
+    COMPILER::MemoryFacts Facts =
+        collectMemoryFacts({static_cast<uint8_t>(Case.Opcode)}, Case.Revision);
+    ASSERT_EQ(Facts.Ops.size(), 1u);
+    const COMPILER::MemoryOp &Op = Facts.Ops[0];
+    EXPECT_EQ(Op.Kind, COMPILER::MemoryOpKind::Other);
+    EXPECT_EQ(Op.Effect, COMPILER::MemoryEffect::Unknown);
+    EXPECT_TRUE(Op.ObservableEffects.requiresOrderToken());
+    EXPECT_TRUE(Op.ObservableEffects.mayTrapOrHalt());
+    EXPECT_TRUE(Op.ObservableEffects.terminatesFrame());
+    EXPECT_TRUE(Op.Reads.empty());
+    EXPECT_TRUE(Op.Writes.empty());
+  }
+}
+
+TEST(EVMRuntimeMemoryHelperContractTest,
+     SeparatesPreparedRangeAndExpansionHelperContracts) {
+  using COMPILER::RuntimeMemoryHelperId;
+  using COMPILER::RuntimeProofRequirementFlag;
+  const COMPILER::RuntimeMemoryHelperContract Copy =
+      COMPILER::getRuntimeMemoryHelperContract(
+          RuntimeMemoryHelperId::CodeCopyNoExpand);
+  EXPECT_TRUE(Copy.requires(RuntimeProofRequirementFlag::LogicalSize));
+  EXPECT_TRUE(Copy.requires(RuntimeProofRequirementFlag::AccessRange));
+  EXPECT_TRUE(Copy.requires(RuntimeProofRequirementFlag::DynamicGasCharged));
+  EXPECT_TRUE(Copy.Effects.has(COMPILER::MemoryEffectFlag::WritesMemory));
+  EXPECT_FALSE(Copy.Effects.mayGrowMemory());
+
+  const COMPILER::RuntimeMemoryHelperContract Expand =
+      COMPILER::getRuntimeMemoryHelperContract(
+          RuntimeMemoryHelperId::ExpandMemoryNoGas);
+  EXPECT_TRUE(Expand.requires(RuntimeProofRequirementFlag::DynamicGasCharged));
+  EXPECT_TRUE(Expand.requires(RuntimeProofRequirementFlag::BoundsValidated));
+  EXPECT_TRUE(Expand.EstablishesLogicalSize);
+  EXPECT_TRUE(Expand.Effects.mayGrowMemory());
+  EXPECT_TRUE(Expand.Effects.mayRebaseMemory());
+}
+
+TEST(EVMRuntimeMemoryHelperContractTest,
+     RecordsTwoWordKeccakDynamicGasAndFailureEffects) {
+  const COMPILER::RuntimeMemoryHelperContract Contract =
+      COMPILER::getRuntimeMemoryHelperContract(
+          COMPILER::RuntimeMemoryHelperId::TwoWordKeccakNoExpand);
+  EXPECT_TRUE(Contract.Valid);
+  EXPECT_TRUE(Contract.Effects.observesGas());
+  EXPECT_TRUE(Contract.Effects.chargesDynamicGas());
+  EXPECT_TRUE(Contract.Effects.mayExhaustGas());
+  EXPECT_TRUE(Contract.Effects.mayTrapOrHalt());
+  EXPECT_TRUE(Contract.Effects.requiresOrderToken());
+}
+
+TEST(EVMRuntimeMemoryHelperContractTest,
+     RequiresIndependentCallArgumentAndReturnProofs) {
+  using COMPILER::RuntimeMemoryHelperId;
+  using COMPILER::RuntimeProofRequirementFlag;
+  const COMPILER::RuntimeMemoryHelperContract Contract =
+      COMPILER::getRuntimeMemoryHelperContract(
+          RuntimeMemoryHelperId::CallNoExpand);
+  const RuntimeProofRequirementFlag Required[] = {
+      RuntimeProofRequirementFlag::LogicalSize,
+      RuntimeProofRequirementFlag::CallArgumentsRange,
+      RuntimeProofRequirementFlag::CallReturnRange,
+      RuntimeProofRequirementFlag::OrderToken,
+  };
+  EXPECT_TRUE(Contract.Valid);
+  for (RuntimeProofRequirementFlag Missing : Required) {
+    COMPILER::RuntimeProofToken Incomplete;
+    for (RuntimeProofRequirementFlag Requirement : Required) {
+      if (Requirement != Missing) {
+        Incomplete.establish(Requirement);
+      }
+    }
+    EXPECT_FALSE(
+        COMPILER::satisfiesRuntimeMemoryHelperContract(Contract, Incomplete));
+  }
+}
+
+TEST(EVMRuntimeMemoryHelperContractTest,
+     RejectsSelectionsMissingAnyPreparedHelperRequirement) {
+  using COMPILER::RuntimeMemoryHelperId;
+  using COMPILER::RuntimeProofRequirementFlag;
+  const COMPILER::RuntimeMemoryHelperContract Contract =
+      COMPILER::getRuntimeMemoryHelperContract(
+          RuntimeMemoryHelperId::CallDataCopyNoExpand);
+  const RuntimeProofRequirementFlag Required[] = {
+      RuntimeProofRequirementFlag::LogicalSize,
+      RuntimeProofRequirementFlag::AccessRange,
+      RuntimeProofRequirementFlag::DynamicGasCharged,
+  };
+  COMPILER::RuntimeProofToken Complete;
+  for (RuntimeProofRequirementFlag Requirement : Required) {
+    Complete.establish(Requirement);
+  }
+  EXPECT_TRUE(
+      COMPILER::satisfiesRuntimeMemoryHelperContract(Contract, Complete));
+  for (RuntimeProofRequirementFlag Missing : Required) {
+    COMPILER::RuntimeProofToken Incomplete;
+    for (RuntimeProofRequirementFlag Requirement : Required) {
+      if (Requirement != Missing) {
+        Incomplete.establish(Requirement);
+      }
+    }
+    EXPECT_FALSE(
+        COMPILER::satisfiesRuntimeMemoryHelperContract(Contract, Incomplete));
+  }
 }
 
 TEST(EVMMemoryFactsBuilderTest, AttributesOpsToAnalyzerBlocks) {
@@ -632,6 +831,42 @@ TEST(EVMMemoryGuaranteedMinBytesAnalysisTest, RejectedMergeKeepsMinimumZero) {
   EXPECT_EQ(Guaranteed.getGuaranteedMinBytesAtEntry(14), 0u);
 }
 
+TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
+     DynamicDispatchPredecessorPreventsStaticPathProof) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH0,    OP_CALLDATALOAD,
+                                         OP_PUSH1,    0x09,
+                                         OP_JUMPI,    OP_PUSH1,
+                                         0x20,        OP_CALLDATALOAD,
+                                         OP_JUMP,     OP_JUMPDEST,
+                                         OP_PUSH1,    0x01,
+                                         OP_PUSH1,    0x00,
+                                         OP_MSTORE,   OP_PUSH1,
+                                         0x12,        OP_JUMP,
+                                         OP_JUMPDEST, OP_PUSH1,
+                                         0x00,        OP_MLOAD,
+                                         OP_STOP};
+  COMPILER::MemoryFacts Facts = collectAnalyzerMemoryFacts(Bytecode);
+  const COMPILER::MemoryBlockFacts *Target = Facts.getBlock(18);
+  ASSERT_NE(Target, nullptr);
+  EXPECT_EQ(Target->Predecessors, std::vector<uint64_t>({9, 5}));
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Guaranteed(Facts);
+  EXPECT_EQ(Guaranteed.getGuaranteedMinBytesAtEntry(18), 0u);
+}
+
+TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
+     IncompleteDynamicDispatchPredecessorsDropProof) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1,    0x01,     OP_PUSH1,    0x00,     OP_MSTORE, OP_PUSH1,
+      0x0c,        OP_JUMP,  OP_JUMPDEST, OP_JUMP,  OP_STOP,   OP_STOP,
+      OP_JUMPDEST, OP_PUSH1, 0x00,        OP_MLOAD, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectAnalyzerMemoryFacts(Bytecode);
+  const COMPILER::MemoryBlockFacts *Target = Facts.getBlock(12);
+  ASSERT_NE(Target, nullptr);
+  EXPECT_FALSE(Target->PredecessorsComplete);
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Guaranteed(Facts);
+  EXPECT_EQ(Guaranteed.getGuaranteedMinBytesAtEntry(12), 0u);
+}
+
 TEST(EVMMemoryGuaranteedMinBytesAnalysisTest, RecordsGuaranteeBeforeEachOp) {
   const std::vector<uint8_t> Bytecode = {
       OP_PUSH1, 0x01, OP_PUSH1, 0x80, OP_MSTORE, OP_PUSH1, 0x40, OP_MLOAD};
@@ -644,8 +879,40 @@ TEST(EVMMemoryGuaranteedMinBytesAnalysisTest, RecordsGuaranteeBeforeEachOp) {
   EXPECT_EQ(Guaranteed.getGuaranteedMinBytesBeforeOp(Facts.Ops[1].Id), 0xa0u);
 }
 
+TEST(EVMMemoryProofLifetimeAnalysisTest,
+     ReusesRangeButRejectsExpansionMotionAcrossGas) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,     OP_PUSH1, 0x80,     OP_MSTORE, OP_GAS,
+      OP_POP,   OP_PUSH1, 0x80,     OP_MLOAD, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  COMPILER::MemoryProofLifetimeAnalysis Lifetime(Facts);
+  ASSERT_EQ(Facts.Ops.size(), 3u);
+  const COMPILER::MemoryProofAvailability Proof =
+      Lifetime.queryBeforeOp(Facts.Ops[2].Id, Facts.Ops[2].Reads[0]);
+  EXPECT_EQ(Proof.GuaranteedMinBytes, 0xa0u);
+  EXPECT_TRUE(Proof.canReuseWithoutExpansion());
+  EXPECT_FALSE(
+      Lifetime.canMoveExpansionBetween(Facts.Ops[0].Id, Facts.Ops[2].Id));
+}
+
+TEST(EVMMemoryProofLifetimeAnalysisTest,
+     ReusesRangeButRejectsExpansionMotionAcrossMSize) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,     OP_PUSH1, 0x40,     OP_MSTORE, OP_MSIZE,
+      OP_POP,   OP_PUSH1, 0x40,     OP_MLOAD, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  COMPILER::MemoryProofLifetimeAnalysis Lifetime(Facts);
+  ASSERT_EQ(Facts.Ops.size(), 3u);
+  const COMPILER::MemoryProofAvailability Proof =
+      Lifetime.queryBeforeOp(Facts.Ops[2].Id, Facts.Ops[2].Reads[0]);
+  EXPECT_EQ(Proof.GuaranteedMinBytes, 0x60u);
+  EXPECT_TRUE(Proof.canReuseWithoutExpansion());
+  EXPECT_FALSE(
+      Lifetime.canMoveExpansionBetween(Facts.Ops[0].Id, Facts.Ops[2].Id));
+}
+
 TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
-     DoesNotLearnNewGuaranteesAfterBarrier) {
+     ContinuesLearningLogicalExtentAcrossGasObserver) {
   const std::vector<uint8_t> Bytecode = {
       OP_PUSH1, 0x01,     OP_PUSH1, 0x00,      OP_MSTORE, OP_GAS, OP_PUSH1,
       0x02,     OP_PUSH1, 0x80,     OP_MSTORE, OP_PUSH1,  0x80,   OP_MLOAD};
@@ -654,7 +921,7 @@ TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
   COMPILER::MemoryGuaranteedMinBytesAnalysis Guaranteed(Facts);
 
   ASSERT_EQ(Facts.Ops.size(), 4u);
-  EXPECT_EQ(Guaranteed.getGuaranteedMinBytesBeforeOp(Facts.Ops[3].Id), 32u);
+  EXPECT_EQ(Guaranteed.getGuaranteedMinBytesBeforeOp(Facts.Ops[3].Id), 0xa0u);
 }
 
 TEST(EVMMemoryGuaranteedMinBytesAnalysisTest, LearnsConstMCopyUnionEnd) {
@@ -2587,6 +2854,37 @@ class DynamicPushMockEVMBuilder : public MockEVMBuilder {
 public:
   Operand handlePush(const zen::common::Bytes &) { return Operand(); }
 };
+
+class MemoryFactsCapturingBuilder : public MockEVMBuilder {
+public:
+  void setMemoryFacts(const COMPILER::MemoryFacts &Facts) {
+    CapturedFacts = Facts;
+  }
+
+  COMPILER::MemoryFacts CapturedFacts;
+};
+
+TEST(EVMJITFrontendVisitorTest, UsesActiveRevisionForMemoryEffectFacts) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH0, OP_PUSH0, OP_PUSH0, OP_MCOPY,
+                                         OP_STOP};
+
+  COMPILER::EVMFrontendContext Ctx;
+  Ctx.setRevision(EVMC_SHANGHAI);
+  Ctx.setBytecode(reinterpret_cast<const zen::common::Byte *>(Bytecode.data()),
+                  Bytecode.size());
+
+  MemoryFactsCapturingBuilder Builder;
+  COMPILER::EVMByteCodeVisitor<MemoryFactsCapturingBuilder> Visitor(Builder,
+                                                                    &Ctx);
+  EXPECT_TRUE(Visitor.compile());
+  ASSERT_EQ(Builder.CapturedFacts.Ops.size(), 1u);
+  const COMPILER::MemoryOp &Op = Builder.CapturedFacts.Ops[0];
+  EXPECT_EQ(Op.Opcode, OP_MCOPY);
+  EXPECT_EQ(Op.Kind, COMPILER::MemoryOpKind::Other);
+  EXPECT_EQ(Op.Effect, COMPILER::MemoryEffect::Unknown);
+  EXPECT_TRUE(Op.ObservableEffects.mayTrapOrHalt());
+  EXPECT_TRUE(Op.ObservableEffects.terminatesFrame());
+}
 
 TEST(EVMMirBuilderConstFoldTest, ExpFoldsConstantOperands) {
   MirBuilderConstFoldHarness Harness;

--- a/src/tests/evm_jit_frontend_tests.cpp
+++ b/src/tests/evm_jit_frontend_tests.cpp
@@ -30,6 +30,25 @@
 #include <string>
 #include <vector>
 
+namespace COMPILER {
+
+struct MemoryExpansionPlannerTestPeer {
+  static bool hasLinearRegions(const MemoryExpansionPlanner &Planner) {
+    return Planner.LinearRegions != nullptr;
+  }
+  static bool hasGuaranteedExtent(const MemoryExpansionPlanner &Planner) {
+    return Planner.GuaranteedExtent != nullptr;
+  }
+  static bool hasDeadStores(const MemoryExpansionPlanner &Planner) {
+    return Planner.DeadStores != nullptr;
+  }
+  static bool hasLoadForwarding(const MemoryExpansionPlanner &Planner) {
+    return Planner.LoadForwarding != nullptr;
+  }
+};
+
+} // namespace COMPILER
+
 namespace {
 
 using COMPILER::EVMAnalyzer;
@@ -370,6 +389,7 @@ std::vector<uint8_t> makeLargeStaticDynamicOffsetMStoreBlock(uint64_t Ops) {
 COMPILER::MemoryFacts collectMemoryFacts(const std::vector<uint8_t> &Bytecode,
                                          evmc_revision Revision = EVMC_CANCUN) {
   COMPILER::MemoryFactsBuilder FactsBuilder(Revision);
+  FactsBuilder.reset(Bytecode.size());
   FactsBuilder.beginBlock(0, 0);
 
   size_t PC = 0;
@@ -392,6 +412,7 @@ collectAnalyzerMemoryFacts(const std::vector<uint8_t> &Bytecode) {
   COMPILER::MemoryEntryAddressAnalysis EntryAddresses(Analyzer, Data,
                                                       Bytecode.size());
   COMPILER::MemoryFactsBuilder FactsBuilder(EVMC_CANCUN);
+  FactsBuilder.reset(Bytecode.size());
   const std::vector<uint64_t> DynamicDispatchSources =
       Analyzer.getDynamicJumpDispatchSourceBlocks();
   const auto &Blocks = Analyzer.getBlockInfos();
@@ -450,6 +471,7 @@ COMPILER::MemoryFacts
 collectManualBlockMemoryFacts(const std::vector<uint8_t> &Bytecode,
                               const std::vector<MemoryFactBlockSpec> &Blocks) {
   COMPILER::MemoryFactsBuilder FactsBuilder;
+  FactsBuilder.reset(Bytecode.size());
   const uint8_t *Data = Bytecode.empty() ? nullptr : Bytecode.data();
   for (const MemoryFactBlockSpec &Block : Blocks) {
     FactsBuilder.beginBlock(
@@ -848,7 +870,7 @@ TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
   COMPILER::MemoryFacts Facts = collectAnalyzerMemoryFacts(Bytecode);
   const COMPILER::MemoryBlockFacts *Target = Facts.getBlock(18);
   ASSERT_NE(Target, nullptr);
-  EXPECT_EQ(Target->Predecessors, std::vector<uint64_t>({9, 5}));
+  EXPECT_EQ(Target->Predecessors, std::vector<uint64_t>({5, 9}));
   COMPILER::MemoryGuaranteedMinBytesAnalysis Guaranteed(Facts);
   EXPECT_EQ(Guaranteed.getGuaranteedMinBytesAtEntry(18), 0u);
 }
@@ -909,6 +931,376 @@ TEST(EVMMemoryProofLifetimeAnalysisTest,
   EXPECT_TRUE(Proof.canReuseWithoutExpansion());
   EXPECT_FALSE(
       Lifetime.canMoveExpansionBetween(Facts.Ops[0].Id, Facts.Ops[2].Id));
+}
+
+TEST(EVMMemoryProofLifetimeAnalysisTest, CachesCompletedDemandQuery) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,        OP_PUSH1, 0x00, OP_MSTORE, OP_PUSH1, 0x08,
+      OP_JUMP,  OP_JUMPDEST, OP_PUSH1, 0x00, OP_MLOAD,  OP_STOP};
+  COMPILER::MemoryFacts Facts = collectAnalyzerMemoryFacts(Bytecode);
+  COMPILER::MemoryProofLifetimeAnalysis Lifetime(Facts);
+
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+  EXPECT_TRUE(Lifetime.queryBeforeOp(Facts.Ops[1].Id, Facts.Ops[1].Reads[0])
+                  .canReuseWithoutExpansion());
+  const COMPILER::MemoryExtentOracleStats AfterFirst =
+      Lifetime.getExtentOracleStats();
+  EXPECT_EQ(AfterFirst.QueryCount, 1u);
+  EXPECT_EQ(AfterFirst.QueryCacheHits, 0u);
+  EXPECT_GT(AfterFirst.BlockVisits, 0u);
+
+  EXPECT_TRUE(Lifetime.queryBeforeOp(Facts.Ops[1].Id, Facts.Ops[1].Reads[0])
+                  .canReuseWithoutExpansion());
+  const COMPILER::MemoryExtentOracleStats AfterSecond =
+      Lifetime.getExtentOracleStats();
+  EXPECT_EQ(AfterSecond.QueryCacheHits, 1u);
+  EXPECT_EQ(AfterSecond.BlockVisits, AfterFirst.BlockVisits);
+  EXPECT_EQ(AfterSecond.OpVisits, AfterFirst.OpVisits);
+}
+
+TEST(EVMMemoryProofLifetimeAnalysisTest,
+     FailsClosedAtPerQueryBudgetWithoutPublishingPartialCache) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,        OP_PUSH1, 0x00, OP_MSTORE, OP_PUSH1, 0x08,
+      OP_JUMP,  OP_JUMPDEST, OP_PUSH1, 0x00, OP_MLOAD,  OP_STOP};
+  COMPILER::MemoryFacts Facts = collectAnalyzerMemoryFacts(Bytecode);
+  COMPILER::MemoryProofQueryBudget Budget;
+  Budget.MaxBlockVisits = 1;
+  Budget.MaxOpVisits = 1;
+  COMPILER::MemoryProofLifetimeAnalysis Lifetime(Facts, Budget);
+
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+  EXPECT_FALSE(Lifetime.queryBeforeOp(Facts.Ops[1].Id, Facts.Ops[1].Reads[0])
+                   .canReuseWithoutExpansion());
+  EXPECT_FALSE(Lifetime.queryBeforeOp(Facts.Ops[1].Id, Facts.Ops[1].Reads[0])
+                   .canReuseWithoutExpansion());
+  const COMPILER::MemoryExtentOracleStats Stats =
+      Lifetime.getExtentOracleStats();
+  EXPECT_EQ(Stats.BudgetExhaustions, 2u);
+  EXPECT_EQ(Stats.QueryCacheHits, 0u);
+  EXPECT_EQ(Stats.DemandComputations, 2u);
+}
+
+TEST(EVMMemoryGuaranteedExtentOracleTest,
+     EnforcesCompilationWideBudgetAcrossDistinctQueries) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,     OP_PUSH1, 0x00,      OP_MSTORE,   OP_STOP,
+      OP_STOP,  OP_STOP,  OP_STOP,  OP_STOP,   OP_JUMPDEST, OP_PUSH1,
+      0x02,     OP_PUSH1, 0x20,     OP_MSTORE, OP_STOP};
+  const std::vector<MemoryFactBlockSpec> Blocks = {
+      {.EntryPC = 0,
+       .BodyStartPC = 0,
+       .BodyEndPC = 6,
+       .Successors = {},
+       .Predecessors = {},
+       .PredecessorsComplete = true},
+      {.EntryPC = 10,
+       .BodyStartPC = 11,
+       .BodyEndPC = 17,
+       .Successors = {},
+       .Predecessors = {},
+       .PredecessorsComplete = true}};
+  COMPILER::MemoryFacts Facts = collectManualBlockMemoryFacts(Bytecode, Blocks);
+  COMPILER::MemoryProofQueryBudget Budget;
+  Budget.MaxBlockVisits = 4;
+  Budget.MaxOpVisits = 4;
+  Budget.MaxCompilationBlockVisits = 1;
+  Budget.MaxCompilationOpVisits = 4;
+  COMPILER::MemoryGuaranteedExtentOracle Oracle(Facts, Budget);
+
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+  EXPECT_TRUE(Oracle.queryBeforeOp(Facts.Ops[0].Id).available());
+  const COMPILER::MemoryExtentQueryResult Second =
+      Oracle.queryBeforeOp(Facts.Ops[1].Id);
+  EXPECT_EQ(Second.Status,
+            COMPILER::MemoryExtentQueryStatus::CompilationBudgetExhausted);
+  EXPECT_EQ(Oracle.getStats().CompilationBudgetExhaustions, 1u);
+}
+
+TEST(EVMMemoryGuaranteedExtentOracleTest, HonorsExactQueryBudgetBoundary) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,        OP_PUSH1, 0x00, OP_MSTORE, OP_PUSH1, 0x08,
+      OP_JUMP,  OP_JUMPDEST, OP_PUSH1, 0x00, OP_MLOAD,  OP_STOP};
+  COMPILER::MemoryFacts Facts = collectAnalyzerMemoryFacts(Bytecode);
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+
+  COMPILER::MemoryProofQueryBudget Exact;
+  Exact.MaxBlockVisits = 2;
+  Exact.MaxOpVisits = 2;
+  COMPILER::MemoryGuaranteedExtentOracle ExactOracle(Facts, Exact);
+  EXPECT_TRUE(ExactOracle.queryBeforeOp(Facts.Ops[1].Id).available());
+  EXPECT_EQ(ExactOracle.getStats().BlockVisits, 2u);
+  EXPECT_EQ(ExactOracle.getStats().OpVisits, 2u);
+  EXPECT_EQ(ExactOracle.getStats().EdgeVisits, 1u);
+
+  COMPILER::MemoryProofQueryBudget TooSmall = Exact;
+  TooSmall.MaxBlockVisits = 1;
+  COMPILER::MemoryGuaranteedExtentOracle SmallOracle(Facts, TooSmall);
+  EXPECT_EQ(SmallOracle.queryBeforeOp(Facts.Ops[1].Id).Status,
+            COMPILER::MemoryExtentQueryStatus::BudgetExhausted);
+}
+
+TEST(EVMMemoryGuaranteedExtentOracleTest,
+     FailsClosedForIncompleteOrDynamicPredecessors) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,    OP_PUSH1, 0x00,     OP_MSTORE, OP_STOP,  OP_STOP,
+      OP_STOP,  OP_STOP, OP_STOP,  OP_PUSH1, 0x00,      OP_MLOAD, OP_STOP};
+  const std::vector<MemoryFactBlockSpec> Blocks = {
+      {.EntryPC = 0,
+       .BodyStartPC = 0,
+       .BodyEndPC = 6,
+       .Successors = {10},
+       .Predecessors = {}},
+      {.EntryPC = 10,
+       .BodyStartPC = 10,
+       .BodyEndPC = 14,
+       .Successors = {},
+       .Predecessors = {0},
+       .PredecessorsComplete = false,
+       .PredecessorsAreStatic = false}};
+  COMPILER::MemoryFacts Facts = collectManualBlockMemoryFacts(Bytecode, Blocks);
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+  COMPILER::MemoryGuaranteedExtentOracle Oracle(Facts);
+
+  EXPECT_EQ(Oracle.queryBeforeOp(Facts.Ops[1].Id).Status,
+            COMPILER::MemoryExtentQueryStatus::IncompleteCFG);
+  EXPECT_EQ(Oracle.getStats().QueryCacheHits, 0u);
+  EXPECT_EQ(Oracle.getStats().IncompleteCFGRejects, 1u);
+}
+
+TEST(EVMMemoryGuaranteedExtentOracleTest, FailsClosedForStaticCycle) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_STOP,  OP_STOP, OP_STOP,   OP_STOP, OP_STOP,  OP_STOP,
+      OP_STOP,  OP_STOP, OP_STOP,   OP_STOP, OP_PUSH1, 0x01,
+      OP_PUSH1, 0x00,    OP_MSTORE, OP_STOP, OP_STOP,  OP_STOP,
+      OP_STOP,  OP_STOP, OP_PUSH1,  0x00,    OP_MLOAD, OP_STOP};
+  const std::vector<MemoryFactBlockSpec> Blocks = {{.EntryPC = 10,
+                                                    .BodyStartPC = 10,
+                                                    .BodyEndPC = 16,
+                                                    .Successors = {20},
+                                                    .Predecessors = {20}},
+                                                   {.EntryPC = 20,
+                                                    .BodyStartPC = 20,
+                                                    .BodyEndPC = 24,
+                                                    .Successors = {10},
+                                                    .Predecessors = {10}}};
+  COMPILER::MemoryFacts Facts = collectManualBlockMemoryFacts(Bytecode, Blocks);
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+  COMPILER::MemoryGuaranteedExtentOracle Oracle(Facts);
+
+  EXPECT_EQ(Oracle.queryBeforeOp(Facts.Ops[1].Id).Status,
+            COMPILER::MemoryExtentQueryStatus::Cycle);
+  EXPECT_EQ(Oracle.getStats().CycleCutoffs, 1u);
+  EXPECT_EQ(Oracle.getStats().QueryCacheHits, 0u);
+}
+
+TEST(EVMMemoryGuaranteedExtentOracleTest,
+     NeverExceedsEagerResultOnCompleteDag) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,        OP_PUSH1, 0x00, OP_MSTORE, OP_PUSH1, 0x08,
+      OP_JUMP,  OP_JUMPDEST, OP_PUSH1, 0x00, OP_MLOAD,  OP_STOP};
+  COMPILER::MemoryFacts Facts = collectAnalyzerMemoryFacts(Bytecode);
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Eager(Facts);
+  ASSERT_TRUE(Eager.isComplete());
+  COMPILER::MemoryGuaranteedExtentOracle Oracle(Facts);
+
+  for (const COMPILER::MemoryOp &Op : Facts.Ops) {
+    const COMPILER::MemoryExtentQueryResult Demand =
+        Oracle.queryBeforeOp(Op.Id);
+    ASSERT_TRUE(Demand.available());
+    EXPECT_LE(Demand.GuaranteedMinBytes,
+              Eager.getGuaranteedMinBytesBeforeOp(Op.Id));
+  }
+}
+
+TEST(EVMMemoryGuaranteedExtentOracleTest,
+     BoundsPredecessorEdgesAndDoesNotPublishPartialQueryState) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1,  0x01,    OP_PUSH1, 0x00,     OP_MSTORE, OP_STOP,  OP_STOP,
+      OP_STOP,   OP_STOP, OP_STOP,  OP_PUSH1, 0x02,      OP_PUSH1, 0x20,
+      OP_MSTORE, OP_STOP, OP_STOP,  OP_STOP,  OP_STOP,   OP_STOP,  OP_JUMPDEST,
+      OP_PUSH1,  0x00,    OP_MLOAD, OP_STOP};
+  const std::vector<MemoryFactBlockSpec> Blocks = {
+      {.EntryPC = 0,
+       .BodyStartPC = 0,
+       .BodyEndPC = 6,
+       .Successors = {20},
+       .Predecessors = {}},
+      {.EntryPC = 10,
+       .BodyStartPC = 10,
+       .BodyEndPC = 16,
+       .Successors = {20},
+       .Predecessors = {}},
+      {.EntryPC = 20,
+       .BodyStartPC = 21,
+       .BodyEndPC = 25,
+       .Successors = {},
+       .Predecessors = {10, 0, 10}}};
+  COMPILER::MemoryFacts Facts = collectManualBlockMemoryFacts(Bytecode, Blocks);
+  ASSERT_EQ(Facts.Ops.size(), 3u);
+  ASSERT_EQ(Facts.getBlock(20)->Predecessors, (std::vector<uint64_t>{0, 10}));
+  COMPILER::MemoryProofQueryBudget Budget;
+  Budget.MaxBlockVisits = 8;
+  Budget.MaxOpVisits = 8;
+  Budget.MaxEdgeVisits = 1;
+  COMPILER::MemoryGuaranteedExtentOracle Oracle(Facts, Budget);
+
+  EXPECT_EQ(Oracle.queryBeforeOp(Facts.Ops[2].Id).Status,
+            COMPILER::MemoryExtentQueryStatus::BudgetExhausted);
+  EXPECT_EQ(Oracle.getStats().EdgeVisits, 1u);
+  EXPECT_EQ(Oracle.getStats().QueryCacheHits, 0u);
+
+  EXPECT_TRUE(Oracle.queryBeforeOp(Facts.Ops[0].Id).available());
+  EXPECT_EQ(Oracle.getStats().QueryCacheHits, 0u);
+  EXPECT_EQ(Oracle.getStats().DemandComputations, 2u);
+}
+
+TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
+     BoundedRunPublishesOnlyCompleteResults) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH1, 0x01,      OP_PUSH1,
+                                         0x80,     OP_MSTORE, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  COMPILER::MemoryGlobalAnalysisBudget Budget;
+  Budget.MaxBlockTransfers = 0;
+  Budget.MaxOpVisits = 0;
+
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Analysis(Facts, Budget);
+
+  EXPECT_FALSE(Analysis.isComplete());
+  EXPECT_EQ(Analysis.getGuaranteedMinBytesAtEntry(0), 0u);
+  EXPECT_EQ(Analysis.getGuaranteedMinBytesBeforeOp(Facts.Ops.front().Id), 0u);
+  EXPECT_EQ(Analysis.getStats().BudgetExhaustions, 1u);
+}
+
+TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
+     CountsDependencyPropagationAtExactEdgeBudgetBoundary) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,    OP_PUSH1, 0x00,     OP_MSTORE, OP_STOP,  OP_STOP,
+      OP_STOP,  OP_STOP, OP_STOP,  OP_PUSH1, 0x00,      OP_MLOAD, OP_STOP};
+  const std::vector<MemoryFactBlockSpec> Blocks = {{.EntryPC = 0,
+                                                    .BodyStartPC = 0,
+                                                    .BodyEndPC = 6,
+                                                    .Successors = {10},
+                                                    .Predecessors = {}},
+                                                   {.EntryPC = 10,
+                                                    .BodyStartPC = 10,
+                                                    .BodyEndPC = 14,
+                                                    .Successors = {},
+                                                    .Predecessors = {0}}};
+  COMPILER::MemoryFacts Facts = collectManualBlockMemoryFacts(Bytecode, Blocks);
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+
+  COMPILER::MemoryGlobalAnalysisBudget TooSmall;
+  TooSmall.MaxEdgeVisits = 3;
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Rejected(Facts, TooSmall);
+  EXPECT_FALSE(Rejected.isComplete());
+  EXPECT_EQ(Rejected.getStats().EdgeVisits, 3u);
+  EXPECT_EQ(Rejected.getStats().BudgetExhaustions, 1u);
+
+  COMPILER::MemoryGlobalAnalysisBudget Exact;
+  Exact.MaxEdgeVisits = 4;
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Accepted(Facts, Exact);
+  EXPECT_TRUE(Accepted.isComplete());
+  EXPECT_EQ(Accepted.getStats().EdgeVisits, 4u);
+  EXPECT_EQ(Accepted.getStats().BudgetExhaustions, 0u);
+  EXPECT_EQ(Accepted.getGuaranteedMinBytesBeforeOp(Facts.Ops[1].Id), 0x20u);
+}
+
+TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
+     CountsRepeatedDependencyPropagationAcrossStaticBackedge) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,    OP_PUSH1,  0x00,    OP_MSTORE, OP_STOP,
+      OP_STOP,  OP_STOP, OP_STOP,   OP_STOP, OP_PUSH1,  0x02,
+      OP_PUSH1, 0x20,    OP_MSTORE, OP_STOP, OP_STOP,   OP_STOP,
+      OP_STOP,  OP_STOP, OP_PUSH1,  0x00,    OP_MLOAD,  OP_STOP};
+  const std::vector<MemoryFactBlockSpec> Blocks = {{.EntryPC = 0,
+                                                    .BodyStartPC = 0,
+                                                    .BodyEndPC = 6,
+                                                    .Successors = {10},
+                                                    .Predecessors = {}},
+                                                   {.EntryPC = 10,
+                                                    .BodyStartPC = 10,
+                                                    .BodyEndPC = 16,
+                                                    .Successors = {20},
+                                                    .Predecessors = {0, 20}},
+                                                   {.EntryPC = 20,
+                                                    .BodyStartPC = 20,
+                                                    .BodyEndPC = 24,
+                                                    .Successors = {10},
+                                                    .Predecessors = {10}}};
+  COMPILER::MemoryFacts Facts = collectManualBlockMemoryFacts(Bytecode, Blocks);
+  ASSERT_EQ(Facts.Ops.size(), 3u);
+
+  COMPILER::MemoryGlobalAnalysisBudget TooSmall;
+  TooSmall.MaxEdgeVisits = 13;
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Rejected(Facts, TooSmall);
+  EXPECT_FALSE(Rejected.isComplete());
+  EXPECT_EQ(Rejected.getStats().EdgeVisits, 13u);
+  EXPECT_EQ(Rejected.getStats().BudgetExhaustions, 1u);
+
+  COMPILER::MemoryGlobalAnalysisBudget Exact;
+  Exact.MaxEdgeVisits = 14;
+  COMPILER::MemoryGuaranteedMinBytesAnalysis Accepted(Facts, Exact);
+  EXPECT_TRUE(Accepted.isComplete());
+  EXPECT_EQ(Accepted.getStats().EdgeVisits, 14u);
+  EXPECT_EQ(Accepted.getStats().BudgetExhaustions, 0u);
+  EXPECT_EQ(Accepted.getGuaranteedMinBytesBeforeOp(Facts.Ops[2].Id), 0x40u);
+}
+
+TEST(EVMMemoryGuaranteedExtentOracleTest,
+     DefersPromotionUntilNextUncachedQuery) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,     OP_PUSH1,  0x40,      OP_MSTORE, OP_PUSH1,
+      0x02,     OP_PUSH1, 0x80,      OP_MSTORE, OP_PUSH1,  0x03,
+      OP_PUSH1, 0xc0,     OP_MSTORE, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  ASSERT_EQ(Facts.Ops.size(), 3u);
+  COMPILER::MemoryProofPromotionPolicy Promotion;
+  Promotion.Enabled = true;
+  Promotion.DemandComputationThreshold = 1;
+  Promotion.DemandWorkMultiplier = 0;
+  COMPILER::MemoryGuaranteedExtentOracle Oracle(Facts, {}, Promotion);
+
+  EXPECT_TRUE(Oracle.queryBeforeOp(Facts.Ops[0].Id).available());
+  EXPECT_EQ(Oracle.getStats().PromotionSchedules, 1u);
+  EXPECT_EQ(Oracle.getStats().GlobalPromotionAttempts, 0u);
+  EXPECT_EQ(Oracle.getStats().PromotionPending, 1u);
+
+  EXPECT_TRUE(Oracle.queryBeforeOp(Facts.Ops[0].Id).available());
+  EXPECT_EQ(Oracle.getStats().GlobalPromotionAttempts, 0u);
+  EXPECT_EQ(Oracle.getStats().PromotionPending, 1u);
+
+  const COMPILER::MemoryExtentQueryResult Second =
+      Oracle.queryBeforeOp(Facts.Ops[1].Id);
+  EXPECT_TRUE(Second.available());
+  EXPECT_EQ(Second.GuaranteedMinBytes, 0x60u);
+  EXPECT_EQ(Oracle.getStats().GlobalPromotionAttempts, 1u);
+  EXPECT_EQ(Oracle.getStats().GlobalPromotions, 1u);
+  EXPECT_EQ(Oracle.getStats().PromotionPending, 0u);
+}
+
+TEST(EVMMemoryGuaranteedExtentOracleTest,
+     FailedPromotionDoesNotPublishGlobalResults) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,     OP_PUSH1, 0x40,      OP_MSTORE, OP_PUSH1,
+      0x02,     OP_PUSH1, 0x80,     OP_MSTORE, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+  COMPILER::MemoryProofPromotionPolicy Promotion;
+  Promotion.Enabled = true;
+  Promotion.DemandComputationThreshold = 1;
+  Promotion.DemandWorkMultiplier = 0;
+  Promotion.MaxGlobalBlockTransfers = 0;
+  Promotion.MaxGlobalOpVisits = 0;
+  COMPILER::MemoryGuaranteedExtentOracle Oracle(Facts, {}, Promotion);
+
+  EXPECT_TRUE(Oracle.queryBeforeOp(Facts.Ops[0].Id).available());
+  EXPECT_TRUE(Oracle.queryBeforeOp(Facts.Ops[1].Id).available());
+  EXPECT_EQ(Oracle.getStats().GlobalPromotionAttempts, 1u);
+  EXPECT_EQ(Oracle.getStats().GlobalPromotions, 0u);
+  EXPECT_EQ(Oracle.getStats().GlobalBudgetExhaustions, 1u);
+  EXPECT_TRUE(Oracle.queryBeforeOp(Facts.Ops[0].Id).available());
+  EXPECT_EQ(Oracle.getStats().GlobalPromotionAttempts, 1u);
 }
 
 TEST(EVMMemoryGuaranteedMinBytesAnalysisTest,
@@ -1617,6 +2009,27 @@ TEST(EVMMemoryPrecheckConsumerTest,
   EXPECT_EQ(EndOffset, 0xc0u);
 }
 
+TEST(EVMMemoryPrecheckConsumerTest,
+     RestrictsBlockPrecheckToIndexedOperationSpan) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01, OP_PUSH1, 0x00, OP_MSTORE,
+      OP_PUSH1, 0x02, OP_PUSH1, 0x20, OP_MSTORE,
+      OP_PUSH1, 0x03, OP_PUSH1, 0x40, OP_MSTORE};
+  const std::vector<MemoryFactBlockSpec> Blocks = {
+      {0, 0, 5, {5}, {}},
+      {5, 5, 15, {}, {0}},
+  };
+
+  COMPILER::MemoryFacts Facts = collectManualBlockMemoryFacts(Bytecode, Blocks);
+  COMPILER::MemoryAnalysisView View(Facts);
+  COMPILER::MemoryPrecheckConsumer Consumer(View);
+
+  // Even if a caller supplies a wider bytecode interval, the block index is
+  // authoritative. The first block contains only one direct memory operation
+  // and therefore cannot form a shared precheck.
+  EXPECT_FALSE(Consumer.getBlockPrecheckRange(0, Bytecode.size()).has_value());
+}
+
 TEST(EVMMemoryPrecheckConsumerTest, RejectsHelperBarrierInBlockRange) {
   const std::vector<uint8_t> Bytecode = {
       OP_PUSH1, 0x01, OP_PUSH1, 0x80, OP_MSTORE,
@@ -1859,6 +2272,110 @@ TEST(EVMMemoryConsumerFrameworkTest, ExpansionPlannerPrefersGroupingPlan) {
   EXPECT_EQ(Diag.GroupingCandidates, 1u);
   EXPECT_EQ(Diag.GroupingAccepted, 1u);
   EXPECT_EQ(Diag.PrecheckCandidates, 0u);
+}
+
+TEST(EVMMemoryExpansionPlannerLazyTest,
+     StartsWithoutMaterializingOptionalAnalyses) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1,     0x20,     OP_PUSH1, 0x80,     OP_KECCAK256,
+      OP_POP,       OP_PUSH1, 0x20,     OP_PUSH1, 0x80,
+      OP_KECCAK256, OP_POP,   OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  COMPILER::MemoryAnalysisView View(Facts);
+  COMPILER::MemoryExpansionPlanner Planner(View);
+
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLinearRegions(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasGuaranteedExtent(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasDeadStores(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLoadForwarding(Planner));
+}
+
+TEST(EVMMemoryExpansionPlannerLazyTest,
+     ExtentQueryMaterializesOnlyExtentOracle) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1,     0x20,     OP_PUSH1, 0x80,     OP_KECCAK256,
+      OP_POP,       OP_PUSH1, 0x20,     OP_PUSH1, 0x80,
+      OP_KECCAK256, OP_POP,   OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  ASSERT_GE(Facts.Ops.size(), 2u);
+  COMPILER::MemoryAnalysisView View(Facts);
+  COMPILER::MemoryExpansionPlanner Planner(View);
+
+  EXPECT_EQ(Planner.getGuaranteedMinBytesBeforeOp(Facts.Ops.back().Pc), 0xa0u);
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLinearRegions(Planner));
+  EXPECT_TRUE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasGuaranteedExtent(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasDeadStores(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLoadForwarding(Planner));
+}
+
+TEST(EVMMemoryExpansionPlannerLazyTest,
+     SharedPrecheckDoesNotMaterializeGlobalAnalyses) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH1, 0x20,     OP_PUSH1, 0x40,
+                                         OP_PUSH1, 0x00,     OP_MCOPY, OP_PUSH1,
+                                         0x20,     OP_PUSH1, 0x80,     OP_PUSH1,
+                                         0x40,     OP_MCOPY, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  COMPILER::MemoryAnalysisView View(Facts);
+  COMPILER::MemoryExpansionPlanner Planner(View);
+
+  EXPECT_TRUE(Planner.buildMemoryExpansionPlan(0, Bytecode.size()).has_value());
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLinearRegions(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasGuaranteedExtent(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasDeadStores(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLoadForwarding(Planner));
+}
+
+TEST(EVMMemoryExpansionPlannerLazyTest, DeadStoreQueryMaterializesOnlyDSE) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01,     OP_PUSH1, 0x80,      OP_MSTORE, OP_PUSH1,
+      0x02,     OP_PUSH1, 0x80,     OP_MSTORE, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  ASSERT_GE(Facts.Ops.size(), 2u);
+  COMPILER::MemoryAnalysisView View(Facts);
+  COMPILER::MemoryExpansionPlanner Planner(View);
+
+  EXPECT_TRUE(Planner.isDeadStore(Facts.Ops.front().Pc));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLinearRegions(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasGuaranteedExtent(Planner));
+  EXPECT_TRUE(COMPILER::MemoryExpansionPlannerTestPeer::hasDeadStores(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLoadForwarding(Planner));
+}
+
+TEST(EVMMemoryExpansionPlannerLazyTest,
+     ForwardingQueryMaterializesOnlyForwardingAnalysis) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01, OP_PUSH1, 0x80,   OP_MSTORE,
+      OP_PUSH1, 0x80, OP_MLOAD, OP_POP, OP_STOP};
+  COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+  ASSERT_GE(Facts.Ops.size(), 2u);
+  COMPILER::MemoryAnalysisView View(Facts);
+  COMPILER::MemoryExpansionPlanner Planner(View);
+
+  EXPECT_EQ(Planner.getForwardingStorePC(Facts.Ops.back().Pc),
+            std::optional<uint64_t>(Facts.Ops.front().Pc));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLinearRegions(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasGuaranteedExtent(Planner));
+  EXPECT_FALSE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasDeadStores(Planner));
+  EXPECT_TRUE(
+      COMPILER::MemoryExpansionPlannerTestPeer::hasLoadForwarding(Planner));
 }
 
 TEST(EVMMemoryConsumerFrameworkTest, ExpansionPlannerGroupsIntervalsWithGaps) {
@@ -2858,11 +3375,162 @@ public:
 class MemoryFactsCapturingBuilder : public MockEVMBuilder {
 public:
   void setMemoryFacts(const COMPILER::MemoryFacts &Facts) {
+    ++SetMemoryFactsCount;
     CapturedFacts = Facts;
   }
 
   COMPILER::MemoryFacts CapturedFacts;
+  uint32_t SetMemoryFactsCount = 0;
 };
+
+TEST(EVMMemoryFactsIndexTest, MapsOpcodePCWithoutAcceptingPushPayload) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH1, 0x2a,      OP_PUSH1,
+                                         0x80,     OP_MSTORE, OP_STOP};
+
+  const COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+
+  const COMPILER::MemoryOp *Store = Facts.getOpByPC(4);
+  ASSERT_NE(Store, nullptr);
+  EXPECT_EQ(Store->Kind, COMPILER::MemoryOpKind::MStore);
+  EXPECT_EQ(Facts.getOpByPC(1), nullptr);
+  EXPECT_EQ(Facts.getOpByPC(Bytecode.size()), nullptr);
+}
+
+TEST(EVMMemoryPlannerAdmissionTest, RejectsSingleDynamicMemoryNoHit) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH1,        0x01,      OP_PUSH0,
+                                         OP_CALLDATALOAD, OP_MSTORE, OP_STOP};
+
+  const COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+
+  EXPECT_FALSE(Facts.Opportunities.hasPlannerOpportunity());
+}
+
+TEST(EVMMemoryPlannerAdmissionTest, AdmitsExactProducerConsumerPair) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1,     0x20,     OP_PUSH1, 0x80,     OP_KECCAK256,
+      OP_POP,       OP_PUSH1, 0x20,     OP_PUSH1, 0x80,
+      OP_KECCAK256, OP_POP,   OP_STOP};
+
+  const COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+  EXPECT_TRUE(Facts.Opportunities.hasPlannerOpportunity());
+}
+
+TEST(EVMMemoryPlannerAdmissionTest, RejectsSingleExactMemoryOperation) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH1, 0x2a,      OP_PUSH1,
+                                         0x80,     OP_MSTORE, OP_STOP};
+
+  const COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+
+  ASSERT_EQ(Facts.Ops.size(), 1u);
+  EXPECT_FALSE(Facts.Opportunities.hasPlannerOpportunity());
+}
+
+TEST(EVMMemoryPlannerAdmissionTest, RejectsStaticallyEmptyCopies) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH0,        OP_PUSH0,    OP_PUSH0,
+                                         OP_CALLDATACOPY, OP_PUSH0,    OP_PUSH0,
+                                         OP_PUSH0,        OP_CODECOPY, OP_STOP};
+
+  const COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+  EXPECT_FALSE(Facts.Opportunities.hasPlannerOpportunity());
+}
+
+TEST(EVMMemoryPlannerAdmissionTest, AdmitsCopyToKeccakExtentReuse) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1,        0x20,     OP_PUSH0, OP_PUSH1, 0x80,
+      OP_CALLDATACOPY, OP_PUSH1, 0x20,     OP_PUSH1, 0x80,
+      OP_KECCAK256,    OP_POP,   OP_STOP};
+
+  const COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+
+  ASSERT_EQ(Facts.Ops.size(), 2u);
+  EXPECT_TRUE(Facts.Opportunities.HasExtentReuseOpportunity);
+  EXPECT_TRUE(Facts.Opportunities.hasPlannerOpportunity());
+}
+
+TEST(EVMMemoryPlannerAdmissionTest, AdmitsStoreDSEAndForwardingShapes) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1, 0x01, OP_PUSH1, 0x80,   OP_MSTORE,
+      OP_PUSH1, 0x02, OP_PUSH1, 0x80,   OP_MSTORE,
+      OP_PUSH1, 0x80, OP_MLOAD, OP_POP, OP_STOP};
+
+  const COMPILER::MemoryFacts Facts = collectMemoryFacts(Bytecode);
+
+  EXPECT_TRUE(Facts.Opportunities.HasDeadStoreOpportunity);
+  EXPECT_TRUE(Facts.Opportunities.HasLoadForwardingOpportunity);
+  EXPECT_TRUE(Facts.Opportunities.hasPlannerOpportunity());
+}
+
+#ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
+TEST(EVMJITFrontendVisitorTest, DoesNotSetMemoryFactsForNoHitProgram) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH1, 0x01,   OP_PUSH1, 0x02,
+                                         OP_ADD,   OP_POP, OP_STOP};
+
+  COMPILER::EVMFrontendContext Ctx;
+  Ctx.setRevision(EVMC_CANCUN);
+  Ctx.setBytecode(reinterpret_cast<const zen::common::Byte *>(Bytecode.data()),
+                  Bytecode.size());
+
+  MemoryFactsCapturingBuilder Builder;
+  COMPILER::EVMByteCodeVisitor<MemoryFactsCapturingBuilder> Visitor(Builder,
+                                                                    &Ctx);
+  EXPECT_TRUE(Visitor.compile());
+  EXPECT_EQ(Builder.SetMemoryFactsCount, 0u);
+}
+
+TEST(EVMJITFrontendVisitorTest, IgnoresMemoryOpcodeInPushPayload) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH1, OP_MSTORE, OP_POP, OP_STOP};
+
+  COMPILER::EVMFrontendContext Ctx;
+  Ctx.setRevision(EVMC_CANCUN);
+  Ctx.setBytecode(reinterpret_cast<const zen::common::Byte *>(Bytecode.data()),
+                  Bytecode.size());
+
+  MemoryFactsCapturingBuilder Builder;
+  COMPILER::EVMByteCodeVisitor<MemoryFactsCapturingBuilder> Visitor(Builder,
+                                                                    &Ctx);
+  EXPECT_TRUE(Visitor.compile());
+  EXPECT_EQ(Builder.SetMemoryFactsCount, 0u);
+}
+
+TEST(EVMJITFrontendVisitorTest, ConservativelyAdmitsPotentialMultiBlockCFG) {
+  const std::vector<uint8_t> Bytecode = {OP_PUSH1,  0x01,        OP_PUSH1, 0x80,
+                                         OP_MSTORE, OP_JUMPDEST, OP_STOP};
+
+  COMPILER::EVMFrontendContext Ctx;
+  Ctx.setRevision(EVMC_CANCUN);
+  Ctx.setBytecode(reinterpret_cast<const zen::common::Byte *>(Bytecode.data()),
+                  Bytecode.size());
+
+  MemoryFactsCapturingBuilder Builder;
+  COMPILER::EVMByteCodeVisitor<MemoryFactsCapturingBuilder> Visitor(Builder,
+                                                                    &Ctx);
+  EXPECT_TRUE(Visitor.compile());
+  EXPECT_EQ(Builder.SetMemoryFactsCount, 1u);
+}
+
+TEST(EVMJITFrontendVisitorTest, PreservesDenseExactProofOpportunity) {
+  const std::vector<uint8_t> Bytecode = {
+      OP_PUSH1,     0x20,     OP_PUSH1, 0x80,     OP_KECCAK256,
+      OP_POP,       OP_PUSH1, 0x20,     OP_PUSH1, 0x80,
+      OP_KECCAK256, OP_POP,   OP_STOP};
+
+  COMPILER::EVMFrontendContext Ctx;
+  Ctx.setRevision(EVMC_CANCUN);
+  Ctx.setBytecode(reinterpret_cast<const zen::common::Byte *>(Bytecode.data()),
+                  Bytecode.size());
+
+  MemoryFactsCapturingBuilder Builder;
+  COMPILER::EVMByteCodeVisitor<MemoryFactsCapturingBuilder> Visitor(Builder,
+                                                                    &Ctx);
+  EXPECT_TRUE(Visitor.compile());
+  EXPECT_EQ(Builder.SetMemoryFactsCount, 1u);
+  EXPECT_EQ(Builder.CapturedFacts.Ops.size(), 2u);
+}
+#endif
 
 TEST(EVMJITFrontendVisitorTest, UsesActiveRevisionForMemoryEffectFacts) {
   const std::vector<uint8_t> Bytecode = {OP_PUSH0, OP_PUSH0, OP_PUSH0, OP_MCOPY,

--- a/src/tests/evm_jit_frontend_tests.cpp
+++ b/src/tests/evm_jit_frontend_tests.cpp
@@ -702,6 +702,81 @@ TEST(EVMRuntimeMemoryHelperContractTest,
   }
 }
 
+TEST(EVMRuntimeMemoryHelperContractTest,
+     EveryPreparedHelperRejectsEachMissingObligation) {
+  using COMPILER::RuntimeMemoryHelperId;
+  using COMPILER::RuntimeProofRequirementFlag;
+
+  const auto ExpectExactRequirements =
+      [](RuntimeMemoryHelperId Helper,
+         std::initializer_list<RuntimeProofRequirementFlag> Requirements) {
+        const COMPILER::RuntimeMemoryHelperContract Contract =
+            COMPILER::getRuntimeMemoryHelperContract(Helper);
+        ASSERT_TRUE(Contract.Valid);
+
+        COMPILER::RuntimeProofToken Complete;
+        for (RuntimeProofRequirementFlag Requirement : Requirements) {
+          Complete.establish(Requirement);
+        }
+        EXPECT_TRUE(
+            COMPILER::satisfiesRuntimeMemoryHelperContract(Contract, Complete));
+
+        for (RuntimeProofRequirementFlag Missing : Requirements) {
+          COMPILER::RuntimeProofToken Incomplete;
+          for (RuntimeProofRequirementFlag Requirement : Requirements) {
+            if (Requirement != Missing) {
+              Incomplete.establish(Requirement);
+            }
+          }
+          EXPECT_FALSE(COMPILER::satisfiesRuntimeMemoryHelperContract(
+              Contract, Incomplete));
+        }
+      };
+
+  const auto PreparedRangeAndGas = {
+      RuntimeProofRequirementFlag::LogicalSize,
+      RuntimeProofRequirementFlag::AccessRange,
+      RuntimeProofRequirementFlag::DynamicGasCharged,
+  };
+  ExpectExactRequirements(RuntimeMemoryHelperId::CodeCopyNoExpand,
+                          PreparedRangeAndGas);
+  ExpectExactRequirements(RuntimeMemoryHelperId::CallDataCopyNoExpand,
+                          PreparedRangeAndGas);
+  ExpectExactRequirements(RuntimeMemoryHelperId::KeccakNoExpand,
+                          PreparedRangeAndGas);
+
+  const auto PreparedRangeAndOrder = {
+      RuntimeProofRequirementFlag::LogicalSize,
+      RuntimeProofRequirementFlag::AccessRange,
+      RuntimeProofRequirementFlag::OrderToken,
+  };
+  ExpectExactRequirements(RuntimeMemoryHelperId::TwoWordKeccakNoExpand,
+                          PreparedRangeAndOrder);
+  ExpectExactRequirements(RuntimeMemoryHelperId::ReturnNoExpand,
+                          PreparedRangeAndOrder);
+  ExpectExactRequirements(RuntimeMemoryHelperId::RevertNoExpand,
+                          PreparedRangeAndOrder);
+
+  ExpectExactRequirements(RuntimeMemoryHelperId::ExpandMemoryNoGas,
+                          {RuntimeProofRequirementFlag::DynamicGasCharged,
+                           RuntimeProofRequirementFlag::BoundsValidated,
+                           RuntimeProofRequirementFlag::OrderToken});
+  ExpectExactRequirements(RuntimeMemoryHelperId::CallNoExpand,
+                          {RuntimeProofRequirementFlag::LogicalSize,
+                           RuntimeProofRequirementFlag::CallArgumentsRange,
+                           RuntimeProofRequirementFlag::CallReturnRange,
+                           RuntimeProofRequirementFlag::OrderToken});
+}
+
+TEST(EVMRuntimeMemoryHelperContractTest, RejectsUnknownHelperFailClosed) {
+  const COMPILER::RuntimeMemoryHelperContract Contract =
+      COMPILER::getRuntimeMemoryHelperContract(
+          static_cast<COMPILER::RuntimeMemoryHelperId>(255));
+  COMPILER::RuntimeProofToken Empty;
+  EXPECT_FALSE(Contract.Valid);
+  EXPECT_FALSE(COMPILER::satisfiesRuntimeMemoryHelperContract(Contract, Empty));
+}
+
 TEST(EVMMemoryFactsBuilderTest, AttributesOpsToAnalyzerBlocks) {
   const std::vector<uint8_t> Bytecode = {
       OP_PUSH1, 0x01,     OP_PUSH1, 0x0b,      OP_JUMPI,  OP_PUSH1,

--- a/src/tests/evm_jit_frontend_tests.cpp
+++ b/src/tests/evm_jit_frontend_tests.cpp
@@ -617,17 +617,20 @@ TEST(EVMRuntimeMemoryHelperContractTest,
   const COMPILER::RuntimeMemoryHelperContract Copy =
       COMPILER::getRuntimeMemoryHelperContract(
           RuntimeMemoryHelperId::CodeCopyNoExpand);
-  EXPECT_TRUE(Copy.requires(RuntimeProofRequirementFlag::LogicalSize));
-  EXPECT_TRUE(Copy.requires(RuntimeProofRequirementFlag::AccessRange));
-  EXPECT_TRUE(Copy.requires(RuntimeProofRequirementFlag::DynamicGasCharged));
+  EXPECT_TRUE(Copy.hasRequirement(RuntimeProofRequirementFlag::LogicalSize));
+  EXPECT_TRUE(Copy.hasRequirement(RuntimeProofRequirementFlag::AccessRange));
+  EXPECT_TRUE(
+      Copy.hasRequirement(RuntimeProofRequirementFlag::DynamicGasCharged));
   EXPECT_TRUE(Copy.Effects.has(COMPILER::MemoryEffectFlag::WritesMemory));
   EXPECT_FALSE(Copy.Effects.mayGrowMemory());
 
   const COMPILER::RuntimeMemoryHelperContract Expand =
       COMPILER::getRuntimeMemoryHelperContract(
           RuntimeMemoryHelperId::ExpandMemoryNoGas);
-  EXPECT_TRUE(Expand.requires(RuntimeProofRequirementFlag::DynamicGasCharged));
-  EXPECT_TRUE(Expand.requires(RuntimeProofRequirementFlag::BoundsValidated));
+  EXPECT_TRUE(
+      Expand.hasRequirement(RuntimeProofRequirementFlag::DynamicGasCharged));
+  EXPECT_TRUE(
+      Expand.hasRequirement(RuntimeProofRequirementFlag::BoundsValidated));
   EXPECT_TRUE(Expand.EstablishesLogicalSize);
   EXPECT_TRUE(Expand.Effects.mayGrowMemory());
   EXPECT_TRUE(Expand.Effects.mayRebaseMemory());
@@ -1441,8 +1444,8 @@ TEST(EVMMemoryGuaranteedMinBytesAnalysisTest, IgnoresZeroLengthKeccak) {
 }
 
 #ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
-std::optional<size_t>
-countKeccakExpandMemoryCalls(const std::vector<uint8_t> &Bytecode) {
+std::optional<std::string>
+compileKeccakMemoryMir(const std::vector<uint8_t> &Bytecode) {
   COMPILER::EVMFrontendContext Ctx;
   Ctx.setRevision(EVMC_CANCUN);
   Ctx.setBytecode(reinterpret_cast<const zen::common::Byte *>(Bytecode.data()),
@@ -1466,25 +1469,19 @@ countKeccakExpandMemoryCalls(const std::vector<uint8_t> &Bytecode) {
   llvm::raw_string_ostream OS(Mir);
   Func.print(OS);
   OS.flush();
+  return Mir;
+}
 
-  const auto &RuntimeFunctions = COMPILER::getRuntimeFunctionTable();
-  const auto Address =
-      COMPILER::getFunctionAddress(RuntimeFunctions.ExpandMemoryNoGas);
+template <typename FuncType>
+bool containsKeccakRuntimeCall(const std::string &Mir, FuncType Function) {
   const std::string Needle =
-      "target = const.i64 " + std::to_string(Address) + ", ";
-  size_t Count = 0;
-  for (size_t Pos = Mir.find(Needle); Pos != std::string::npos;
-       Pos = Mir.find(Needle, Pos + Needle.size())) {
-    ++Count;
-  }
-  return Count;
+      "target = const.i64 " +
+      std::to_string(COMPILER::getFunctionAddress(Function)) + ", ";
+  return Mir.find(Needle) != std::string::npos;
 }
 
 TEST(EVMMirBuilderMemoryProofTest,
      ReusesCrossBlockGuaranteedSizeForKeccakConsumer) {
-  const std::vector<uint8_t> ProducerOnly = {
-      OP_PUSH1, 0x01, OP_PUSH1, 0x80,        OP_MSTORE,
-      OP_PUSH1, 0x08, OP_JUMP,  OP_JUMPDEST, OP_STOP};
   const std::vector<uint8_t> CoveredKeccak = {
       OP_PUSH1, 0x01,         OP_PUSH1,    0x80,     OP_MSTORE, OP_PUSH1,
       0x08,     OP_JUMP,      OP_JUMPDEST, OP_PUSH1, 0x20,      OP_PUSH1,
@@ -1494,18 +1491,20 @@ TEST(EVMMirBuilderMemoryProofTest,
       0x08,     OP_JUMP,      OP_JUMPDEST, OP_PUSH1, 0x20,      OP_PUSH1,
       0xa0,     OP_KECCAK256, OP_POP,      OP_STOP};
 
-  const std::optional<size_t> ProducerExpansionCalls =
-      countKeccakExpandMemoryCalls(ProducerOnly);
-  const std::optional<size_t> CoveredExpansionCalls =
-      countKeccakExpandMemoryCalls(CoveredKeccak);
-  const std::optional<size_t> UncoveredExpansionCalls =
-      countKeccakExpandMemoryCalls(UncoveredKeccak);
+  const auto CoveredMir = compileKeccakMemoryMir(CoveredKeccak);
+  const auto UncoveredMir = compileKeccakMemoryMir(UncoveredKeccak);
+  ASSERT_TRUE(CoveredMir.has_value());
+  ASSERT_TRUE(UncoveredMir.has_value());
 
-  ASSERT_TRUE(ProducerExpansionCalls.has_value());
-  ASSERT_TRUE(CoveredExpansionCalls.has_value());
-  ASSERT_TRUE(UncoveredExpansionCalls.has_value());
-  EXPECT_EQ(*CoveredExpansionCalls, *ProducerExpansionCalls);
-  EXPECT_EQ(*UncoveredExpansionCalls, *ProducerExpansionCalls + 1);
+  const auto &RuntimeFunctions = COMPILER::getRuntimeFunctionTable();
+  EXPECT_TRUE(containsKeccakRuntimeCall(*CoveredMir,
+                                        RuntimeFunctions.GetKeccak256NoExpand));
+  EXPECT_FALSE(
+      containsKeccakRuntimeCall(*CoveredMir, RuntimeFunctions.GetKeccak256));
+  EXPECT_TRUE(
+      containsKeccakRuntimeCall(*UncoveredMir, RuntimeFunctions.GetKeccak256));
+  EXPECT_FALSE(containsKeccakRuntimeCall(
+      *UncoveredMir, RuntimeFunctions.GetKeccak256NoExpand));
 }
 
 TEST(EVMMirBuilderMemoryProofTest, ReusesPriorKeccakProofAtExactOpcodePC) {
@@ -1516,14 +1515,18 @@ TEST(EVMMirBuilderMemoryProofTest, ReusesPriorKeccakProofAtExactOpcodePC) {
       OP_POP,       OP_PUSH1, 0x20,     OP_PUSH1, 0x80,
       OP_KECCAK256, OP_POP,   OP_STOP};
 
-  const std::optional<size_t> OneExpansionCalls =
-      countKeccakExpandMemoryCalls(OneKeccak);
-  const std::optional<size_t> TwoExpansionCalls =
-      countKeccakExpandMemoryCalls(TwoKeccaks);
+  const auto OneMir = compileKeccakMemoryMir(OneKeccak);
+  const auto TwoMir = compileKeccakMemoryMir(TwoKeccaks);
+  ASSERT_TRUE(OneMir.has_value());
+  ASSERT_TRUE(TwoMir.has_value());
 
-  ASSERT_TRUE(OneExpansionCalls.has_value());
-  ASSERT_TRUE(TwoExpansionCalls.has_value());
-  EXPECT_EQ(*TwoExpansionCalls, *OneExpansionCalls);
+  const auto &RuntimeFunctions = COMPILER::getRuntimeFunctionTable();
+  EXPECT_TRUE(
+      containsKeccakRuntimeCall(*OneMir, RuntimeFunctions.GetKeccak256));
+  EXPECT_TRUE(
+      containsKeccakRuntimeCall(*TwoMir, RuntimeFunctions.GetKeccak256));
+  EXPECT_TRUE(containsKeccakRuntimeCall(*TwoMir,
+                                        RuntimeFunctions.GetKeccak256NoExpand));
 }
 #endif
 

--- a/src/tests/evm_terminating_memory_tests.cpp
+++ b/src/tests/evm_terminating_memory_tests.cpp
@@ -18,8 +18,8 @@ namespace {
 using COMPILER::EVMMirBuilder;
 
 #ifdef ZEN_ENABLE_EVM_MEMORY_PLAN_FRAMEWORK
-std::optional<size_t>
-countTerminatingExpandMemoryCalls(const std::vector<uint8_t> &Bytecode) {
+std::optional<std::string>
+compileTerminatingMemoryMir(const std::vector<uint8_t> &Bytecode) {
   COMPILER::EVMFrontendContext Ctx;
   Ctx.setRevision(EVMC_CANCUN);
   Ctx.setBytecode(reinterpret_cast<const zen::common::Byte *>(Bytecode.data()),
@@ -43,18 +43,15 @@ countTerminatingExpandMemoryCalls(const std::vector<uint8_t> &Bytecode) {
   llvm::raw_string_ostream OS(Mir);
   Func.print(OS);
   OS.flush();
+  return Mir;
+}
 
-  const auto &RuntimeFunctions = COMPILER::getRuntimeFunctionTable();
-  const auto Address =
-      COMPILER::getFunctionAddress(RuntimeFunctions.ExpandMemoryNoGas);
+template <typename FuncType>
+bool containsTerminatingRuntimeCall(const std::string &Mir, FuncType Function) {
   const std::string Needle =
-      "target = const.i64 " + std::to_string(Address) + ", ";
-  size_t Count = 0;
-  for (size_t Pos = Mir.find(Needle); Pos != std::string::npos;
-       Pos = Mir.find(Needle, Pos + Needle.size())) {
-    ++Count;
-  }
-  return Count;
+      "target = const.i64 " +
+      std::to_string(COMPILER::getFunctionAddress(Function)) + ", ";
+  return Mir.find(Needle) != std::string::npos;
 }
 
 TEST(EVMMirBuilderTerminatingMemoryProofTest,
@@ -72,18 +69,28 @@ TEST(EVMMirBuilderTerminatingMemoryProofTest,
       OP_PUSH1, 0x01,        OP_PUSH1, 0x80, OP_MSTORE, OP_PUSH1, 0x08,
       OP_JUMP,  OP_JUMPDEST, OP_PUSH1, 0x20, OP_PUSH1,  0x80,     OP_REVERT};
 
-  const auto ZeroReturnCalls =
-      countTerminatingExpandMemoryCalls(ZeroSizeReturn);
-  const auto ReturnCalls = countTerminatingExpandMemoryCalls(CoveredReturn);
-  const auto ZeroRevertCalls =
-      countTerminatingExpandMemoryCalls(ZeroSizeRevert);
-  const auto RevertCalls = countTerminatingExpandMemoryCalls(CoveredRevert);
-  ASSERT_TRUE(ZeroReturnCalls.has_value());
-  ASSERT_TRUE(ReturnCalls.has_value());
-  ASSERT_TRUE(ZeroRevertCalls.has_value());
-  ASSERT_TRUE(RevertCalls.has_value());
-  EXPECT_EQ(*ReturnCalls, *ZeroReturnCalls);
-  EXPECT_EQ(*RevertCalls, *ZeroRevertCalls);
+  const auto ZeroReturnMir = compileTerminatingMemoryMir(ZeroSizeReturn);
+  const auto ReturnMir = compileTerminatingMemoryMir(CoveredReturn);
+  const auto ZeroRevertMir = compileTerminatingMemoryMir(ZeroSizeRevert);
+  const auto RevertMir = compileTerminatingMemoryMir(CoveredRevert);
+  ASSERT_TRUE(ZeroReturnMir.has_value());
+  ASSERT_TRUE(ReturnMir.has_value());
+  ASSERT_TRUE(ZeroRevertMir.has_value());
+  ASSERT_TRUE(RevertMir.has_value());
+
+  const auto &RuntimeFunctions = COMPILER::getRuntimeFunctionTable();
+  EXPECT_TRUE(containsTerminatingRuntimeCall(
+      *ZeroReturnMir, RuntimeFunctions.SetReturnNoExpand));
+  EXPECT_TRUE(containsTerminatingRuntimeCall(
+      *ReturnMir, RuntimeFunctions.SetReturnNoExpand));
+  EXPECT_FALSE(
+      containsTerminatingRuntimeCall(*ReturnMir, RuntimeFunctions.SetReturn));
+  EXPECT_TRUE(containsTerminatingRuntimeCall(
+      *ZeroRevertMir, RuntimeFunctions.SetRevertNoExpand));
+  EXPECT_TRUE(containsTerminatingRuntimeCall(
+      *RevertMir, RuntimeFunctions.SetRevertNoExpand));
+  EXPECT_FALSE(
+      containsTerminatingRuntimeCall(*RevertMir, RuntimeFunctions.SetRevert));
 }
 
 TEST(EVMMirBuilderTerminatingMemoryProofTest,
@@ -102,20 +109,27 @@ TEST(EVMMirBuilderTerminatingMemoryProofTest,
       OP_PUSH1, 0x01,    OP_PUSH1,    0x80,     OP_MSTORE, OP_PUSH1,
       0x08,     OP_JUMP, OP_JUMPDEST, OP_PUSH0, OP_PUSH0,  OP_REVERT};
 
-  const auto ZeroReturnCalls =
-      countTerminatingExpandMemoryCalls(ZeroSizeReturn);
-  const auto UncoveredCalls =
-      countTerminatingExpandMemoryCalls(UncoveredReturn);
-  const auto HugeOffsetZeroSizeCalls =
-      countTerminatingExpandMemoryCalls(HugeOffsetZeroSizeRevert);
-  const auto ZeroRevertCalls =
-      countTerminatingExpandMemoryCalls(ZeroSizeRevert);
-  ASSERT_TRUE(ZeroReturnCalls.has_value());
-  ASSERT_TRUE(UncoveredCalls.has_value());
-  ASSERT_TRUE(HugeOffsetZeroSizeCalls.has_value());
-  ASSERT_TRUE(ZeroRevertCalls.has_value());
-  EXPECT_EQ(*UncoveredCalls, *ZeroReturnCalls + 1);
-  EXPECT_EQ(*HugeOffsetZeroSizeCalls, *ZeroRevertCalls);
+  const auto ZeroReturnMir = compileTerminatingMemoryMir(ZeroSizeReturn);
+  const auto UncoveredMir = compileTerminatingMemoryMir(UncoveredReturn);
+  const auto HugeOffsetZeroSizeMir =
+      compileTerminatingMemoryMir(HugeOffsetZeroSizeRevert);
+  const auto ZeroRevertMir = compileTerminatingMemoryMir(ZeroSizeRevert);
+  ASSERT_TRUE(ZeroReturnMir.has_value());
+  ASSERT_TRUE(UncoveredMir.has_value());
+  ASSERT_TRUE(HugeOffsetZeroSizeMir.has_value());
+  ASSERT_TRUE(ZeroRevertMir.has_value());
+
+  const auto &RuntimeFunctions = COMPILER::getRuntimeFunctionTable();
+  EXPECT_TRUE(containsTerminatingRuntimeCall(
+      *ZeroReturnMir, RuntimeFunctions.SetReturnNoExpand));
+  EXPECT_TRUE(containsTerminatingRuntimeCall(*UncoveredMir,
+                                             RuntimeFunctions.SetReturn));
+  EXPECT_FALSE(containsTerminatingRuntimeCall(
+      *UncoveredMir, RuntimeFunctions.SetReturnNoExpand));
+  EXPECT_TRUE(containsTerminatingRuntimeCall(
+      *HugeOffsetZeroSizeMir, RuntimeFunctions.SetRevertNoExpand));
+  EXPECT_TRUE(containsTerminatingRuntimeCall(
+      *ZeroRevertMir, RuntimeFunctions.SetRevertNoExpand));
 }
 #endif
 


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y

Refs #595.
#596 has merged. This PR depends on #597 and must merge after it.

#### 2. What is the scope of this PR?

EVM MIR prepared-memory helper contract enforcement, cross-block proof consumers, focused frontend and differential regression tests, and compiler documentation.

#### 3. What is the behavior change?

- Selects COPY/CALLDATACOPY, KECCAK (including two-word variants), RETURN, and REVERT prepared/no-expand helpers only after typed range proofs are established; otherwise selects the generic helper.
- Keeps CALL arguments and return memory as two separate obligations.
- Keeps terminal RETURN/REVERT behavior fail closed without treating LOG as a typed cross-block consumer.
- Requests witness data only at certificate-emission boundaries; this production PR does not publish certificates or telemetry.
- Fails closed when a required contract cannot be established.

This is PR 3 of the ordered series #596 -> #597 -> this PR. #596 is merged; merge this PR only after #597.

`423ebd1 chore(evm): merge reviewed budget branch` records the reviewed #597 ancestry; its tree equals the independently tested ordered-integration tree.

#### 4. Is this a breaking change?

- [x] N
- [ ] Y

#### 5. How was it tested?

- [x] Unit tests
- [x] Integration tests

- `./tools/format.sh format`
- `./tools/format.sh check`
- `git diff --check`
- LLVM 15 Release build of the multipass target
- Fixture generation: 209/209
- Frontend tests: 179/179
- Differential tests: 74/74
- Directed dynamic-destination CODECOPY fallback: interpreter and multipass output/gas match

No formal performance benchmark was run or claimed.

#### 6. Release note

```release-note
Enforce typed proof contracts at EVM prepared-memory helper call sites.
```