### PR TITLE
fix(evm): consume all gas when a frame halts exceptionally

### DIFF
--- a/src/evm/evm.h
+++ b/src/evm/evm.h
@@ -49,6 +49,23 @@ constexpr auto MAX_SIZE_OF_INITCODE = 0xC000;
 /// code.
 static constexpr auto EMPTY_CODE_HASH =
     0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32;
+
+/// Store the gas a finished frame hands back to its caller, applying the EVM's
+/// terminal gas rule: an exceptional halt consumes all of the frame's gas, and
+/// only a success or a revert returns any.
+///
+/// This must be the last write to `Result.gas_left`. The instance's own gas
+/// counter is not authoritative once a frame has halted - the interpreter
+/// zeroes the frame's gas rather than the instance's, and the JIT trap path
+/// never touches either - so assigning `Instance::getGas()` unconditionally
+/// hands the caller gas the EVM has already burned. evmone applies the same
+/// rule in `make_execution_result`.
+inline void setFrameGasLeft(evmc::Result &Result, uint64_t InstanceGas) {
+  const bool KeepsGas =
+      Result.status_code == EVMC_SUCCESS || Result.status_code == EVMC_REVERT;
+  Result.gas_left = KeepsGas ? static_cast<int64_t>(InstanceGas) : 0;
+}
+
 } // namespace zen::evm
 
 #endif // ZEN_EVM_GAS_EVM_H

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -785,7 +785,7 @@ void Runtime::callEVMMainOnPhysStack(EVMInstance &Inst, evmc_message &Msg,
   } else {
     callEVMInInterpMode(Inst, MsgWithCode, Result);
   }
-  Result.gas_left = Inst.getGas();
+  zen::evm::setFrameGasLeft(Result, Inst.getGas());
 }
 
 void Runtime::callEVMMain(EVMInstance &Inst, evmc_message &Msg,

--- a/src/vm/dt_evmc_vm.cpp
+++ b/src/vm/dt_evmc_vm.cpp
@@ -6,6 +6,7 @@
 #include "common/enums.h"
 #include "common/errors.h"
 #include "compiler/evm_frontend/evm_analyzer.h"
+#include "evm/evm.h"
 #include "evm/interpreter.h"
 #include "evm/opcode_handlers.h"
 #include "jit_profile.h"
@@ -691,7 +692,7 @@ evmc_result runInterpreterOnResolvedInstance(DTVM *VM, EVMModule *Mod,
 
   evmc::Result Result =
       std::move(const_cast<evmc::Result &>(Ctx.getExeResult()));
-  Result.gas_left = TheInst->getGas();
+  zen::evm::setFrameGasLeft(Result, TheInst->getGas());
 
   return Result.release_raw();
 }
@@ -985,7 +986,7 @@ evmc_result execute(evmc_vm *EVMInstance, const evmc_host_interface *Host,
     VM->RT->callEVMInJITMode(*TheInst, MsgWithCode, Result);
 #endif // ZEN_ENABLE_VIRTUAL_STACK
 
-    Result.gas_left = TheInst->getGas();
+    zen::evm::setFrameGasLeft(Result, TheInst->getGas());
     return Result.release_raw();
   }
 #else


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y

#### 2. What is the scope of this PR (e.g. component or file name):

Exceptional-halt gas accounting at the three `evmc_result` finalisation sites:
`src/vm/dt_evmc_vm.cpp` and `src/runtime/runtime.cpp`, with the shared rule added
as a helper in `src/evm/evm.h`.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

The three places that finalise an `evmc_result` all ended with

```cpp
Result.gas_left = <instance>.getGas();
```

which unconditionally overwrites whatever the halt paths had already decided. The
instance's gas counter is not authoritative after a halt: the interpreter zeroes
the **frame's** gas, and the JIT trap path never touches gas at all. So an
exceptional halt handed the caller back gas the EVM had already burned.

evmone states the rule directly in `make_execution_result`:

```cpp
// An exceptional halt consumes all gas; only a success or revert keeps gas_left.
if (state.status != EVMC_SUCCESS && state.status != EVMC_REVERT)
    gas_left = 0;
```

This routes the three sites through one helper that applies that rule.

How it surfaced: mainnet witness replay of blocks 25818502 and 25818530, where a
nested frame halted with `EVMC_INVALID_MEMORY_ACCESS` and returned 339011 of its
440977 gas limit. The embedder rejects any halted result that retained gas, which
is what made it visible.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [ ] N
- [x] Y

A caller that observed non-zero `gas_left` on an exceptionally halted frame now
observes zero. That is the consensus behaviour and the reason for the change; any
consumer relying on the old value was relying on a defect. Success and revert
results are unaffected, and under the interpreter the frame's gas was already
zeroed — the difference is that the frame's decision now survives to the caller.

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [x] Other

Validation on a GCC 12 / LLVM 15 Release multipass build, configured to match the
existing EVM configuration (`ZEN_ENABLE_EVM`, `ZEN_ENABLE_MULTIPASS_JIT`,
`ZEN_ENABLE_VIRTUAL_STACK`, `ZEN_ENABLE_CPU_EXCEPTION` all ON):

- `./tools/format.sh check`: PASS
- Release build on top of `338d123`: PASS
- EVM fixture generation (`tools/easm2bytecode.sh`): 209/209
- `ctest`: 11/12 test binaries pass

The one failure, `solidityContractTests` (7 cases), is `solc not found` in this
environment. It fails identically on a pristine `338d123` build configured the
same way, which was built and run side by side for exactly this comparison — so
it is environmental, not a regression from this change. Every other binary
passes, including `evmDifferentialTests`, `evmJitFrontendTests`, `evmStateTests`,
`evmInterpTests`, `evmModuleCacheTests`, `evmFallbackExecutionTests` and
`evmProfileGuidedJITTests`.

Behavioural check: mainnet witness replay through the EVMC interface. Before, a
nested frame halting with `EVMC_INVALID_MEMORY_ACCESS` returned 339011 of a 440977
gas limit; after, it returns zero, which is what the embedder's halt check
expects.

Note on the two blocks above: this change is necessary but not sufficient for
them. The halt itself is a separate JIT defect — a null-pointer dereference in
generated code — which was still unlocated when this PR was opened and has since
been found and fixed in #607. This PR does not fix those blocks and does not
depend on #607; it corrects the gas rule that their halt happened to expose.

#### 6. Release note

```release-note
Zero gas_left on an exceptional halt, matching consensus behaviour; only success and revert retain gas.
```

