### PR TITLE
fix(evm): do not report a null-pointer dereference as an EVM memory fault

### DIFF
--- a/src/common/errors.def
+++ b/src/common/errors.def
@@ -180,6 +180,11 @@ DEFINE_ERROR(Execution,     None,   EVMTooLargeRequiredMemory, "EVM Required Mem
 // EVM Error: About Storage
 DEFINE_ERROR(Execution,     None,   EVMStaticModeViolation, "Prohibit modification of the storage")
 
+// EVM Error: a null-pointer dereference inside compiled code. Not an EVM
+// condition - EVM memory is a heap buffer that is never mapped at page zero -
+// so this is an engine defect and must not be reported as an EVM halt.
+DEFINE_ERROR(Execution,     None,   EVMNullPointerDereference, "null pointer dereference in compiled code")
+
 // EVM Error: About JIT compilation invariants
 DEFINE_ERROR(Compilation,   None,   EVMDynamicJumpConsistencyFailed, "analyzer and codegen disagree on dynamic-jump dispatch")
 

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -930,6 +930,10 @@ void Runtime::callWasmFunctionInJITMode(Instance &Inst, uint32_t FuncIdx,
 }
 
 #ifdef ZEN_ENABLE_EVM
+/// Size of the unmapped low address range. A faulting address below this is a
+/// null pointer plus a small offset, never a real allocation.
+static constexpr uintptr_t NullPointerPageSize = 4096;
+
 void Runtime::callEVMInJITMode(EVMInstance &Inst, evmc_message &Msg,
                                evmc::Result &Result) {
   EVMModule *Module = const_cast<EVMModule *>(Inst.getModule());
@@ -996,6 +1000,20 @@ void Runtime::callEVMInJITMode(EVMInstance &Inst, evmc_message &Msg,
       switch (JmpSignum) {
       case SIGSEGV:
       case SIGBUS: {
+        // A fault in the first page is a null-pointer dereference inside
+        // compiled code, not an EVM memory access: EVM memory is a heap buffer
+        // and is never mapped at page zero. Reporting it as an out-of-bounds
+        // access laundered an engine defect into a consensus-visible halt,
+        // which is how one stayed hidden - the caller saw a plausible
+        // EVMC_INVALID_MEMORY_ACCESS and carried on with the wrong gas. Report
+        // an internal error so the embedder fails loudly instead. This branch
+        // should be unreachable; it is a tripwire, not a recovery path.
+        if (reinterpret_cast<uintptr_t>(TLS.getTrapState().FaultingAddress) <
+            NullPointerPageSize) {
+          CapturedTapErrCode = ErrorCode::EVMNullPointerDereference;
+          StatusCode = EVMC_INTERNAL_ERROR;
+          break;
+        }
         // out of bounds signal
         CapturedTapErrCode = ErrorCode::OutOfBoundsMemory;
         StatusCode = EVMC_INVALID_MEMORY_ACCESS;


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y

#### 2. What is the scope of this PR (e.g. component or file name):

`src/runtime/runtime.cpp` JIT trap handling for EVM, plus one new error code in
`src/common/errors.def`.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

The JIT trap handler mapped every SIGSEGV to `ErrorCode::OutOfBoundsMemory` and
`EVMC_INVALID_MEMORY_ACCESS`. That is correct for a real out-of-bounds EVM memory
access and wrong for a fault at a null pointer: EVM memory is a heap buffer and
is never mapped at page zero, so a fault there is a defect in compiled code, not
an EVM condition.

The misclassification is not cosmetic. `EVMC_INVALID_MEMORY_ACCESS` is a
consensus status, so an engine crash was handed to the embedder as a plausible
exceptional halt. Execution continued and the block finished with the wrong gas
instead of failing: on mainnet block 25818502 the replay reported 27730760 gas
used against an expected 27644811. Locating the real cause required a patched
build that printed the faulting address.

This classifies a fault in the first page as `EVMNullPointerDereference` /
`EVMC_INTERNAL_ERROR`, which is not a consensus status and which an embedder must
reject. On the affected blocks the replay now stops with an internal-status error
rather than producing a wrong gas number.

**This is a tripwire, not a fix.** The branch should be unreachable, and this PR
does not make it so — it only ensures that if it is reached, the embedder is told
something it must reject rather than a consensus status it may accept.

*Update since this PR was opened:* the specific dereference behind those two
blocks has since been found and fixed in #607 — the multipass JIT reloaded its
cached memory size after a runtime helper but never the cached base, so a frame
whose first memory growth happened inside a helper kept an entry-time null base.
That does not make this PR redundant; it is the reason the defect survived as
long as it did. Without this reclassification a null dereference is reported as
`EVMC_INVALID_MEMORY_ACCESS` — a consensus status — so the caller treats an
engine crash as a legitimate exceptional halt, execution continues, and the
block's gas comes out wrong instead of the run failing loudly. #607 removes that
cause; this PR makes any remaining member of the class audible. The two are
independent and separately mergeable.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [x] Y

An embedder that today sees `EVMC_INVALID_MEMORY_ACCESS` for a null-pointer fault
in JIT'd code will now see `EVMC_INTERNAL_ERROR`. This is deliberate and is the
point of the change: the old status is a consensus status that an embedder may
legitimately accept as an exceptional halt, and accepting it silently converts an
engine defect into a wrong execution result. No behaviour changes for a genuine
out-of-bounds EVM memory access, which still maps to
`EVMC_INVALID_MEMORY_ACCESS`.

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [x] Other

No automated test is added: the branch is only reachable through a defect in
generated code, and there is no supported way to construct that fault from an EVM
program. Suggestions for a test hook are welcome.

Validation on a GCC 12 / LLVM 15 Release multipass build, configured to match the
existing EVM configuration (`ZEN_ENABLE_EVM`, `ZEN_ENABLE_MULTIPASS_JIT`,
`ZEN_ENABLE_VIRTUAL_STACK`, `ZEN_ENABLE_CPU_EXCEPTION` all ON):

- `./tools/format.sh check`: PASS
- Release build on top of `338d123`: PASS
- EVM fixture generation (`tools/easm2bytecode.sh`): 209/209
- `ctest`: 11/12 test binaries pass

The one failure, `solidityContractTests` (7 cases), is `solc not found` in this
environment. It fails identically on a pristine `338d123` build configured the
same way, which was built and run side by side for exactly this comparison — so
it is environmental, not a regression from this change. Every other binary
passes, including `evmDifferentialTests`, `evmJitFrontendTests`, `evmStateTests`,
`evmInterpTests`, `evmModuleCacheTests`, `evmFallbackExecutionTests` and
`evmProfileGuidedJITTests`.

Behavioural check: mainnet witness replay of blocks 25818502 and 25818530 through
the EVMC interface. Before, the run completed with an incorrect gas figure; after,
it stops with a backend/internal status. Access counts at the fault are unchanged
(152 and 45), i.e. the underlying dereference is not affected by this change.

#### 6. Release note

```release-note
Report a null-pointer fault in JIT'd EVM code as an internal error instead of an out-of-bounds memory access.
```

