### PR TITLE
fix(evm): reload the cached memory base whenever the cached size is reloaded

### DIFF
--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -4773,7 +4773,7 @@ void EVMMirBuilder::handleCodeCopy(Operand DestOffsetComponents,
   }
 #endif
   if (!UsePreparedMemory) {
-    reloadMemorySizeFromInstance();
+    reloadMemoryCachesFromInstance();
   }
 }
 
@@ -5579,7 +5579,7 @@ void EVMMirBuilder::handleLogWithTopics(Operand OffsetOp, Operand SizeOp,
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
+  reloadMemoryCachesFromInstance();
 }
 
 typename EVMMirBuilder::Operand
@@ -5596,7 +5596,7 @@ EVMMirBuilder::handleCreate(Operand ValueOp, Operand OffsetOp, Operand SizeOp) {
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
+  reloadMemoryCachesFromInstance();
   return Result;
 }
 
@@ -5616,7 +5616,7 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleCreate2(Operand ValueOp,
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
+  reloadMemoryCachesFromInstance();
   return Result;
 }
 
@@ -5698,7 +5698,7 @@ EVMMirBuilder::handleCall(Operand GasOp, Operand ToAddrOp, Operand ValueOp,
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
+  reloadMemoryCachesFromInstance();
   return Result;
 }
 
@@ -5730,7 +5730,7 @@ EVMMirBuilder::handleCallCode(Operand GasOp, Operand ToAddrOp, Operand ValueOp,
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
+  reloadMemoryCachesFromInstance();
   return Result;
 }
 
@@ -5798,7 +5798,7 @@ EVMMirBuilder::handleDelegateCall(Operand GasOp, Operand ToAddrOp,
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
+  reloadMemoryCachesFromInstance();
   return Result;
 }
 
@@ -5828,7 +5828,7 @@ EVMMirBuilder::handleStaticCall(Operand GasOp, Operand ToAddrOp,
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
+  reloadMemoryCachesFromInstance();
   return Result;
 }
 
@@ -6011,7 +6011,7 @@ EVMMirBuilder::handleKeccak256(Operand OffsetComponents,
   reloadGasFromMemory();
 #endif
   if (!UsePreparedMemory) {
-    reloadMemorySizeFromInstance();
+    reloadMemoryCachesFromInstance();
   }
   return Result;
 }
@@ -6043,7 +6043,7 @@ EVMMirBuilder::handleKeccak256TwoWord(Operand OffsetComponents, Operand Word0,
   reloadGasFromMemory();
 #endif
   if (!UsePreparedMemory) {
-    reloadMemorySizeFromInstance();
+    reloadMemoryCachesFromInstance();
   }
   return Result;
 }
@@ -6076,7 +6076,7 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleKeccak256CallDataConstSlot(
   reloadGasFromMemory();
 #endif
   if (!UsePreparedMemory) {
-    reloadMemorySizeFromInstance();
+    reloadMemoryCachesFromInstance();
   }
   return Result;
 }
@@ -6108,7 +6108,7 @@ EVMMirBuilder::handleKeccak256CallerConstSlot(Operand OffsetComponents,
   reloadGasFromMemory();
 #endif
   if (!UsePreparedMemory) {
-    reloadMemorySizeFromInstance();
+    reloadMemoryCachesFromInstance();
   }
   return Result;
 }
@@ -7410,7 +7410,7 @@ void EVMMirBuilder::handleCallDataCopy(Operand DestOffsetComponents,
   }
 #endif
   if (!UsePreparedMemory) {
-    reloadMemorySizeFromInstance();
+    reloadMemoryCachesFromInstance();
   }
 }
 
@@ -7448,7 +7448,7 @@ void EVMMirBuilder::handleExtCodeCopy(Operand AddressComponents,
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
+  reloadMemoryCachesFromInstance();
 }
 
 void EVMMirBuilder::handleReturnDataCopy(Operand DestOffsetComponents,
@@ -7490,7 +7490,7 @@ void EVMMirBuilder::handleReturnDataCopy(Operand DestOffsetComponents,
 #ifdef ZEN_ENABLE_EVM_GAS_REGISTER
   reloadGasFromMemory();
 #endif
-  reloadMemorySizeFromInstance();
+  reloadMemoryCachesFromInstance();
 }
 
 typename EVMMirBuilder::Operand EVMMirBuilder::handleReturnDataSize() {
@@ -9524,22 +9524,42 @@ MInstruction *EVMMirBuilder::getMemorySize() {
   return getInstanceElement(I64Type, MemorySizeOffset);
 }
 
-void EVMMirBuilder::reloadMemorySizeFromInstance() {
+void EVMMirBuilder::reloadMemoryBaseFromInstance() {
+  if (!MemoryBaseVar) {
+    return;
+  }
+  MPointerType *VoidPtrType = createVoidPtrType();
+  const int32_t MemoryBaseOffset =
+      zen::runtime::EVMInstance::getMemoryBaseOffset();
+  MInstruction *MemPtr = getInstanceElement(VoidPtrType, MemoryBaseOffset);
+  MInstruction *MemBaseInt = createInstruction<ConversionInstruction>(
+      false, OP_ptrtoint, &Ctx.I64Type, MemPtr);
+  createInstruction<DassignInstruction>(true, &(Ctx.VoidType), MemBaseInt,
+                                        MemoryBaseVar->getVarIdx());
+}
+
+void EVMMirBuilder::reloadMemoryCachesFromInstance() {
 #ifdef ZEN_ENABLE_MULTIPASS_JIT_LOGGING
   ++MemStats.ReloadMemorySizeCount;
   if (CurBlockMemStats.Active) {
     CurBlockMemStats.ReloadMemSizeCount++;
   }
 #endif // ZEN_ENABLE_MULTIPASS_JIT_LOGGING
-  if (!MemorySizeVar) {
-    return;
+  if (MemorySizeVar) {
+    MType *I64Type = &Ctx.I64Type;
+    const int32_t MemorySizeOffset =
+        zen::runtime::EVMInstance::getMemorySizeOffset();
+    MInstruction *MemSize = getInstanceElement(I64Type, MemorySizeOffset);
+    createInstruction<DassignInstruction>(true, &(Ctx.VoidType), MemSize,
+                                          MemorySizeVar->getVarIdx());
   }
-  MType *I64Type = &Ctx.I64Type;
-  const int32_t MemorySizeOffset =
-      zen::runtime::EVMInstance::getMemorySizeOffset();
-  MInstruction *MemSize = getInstanceElement(I64Type, MemorySizeOffset);
-  createInstruction<DassignInstruction>(true, &(Ctx.VoidType), MemSize,
-                                        MemorySizeVar->getVarIdx());
+  // The base must be reloaded with the size, never on its own schedule. A
+  // runtime helper that grows memory performs the frame's lazy first
+  // allocation, which moves MemoryBase from null to the new buffer. Refreshing
+  // only the size leaves a cached null base that later memory ops then trust,
+  // because a large enough cached size makes them skip expandMemoryIR - the
+  // only other place the base is refreshed.
+  reloadMemoryBaseFromInstance();
 }
 
 MInstruction *
@@ -9783,16 +9803,7 @@ void EVMMirBuilder::expandMemoryIR(MInstruction *RequiredSize,
     createInstruction<DassignInstruction>(true, &(Ctx.VoidType), AlignedSize,
                                           MemorySizeVar->getVarIdx());
   }
-  if (MemoryBaseVar) {
-    MPointerType *VoidPtrType = createVoidPtrType();
-    const int32_t MemoryBaseOffset =
-        zen::runtime::EVMInstance::getMemoryBaseOffset();
-    MInstruction *MemPtr = getInstanceElement(VoidPtrType, MemoryBaseOffset);
-    MInstruction *MemBaseInt = createInstruction<ConversionInstruction>(
-        false, OP_ptrtoint, I64Type, MemPtr);
-    createInstruction<DassignInstruction>(true, &(Ctx.VoidType), MemBaseInt,
-                                          MemoryBaseVar->getVarIdx());
-  }
+  reloadMemoryBaseFromInstance();
 
   createInstruction<BrInstruction>(true, Ctx, ContinueBB);
   addSuccessor(ContinueBB);

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -1889,7 +1889,12 @@ private:
   MInstruction *getConstBlockDirectMemoryBasePtr();
   MInstruction *getLargeStaticWorkspaceDirectMemoryBasePtr();
   MInstruction *getMemorySize();
-  void reloadMemorySizeFromInstance();
+  // Refresh the cached EVM memory base from the instance. Callers must keep
+  // this paired with the cached size: the two are one snapshot of the frame's
+  // memory, and refreshing either alone lets generated code combine a fresh
+  // size with a stale base.
+  void reloadMemoryBaseFromInstance();
+  void reloadMemoryCachesFromInstance();
   void expandMemoryIR(MInstruction *RequiredSize, MInstruction *Overflow);
   void chargeWordCopyGasIR(MInstruction *Size);
   void chargeDynamicGasIR(MInstruction *GasCost);

--- a/src/tests/evm_differential_tests.cpp
+++ b/src/tests/evm_differential_tests.cpp
@@ -284,6 +284,51 @@ TEST(EVMPreparedCopyFallbackDifferential,
   EXPECT_EQ(Output, "60045F5F");
 }
 
+TEST(EVMMemoryBaseCacheDifferential,
+     HelperGrownMemoryIsAddressableFromALaterBlock) {
+  // The JIT caches the EVM memory base and size in function-entry locals. A
+  // frame starts with a null base, because EVM memory is allocated lazily on
+  // the frame's first growth, and the expansion branch is the only place the
+  // base cache is refreshed.
+  //
+  // Here the first growth happens inside the CALLDATACOPY runtime helper - a
+  // dynamic copy length keeps it on the generic, memory-growing helper rather
+  // than a prepared one - so the helper performs the lazy allocation and moves
+  // the instance's base off null. The two constant-offset stores in the next
+  // block share one block precheck, whose expansion is already satisfied by
+  // the reloaded size, so they address memory through the cached base without
+  // taking the expansion branch. If that cache was not refreshed alongside the
+  // size it still holds the entry-time null and the stores dereference it.
+  const std::vector<uint8_t> Bytecode = {
+      0x36,       // PC0:  CALLDATASIZE, dynamic copy length
+      0x5f,       // PC1:  PUSH0 calldata offset
+      0x5f,       // PC2:  PUSH0 destination offset
+      0x37,       // PC3:  CALLDATACOPY, grows memory inside the helper
+      0x60, 0x08, // PC4:  PUSH1 successor
+      0x56,       // PC6:  JUMP
+      0x5b,       // PC7:  unreachable padding
+      0x5b,       // PC8:  JUMPDEST
+      0x60, 0x01, // PC9:  PUSH1 1
+      0x5f,       // PC11: PUSH0 store offset
+      0x52,       // PC12: MSTORE through the cached base
+      0x60, 0x02, // PC13: PUSH1 2
+      0x60, 0x20, // PC15: PUSH1 store offset
+      0x52,       // PC17: MSTORE, second op sharing the block precheck
+      0x60, 0x40, // PC18: PUSH1 return length
+      0x5f,       // PC20: PUSH0 return offset
+      0xf3,       // PC21: RETURN
+  };
+  // 64 bytes of calldata, so the helper grows memory to exactly the 64 bytes
+  // the two stores need and the block precheck finds nothing left to expand.
+  const std::vector<uint8_t> CallData(64, 0xab);
+
+  const auto Output = expectInterpMatchesMultipassWithGas(
+      "memory_base_cache_after_helper_growth", Bytecode, CallData);
+  EXPECT_EQ(Output,
+            "0000000000000000000000000000000000000000000000000000000000000001"
+            "0000000000000000000000000000000000000000000000000000000000000002");
+}
+
 TEST(EVMKeccakMemoryProofDifferential,
      CrossBlockProofReusePreservesHashAndGas) {
   const std::vector<uint8_t> Bytecode = {


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [x] N
- [ ] Y

Related, but independent and separately mergeable: #604 reclassifies the fault
this defect produces, so that a null dereference in JIT'd code is no longer
reported as a consensus `EVMC_INVALID_MEMORY_ACCESS` halt. This PR removes the
dereference itself. Neither depends on the other.

#### 2. What is the scope of this PR (e.g. component or file name):

Multipass JIT memory-cache invalidation in
`src/compiler/evm_frontend/evm_mir_compiler.{cpp,h}`, plus a differential
regression test in `src/tests/evm_differential_tests.cpp`.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Affects user behaviors
- [ ] Contains CI/CD configuration changes
- [ ] Contains documentation changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

The multipass JIT caches the EVM memory base and size in function-entry locals.
It refreshes **both** on the memory-expansion branch, but after a runtime helper
that can grow memory it refreshed **only the size** — the CALL family, CREATE,
CREATE2, LOG, KECCAK256, CALLDATACOPY, CODECOPY, EXTCODECOPY, RETURNDATACOPY.
The base was never refreshed there, and those helpers can move it.

The reason that is not merely theoretical is **lazy allocation**. A frame starts
with `MemoryBase == nullptr`; the buffer is created by `ensureMemoryBuffer()` on
that frame's first real growth. When the first growth happens inside a runtime
helper rather than through `expandMemoryIR`, the helper allocates the buffer and
sets the instance's base, the JIT reloads only the size, and the cached base
keeps the entry-time null.

A later access then combines the two halves: the reloaded size is large enough
that the expansion branch — the only other place the base is refreshed — is not
taken, so a precheck-covered access reads the cached base and stores through
null.

Two consequences worth stating plainly:

- **No nested call is required.** Depth 0 on a fresh instance qualifies. The
  trigger is "first growth happened in a helper", not call depth.
- The write lands on page zero. Before #604 that was laundered into an
  `EVMC_INVALID_MEMORY_ACCESS` halt — a consensus status — and execution
  continued to a **wrong gas number** rather than failing.

The fix makes the pairing structural rather than incidental:
`reloadMemoryBaseFromInstance()` becomes one helper used by both the expansion
branch and the post-helper reload, and `reloadMemorySizeFromInstance()` becomes
`reloadMemoryCachesFromInstance()`, refreshing both halves of the snapshot. All
15 post-helper reload sites go through it. The cost is one 8-byte load after a
call that has already gone out to a runtime helper.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y

No API, ABI or interface change. Code that previously faulted on a null store —
surfacing as an `invalid memory access` status, and before #604 as a consensus
halt with a wrong gas number — now executes correctly.

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

**Regression test** — `EVMMemoryBaseCacheDifferential.HelperGrownMemoryIsAddressableFromALaterBlock`,
a 22-byte contract with no nested call. A `CALLDATACOPY` with a dynamic copy
length stays on the generic memory-growing helper and performs the lazy
allocation; two constant-offset `MSTORE`s in the next block share one block
precheck whose expansion is already satisfied by the reloaded size, so they
address memory through the cached base without taking the expansion branch.

**The two stores are load-bearing — please keep them.** A single-store version
passes even against unfixed code. The block precheck that makes the stores skip
the expansion branch is only formed when it covers at least two ops
(`evm_memory_grouping.h`, `if (CoveredOps < 2) { RejectReason = TooFewOps; }`);
with one store there is no shared precheck, the expansion branch is taken, and
the base gets refreshed by the very path the defect avoids. Anyone simplifying
this test will get a false green.

**The test is a real negative control — verified, not assumed.** I built a third
tree carrying *only* the test file from this commit on top of pristine `338d123`,
with the compiler left unfixed, and ran it:

```
Expected equality of these values:
  Multi.Status    Which is: invalid memory access
  Interp.Status   Which is: success
status diverged: memory_base_cache_after_helper_growth
  Multi.OutputHex   Which is: ""
  Interp.OutputHex  Which is: "...0001...0002"
```

So against unfixed code the multipass JIT reports `invalid memory access` where
the interpreter succeeds — which is exactly the laundering #604 addresses,
reproduced in a unit test. With this commit applied the same test passes.

**Full suite**, GCC 12 / LLVM 15 Release multipass build (`ZEN_ENABLE_EVM`,
`ZEN_ENABLE_MULTIPASS_JIT`, `ZEN_ENABLE_VIRTUAL_STACK`,
`ZEN_ENABLE_CPU_EXCEPTION` ON):

- `clang-format` check over `src/`: clean
- Release build on top of `338d123`: pass
- EVM fixture generation: 209/209
- `ctest`: 11 of 12 binaries pass

The one failure, `solidityContractTests`, is `solc not found` in this
environment. It fails identically on a pristine `338d123` build that I built and
ran side by side for exactly this comparison, so it is environmental rather than
a regression.

**Mainnet blocks.** The two blocks in a 1000-block window (25817835–25818834)
that failed under DTVM in JIT mode only. Both now verify pre- and post-state
roots, on an independent re-run:

| block | gasUsed | txs | subject db accesses | reference |
|---|---|---|---|---|
| 25818502 | 27644811 | 337 | 3296 | 3296 |
| 25818530 | 59842647 | 374 | 5153 | 5153 |

`27644811` is the figure the crash previously corrupted to `27730760`, so the gas
commitment is what most directly closes the defect. The subject's database access
count matches the reference execution exactly on both blocks. (Access counts are
our replay harness's internal gate, offered as corroboration rather than as
upstream-relevant evidence.)

#### 6. Release note

```release-note
Fix a null memory-base dereference in multipass JIT when a frame's first memory growth happens inside a runtime helper.
```
